### PR TITLE
페이지네이션 개선 수정

### DIFF
--- a/src/main/java/org/sopt/makers/internal/controller/MemberController.java
+++ b/src/main/java/org/sopt/makers/internal/controller/MemberController.java
@@ -172,8 +172,7 @@ public class MemberController {
         if(limit != null) limit += 1;
         val members = memberService.getMemberProfiles(filter, limit, cursor, name);
         val memberList = members.stream().map(memberMapper::toProfileResponse).collect(Collectors.toList());
-        val hasNextMember = (limit != null && memberList.size() > 0);
-        if(hasNextMember) memberList.remove(members.size() - 1);
+        val hasNextMember = (limit != null && memberList.size() > limit);
         val response = new MemberAllProfileResponse(memberList, hasNextMember);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }


### PR DESCRIPTION
## Summary

hasNext라는 필드가 cursor와 filter를 기준으로 다음 가져올 데이터가 있는지를 반환해야하는 것이여서, (커서 + filter ~ 커서 + filter + filter)의 값을 검색해 데이터가 있는지 확인하고, 없다면 false를 return 하도록 구현하였습니다..

이것의 문제점 : 기존 쿼리보다 2배의 쿼리가 나가게 됩니다..

해결하려고 생각했던 점들

- memberList.size() < limit 이면 쿼리를 날리지 않아도 확인이 가능해서 아래와 같이 코드를 작성하려고 했습니다.. 

- 문제점 : member가 딱 30명이고 filter가 30이라면,30 이후에 가져올 데이터가 없음에도, hasNextMember 가 true로 나오게됩니다.. 
```
        val members = memberService.getMemberProfiles(filter, limit, cursor, name);
        val memberList = members.stream().map(memberMapper::toProfileResponse).collect(Collectors.toList());
        val hasNextMember = (limit != null && memberList.size() == limit);
```

그래서 다시 생각한 부분
- if문 사용하기 (쿼리가 덜나가게 된다..)
- 문제점 : hasNextMember가 불변이 아니게 됨.. 

```
        boolean hasNextMember = false;
        if(limit != null && memberList.size() == limit) {
            val nextMember = memberService.getMemberProfiles(filter, limit, cursor + limit, name);
            val nextMemberList = nextMember.stream().map(memberMapper::toProfileResponse).toList();
            hasNextMember = nextMemberList.size() > 0;
        }
```

그래서 이렇게 쿼리가 두배 나가게 되는 코드를 작성하게 되었는데 .. 더 좋은 해결 방안이 있을지 궁금합니다.. 감사합니다..

_그리고 앞으로 이렇게 일 두번 안하게끔 더 .. 컨텍스트를 더 잘 파악하도록 할게요 🥹 같은 일 두번하게 해서 죄송합니다.. 우엥_

## 관련된 이슈
#78 