### PR TITLE
Token Expired 기한 변경

### DIFF
--- a/src/main/java/org/sopt/makers/internal/domain/InternalTokenManager.java
+++ b/src/main/java/org/sopt/makers/internal/domain/InternalTokenManager.java
@@ -35,7 +35,7 @@ public class InternalTokenManager {
         val secretKeyBytes = DatatypeConverter.parseBase64Binary(authConfig.getJwtSecretKey());
         val signingKey = new SecretKeySpec(secretKeyBytes, signatureAlgorithm.getJcaName());
         val exp = new Date().toInstant().atZone(KST)
-                .toLocalDateTime().plusHours(8).atZone(KST).toInstant();
+                .toLocalDateTime().plusDays(7).atZone(KST).toInstant();
         return Jwts.builder()
                 .setSubject(Long.toString(userId))
                 .setExpiration(Date.from(exp))


### PR DESCRIPTION
## Summary
- 7일로 변경
- 로그인이 자주 풀리는 것이 문제라고 하여 보안을 좀 포기하고 변경