### PR TITLE
[HOTFIX] Member필터링 (Generation, Part, Team) 조합 필터 검색 오류 수정

### DIFF
--- a/src/main/java/org/sopt/makers/internal/repository/MemberProfileQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/repository/MemberProfileQueryRepository.java
@@ -31,13 +31,20 @@ public class MemberProfileQueryRepository {
         return QMemberSoptActivity.memberSoptActivity.part.eq(part);
     }
 
+    private BooleanExpression checkUserContainsPart(String part) {
+        if(part == null) return null;
+        return QMember.member.id.in(queryFactory.select(QMember.member.id)
+                .innerJoin(QMember.member.activities, QMemberSoptActivity.memberSoptActivity)
+                .where(checkActivityContainsPart(part)));
+    }
+
     private BooleanExpression checkActivityContainsGenerationAndTeam(Integer generation, String team) {
-        if(generation == null) return null;
+        if(generation == null && team == null) return null;
         return QMember.member.id.in(
                 queryFactory.select(QMember.member.id)
                         .innerJoin(QMember.member.activities, QMemberSoptActivity.memberSoptActivity)
                         .where(QMemberSoptActivity.memberSoptActivity.generation.eq(generation)
-                                .and(checkActivityContainsTeam(team)))
+                                        .and(checkActivityContainsTeam(team)))
         );
     }
 
@@ -47,6 +54,42 @@ public class MemberProfileQueryRepository {
                 queryFactory.select(QMember.member.id)
                         .innerJoin(QMember.member.activities, QMemberSoptActivity.memberSoptActivity)
                         .where(QMemberSoptActivity.memberSoptActivity.generation.eq(generation))
+        );
+    }
+
+    private BooleanExpression checkActivityContainsGenerationAndPart(Integer generation, String part) {
+        if(generation == null && part == null) return null;
+        return QMember.member.id.in(
+                queryFactory.select(QMember.member.id)
+                        .innerJoin(QMember.member.activities, QMemberSoptActivity.memberSoptActivity)
+                        .where(QMemberSoptActivity.memberSoptActivity.generation.eq(generation)
+                                .and(checkActivityContainsPart(part)))
+        );
+    }
+
+    private BooleanExpression checkActivityContainsPartAndTeam(String part, String team) {
+        if(part == null && team == null) return null;
+        else if(part == null) return checkActivityContainsTeam(team);
+        else if(team == null) return checkActivityContainsPart(part);
+        else {
+            return QMember.member.id.in(
+                    queryFactory.select(QMember.member.id)
+                            .innerJoin(QMember.member.activities, QMemberSoptActivity.memberSoptActivity)
+                            .where(checkActivityContainsTeam(team).and(checkUserContainsPart(part)))
+            );
+        }
+    }
+
+    private BooleanExpression checkActivityContainsGenerationAndTeamAndPart(Integer generation, String team, String part) {
+        if(generation == null && team == null && part == null) return null;
+        else if(generation == null) return checkActivityContainsPartAndTeam(part,team);
+        else if(part == null) return checkActivityContainsGenerationAndTeam(generation,team);
+        else if(team == null) return checkActivityContainsGenerationAndPart(generation,part);
+        return QMember.member.id.in(
+                queryFactory.select(QMember.member.id)
+                        .innerJoin(QMember.member.activities, QMemberSoptActivity.memberSoptActivity)
+                        .where(checkActivityContainsGenerationAndTeam(generation,team)
+                                .and(checkActivityContainsGenerationAndPart(generation,part)))
         );
     }
 
@@ -137,8 +180,7 @@ public class MemberProfileQueryRepository {
         return queryFactory.selectFrom(member)
                 .innerJoin(member.activities, activities)
                 .where(checkMemberHasProfile(), checkMemberContainsName(name), checkMemberSojuCapacity(sojuCapacity),
-                        checkActivityContainsPart(part), checkMemberMbti(mbti),
-                        checkActivityContainsGenerationAndTeam(generation, team)
+                        checkMemberMbti(mbti), checkActivityContainsGenerationAndTeamAndPart(generation, team, part)
                 ).offset(cursor)
                 .limit(limit)
                 .groupBy(member.id)
@@ -164,7 +206,7 @@ public class MemberProfileQueryRepository {
                 .innerJoin(member.activities, activities)
                 .where(checkMemberHasProfile(), checkMemberContainsName(name), checkMemberSojuCapacity(sojuCapacity),
                         checkActivityContainsPart(part), checkMemberMbti(mbti),
-                        checkActivityContainsGenerationAndTeam(generation, team)
+                        checkActivityContainsGenerationAndTeamAndPart(generation, team, part)
                 ).groupBy(member.id)
                 .orderBy(getOrderByCondition(OrderByCondition.valueOf(orderBy)))
                 .fetch();
@@ -191,7 +233,7 @@ public class MemberProfileQueryRepository {
                 .where(checkMemberHasProfile(),
                         checkMemberContainsName(name), checkMemberSojuCapacity(sojuCapacity),
                         checkActivityContainsPart(part),checkMemberMbti(mbti),
-                        checkActivityContainsGenerationAndTeam(generation, team))
+                        checkActivityContainsGenerationAndTeamAndPart(generation, team, part))
                 .groupBy(member.id)
                 .fetch()
                 .size();


### PR DESCRIPTION
## SUMMARY
generation 👌 -> Part, team 조회시 generation을 포함한 part , team 조합
generation ❌ ->  part, team 해당하는 모든 필드 검색의 이유로 분기처리를 저질렀어요..

### 설명
generation 👌 
generation + team : 해당 기수를 포함한 운영진,운영팀검색
generation + part : 해당 기수를 포함한 필드의 운영진 + 파트 검색
generation + team + part : 해당 기수를 포함한 team(임원진, 운영팀) & 파트 모두 소속되어있는 사람
- 32기에 총무 & 32기에 서버파트 
- 이를 검색하기 위한 subquery가 필요함

generation ❌
team + part : 해당하는 team 와 part 모두 소속되어있는 사람( team에도 소속되어있던적 있고, 해당 파트에도 포함되어있던적 있는 사람)
- userId로 아래의 예시 모두 포함하는 userId 조회 (여러 row를 다포함하는 userId)
- team(임원진, 운영팀)row의 userId
- part(iOS, server등)row의 userId