### PR TITLE
[FIX] 멤버데이터 삽입 자동화 - NullpointException 예외처리

### DIFF
--- a/src/main/java/org/sopt/makers/internal/service/AuthService.java
+++ b/src/main/java/org/sopt/makers/internal/service/AuthService.java
@@ -300,6 +300,7 @@ public class AuthService {
     }
 
     private boolean isInSoptOrganizerTeam(String part) {
+        if (part == null) return false;
         return (part.contains("장") || part.equals("총무"));
     }
 


### PR DESCRIPTION
## Summary
member의 파트가 Null일 경우 예외처리했습니다.
<img width="1176" alt="image" src="https://github.com/sopt-makers/sopt-playground-backend/assets/78431728/c21341f5-5914-4b22-bcbf-24e3978add77">


## 원인
제 로컬 데이터에 파트가 null 일경우를 넣지 않았어요 .. 
개발자 도구로 확인했고 ..  nohup.out 확인했어요 .. 
오류가 나는 이유가 구글 계정문제인줄알구 .. 원인 확인을 이상하게 했어요 .. 

## 결론
죄송합니다 .. 앞으로 잘할게요 