### PR TITLE
[HOTFIX] member generation + part 검색 오류 수정

### DIFF
--- a/src/main/java/org/sopt/makers/internal/repository/MemberProfileQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/repository/MemberProfileQueryRepository.java
@@ -31,6 +31,16 @@ public class MemberProfileQueryRepository {
         return QMemberSoptActivity.memberSoptActivity.part.eq(part);
     }
 
+    private BooleanExpression checkActivityContainsGenerationAndTeam(Integer generation, String team) {
+        if(generation == null) return null;
+        return QMember.member.id.in(
+                queryFactory.select(QMember.member.id)
+                        .innerJoin(QMember.member.activities, QMemberSoptActivity.memberSoptActivity)
+                        .where(QMemberSoptActivity.memberSoptActivity.generation.eq(generation)
+                                .and(checkActivityContainsTeam(team)))
+        );
+    }
+
     private BooleanExpression checkActivityContainsGeneration(Integer generation) {
         if(generation == null) return null;
         return QMember.member.id.in(
@@ -126,16 +136,13 @@ public class MemberProfileQueryRepository {
         val activities = QMemberSoptActivity.memberSoptActivity;
         return queryFactory.selectFrom(member)
                 .innerJoin(member.activities, activities)
-                .where(
-                        checkMemberHasProfile(),
-                        checkMemberContainsName(name), checkMemberSojuCapacity(sojuCapacity),
-                        checkActivityContainsGeneration(generation), checkActivityContainsPart(part),
-                        checkActivityContainsTeam(team), checkMemberMbti(mbti)
+                .where(checkMemberHasProfile(), checkMemberContainsName(name), checkMemberSojuCapacity(sojuCapacity),
+                        checkActivityContainsPart(part), checkMemberMbti(mbti),
+                        checkActivityContainsGenerationAndTeam(generation, team)
                 ).offset(cursor)
                 .limit(limit)
                 .groupBy(member.id)
-                .orderBy(getOrderByCondition(OrderByCondition.valueOf(orderBy)))
-                .fetch();
+                .orderBy(getOrderByCondition(OrderByCondition.valueOf(orderBy))).fetch();
     }
 
     public List<Member> findAllMemberProfile(String part, Integer cursor, String name, Integer generation) {
@@ -155,11 +162,9 @@ public class MemberProfileQueryRepository {
         val activities = QMemberSoptActivity.memberSoptActivity;
         return queryFactory.selectFrom(member)
                 .innerJoin(member.activities, activities)
-                .where(
-                        checkMemberHasProfile(),
-                        checkMemberContainsName(name), checkMemberSojuCapacity(sojuCapacity),
-                        checkActivityContainsGeneration(generation), checkActivityContainsPart(part),
-                        checkActivityContainsTeam(team), checkMemberMbti(mbti)
+                .where(checkMemberHasProfile(), checkMemberContainsName(name), checkMemberSojuCapacity(sojuCapacity),
+                        checkActivityContainsPart(part), checkMemberMbti(mbti),
+                        checkActivityContainsGenerationAndTeam(generation, team)
                 ).groupBy(member.id)
                 .orderBy(getOrderByCondition(OrderByCondition.valueOf(orderBy)))
                 .fetch();
@@ -185,8 +190,8 @@ public class MemberProfileQueryRepository {
                 .innerJoin(member.activities, activities)
                 .where(checkMemberHasProfile(),
                         checkMemberContainsName(name), checkMemberSojuCapacity(sojuCapacity),
-                        checkActivityContainsGeneration(generation), checkActivityContainsPart(part),
-                        checkActivityContainsTeam(team), checkMemberMbti(mbti))
+                        checkActivityContainsPart(part),checkMemberMbti(mbti),
+                        checkActivityContainsGenerationAndTeam(generation, team))
                 .groupBy(member.id)
                 .fetch()
                 .size();


### PR DESCRIPTION
- generation + part 검색시, 같은 row 가 검색되도록 수정 - and 조건 추가
- ordering은 유지되도록 수정

<img width="514" alt="image" src="https://github.com/sopt-makers/sopt-playground-backend/assets/78431728/0b51954f-3de1-496f-8efc-bddca8d97fff">

## 이후에 해야할 행동
prod에 part가 (운영진 등등이 아닐경우) null로 다통일 하는 작업 필요