### PR TITLE
프로필 항목 고도화

### DIFF
--- a/src/main/java/org/sopt/makers/internal/domain/Member.java
+++ b/src/main/java/org/sopt/makers/internal/domain/Member.java
@@ -84,8 +84,8 @@ public class Member {
     @Column(name = "is_mint_choco_lover")
     private Boolean isMintChocoLover;
 
-    @Column(name = "is_red_bean_lover")
-    private Boolean isRedBeanLover;
+    @Column(name = "is_red_bean_fish_bread_lover")
+    private Boolean isRedBeanFishBreadLover;
 
     @Column(name = "is_soju_lover")
     private Boolean isSojuLover;
@@ -149,7 +149,7 @@ public class Member {
             Boolean isPourSauceLover,
             Boolean isHardPeachLover,
             Boolean isMintChocoLover,
-            Boolean isRedBeanLover,
+            Boolean isRedBeanFishBreadLover,
             Boolean isSojuLover,
             Boolean isRiceTteokLover,
             String idealType,
@@ -176,7 +176,7 @@ public class Member {
         this.isPourSauceLover = isPourSauceLover;
         this.isHardPeachLover = isHardPeachLover;
         this.isMintChocoLover = isMintChocoLover;
-        this.isRedBeanLover = isRedBeanLover;
+        this.isRedBeanFishBreadLover = isRedBeanFishBreadLover;
         this.isSojuLover = isSojuLover;
         this.isRiceTteokLover = isRiceTteokLover;
         this.idealType = idealType;

--- a/src/main/java/org/sopt/makers/internal/dto/member/MemberProfileResponse.java
+++ b/src/main/java/org/sopt/makers/internal/dto/member/MemberProfileResponse.java
@@ -22,7 +22,7 @@ public record MemberProfileResponse(
         Boolean isPourSauceLover,
         Boolean isHardPeachLover,
         Boolean isMintChocoLover,
-        Boolean isRedBeanLover,
+        Boolean isRedBeanFishBreadLover,
         Boolean isSojuLover,
         Boolean isRiceTteokLover,
         String idealType,

--- a/src/main/java/org/sopt/makers/internal/dto/member/MemberProfileSaveRequest.java
+++ b/src/main/java/org/sopt/makers/internal/dto/member/MemberProfileSaveRequest.java
@@ -23,7 +23,7 @@ public record MemberProfileSaveRequest(
 		Boolean isPourSauceLover,
 		Boolean isHardPeachLover,
 		Boolean isMintChocoLover,
-		Boolean isRedBeanLover,
+		Boolean isRedBeanFishBreadLover,
 		Boolean isSojuLover,
 		Boolean isRiceTteokLover,
 		String idealType,

--- a/src/main/java/org/sopt/makers/internal/dto/member/MemberProfileSpecificResponse.java
+++ b/src/main/java/org/sopt/makers/internal/dto/member/MemberProfileSpecificResponse.java
@@ -21,7 +21,7 @@ public record MemberProfileSpecificResponse(
         Boolean isPourSauceLover,
         Boolean isHardPeachLover,
         Boolean isMintChocoLover,
-        Boolean isRedBeanLover,
+        Boolean isRedBeanFishBreadLover,
         Boolean isSojuLover,
         Boolean isRiceTteokLover,
         String idealType,

--- a/src/main/java/org/sopt/makers/internal/dto/member/MemberProfileUpdateRequest.java
+++ b/src/main/java/org/sopt/makers/internal/dto/member/MemberProfileUpdateRequest.java
@@ -23,7 +23,7 @@ public record MemberProfileUpdateRequest (
         Boolean isPourSauceLover,
         Boolean isHardPeachLover,
         Boolean isMintChocoLover,
-        Boolean isRedBeanLover,
+        Boolean isRedBeanFishBreadLover,
         Boolean isSojuLover,
         Boolean isRiceTteokLover,
         String idealType,

--- a/src/main/java/org/sopt/makers/internal/service/MemberService.java
+++ b/src/main/java/org/sopt/makers/internal/service/MemberService.java
@@ -177,7 +177,7 @@ public class MemberService {
                 request.address(), request.university(), request.major(), request.introduction(),
                 request.skill(), request.mbti(), request.mbtiDescription(), request.sojuCapacity(),
                 request.interest(), request.isPourSauceLover(), request.isHardPeachLover(), request.isMintChocoLover(),
-                request.isRedBeanLover(), request.isSojuLover(), request.isRiceTteokLover(), request.idealType(),
+                request.isRedBeanFishBreadLover(), request.isSojuLover(), request.isRiceTteokLover(), request.idealType(),
                 request.selfIntroduction(), request.allowOfficial(),
                 memberActivities, memberLinks, memberCareers
         );
@@ -235,7 +235,7 @@ public class MemberService {
                 request.address(), request.university(), request.major(), request.introduction(),
                 request.skill(), request.mbti(), request.mbtiDescription(), request.sojuCapacity(),
                 request.interest(), request.isPourSauceLover(), request.isHardPeachLover(), request.isMintChocoLover(),
-                request.isRedBeanLover(), request.isSojuLover(), request.isRiceTteokLover(), request.idealType(),
+                request.isRedBeanFishBreadLover(), request.isSojuLover(), request.isRiceTteokLover(), request.idealType(),
                 request.selfIntroduction(), request.allowOfficial(),
                 memberActivities, memberLinks, memberCareers
         );


### PR DESCRIPTION
## Summary

### 엔티티에 필드 추가

``` ‼️ 수정
mbti : String
mbtiDescription : String
sojuCapacity : Double
interest : String 
isPourSauceLover : Boolean
isHardPeachLover : Boolean
isMintChocoLover : Boolean
isRedBeanLover : Boolean
isSojuLover : Boolean
isRiceTteokLover : Boolean
idealType : String
selfIntroduction : String
```

- 자기소개와 한줄소개를 구분하기 위해서 selfIntroduction 과 keyIntroduction 으로 구분함 -> _Entity의 영향력을 생각해서 다시 원래대로 복구_
_- 주량은 0, 0.5단위로 Double로 저장. 0.5단위로 부동소수점 등 불확실성을 고려하지 않아도 될 듯하여.. 고려하지 않았습니다._
- 아래 부분은 프론트 분들의 의견들을 고려해 Boolean으로 설정했습니다. 필터링할때 더 편한 방법이지 않을까 .. ? 싶어서요 ~ .. 
<img width="312" alt="image" src="https://user-images.githubusercontent.com/78431728/224482774-d6a8abef-12c1-40fc-bafa-f0003507130d.png">

### 변경되는 API 요청

- GET /api/v1/members/profile : 멤버프로필 전체 조회 API
- PUT /api/v1/members/profile : 멤버프로필 수정 API
- POST /api/v1/members/profile : 유저 프로필 생성 API
- GET /api/v1/members/profile/{id} : 멤버 프로필 조회 API
- GET /api/v1/members/profile/me : 자신의 토큰으로 프로필 조회 API

### 궁금증 .. 및 질의 ..
디비 프로퍼티 파일에서 UPDATE로 설정하고 ENTITY에 필드를 추가 & 삭제하였는데,, 필드가 추가가 되지만, 삭제한 필드들은 그대로 남아있었습니다..!
create로 다시 테이블들을 생성하니까, 삭제한 필드들이 제대로 삭제가 되더라구요..

안의 데이터들이 유지된채로 필드 추가 및 삭제하기 위해서 .. 배포서버와 운영서버를 수정할때, 어떤식으로 수정을 해야하는걸까요? .. 

## 관련된 이슈
#89 