### PR TITLE
[CHORE] 정렬 이용시, member 데이터 중복 해결

### DIFF
--- a/src/main/java/org/sopt/makers/internal/repository/MemberProfileQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/repository/MemberProfileQueryRepository.java
@@ -177,10 +177,18 @@ public class MemberProfileQueryRepository {
     ) {
         val member = QMember.member;
         val activities = QMemberSoptActivity.memberSoptActivity;
-        return queryFactory.selectFrom(member)
+        return queryFactory
+                .selectFrom(member)
                 .innerJoin(member.activities, activities)
-                .where(checkMemberHasProfile(), checkMemberContainsName(name), checkMemberSojuCapacity(sojuCapacity),
-                        checkMemberMbti(mbti), checkActivityContainsGenerationAndTeamAndPart(generation, team, part)
+                .where(
+                        member.id.in(
+                                queryFactory
+                                        .select(activities.memberId)
+                                        .from(activities)
+                                        .where(checkActivityContainsGenerationAndTeamAndPart(generation, team, part))
+                        ),
+                        checkMemberHasProfile(), checkMemberContainsName(name),
+                        checkMemberSojuCapacity(sojuCapacity), checkMemberMbti(mbti)
                 ).offset(cursor)
                 .limit(limit)
                 .groupBy(member.id)


### PR DESCRIPTION
https://chat.openai.com/share/6c0bb753-86f3-4f30-9ecb-f45ccb55aac8
-> 그냥 sql로 구할때는 , 구할 수 있는 
https://chat.openai.com/share/266f15af-6997-4e36-84ec-45a90656bc93
gpt 힘을 얻어서 구해봤습니다.. 이렇게 할경우에, 정렬 + (team, generation 등등) 필터링이 여러개 걸릴 경우에, 너무 많은 subquery가 생겨난다는 단점이 있네요..

offset 베이스가 아닌 cursor 베이스로 수정을 해보려고 하는데 .. primarykey를 뭐로 선정해야하는지에 대한 어려움

https://velog.io/@znftm97/%EC%BB%A4%EC%84%9C-%EA%B8%B0%EB%B0%98-%ED%8E%98%EC%9D%B4%EC%A7%80%EB%84%A4%EC%9D%B4%EC%85%98Cursor-based-Pagination%EC%9D%B4%EB%9E%80-Querydsl%EB%A1%9C-%EA%B5%AC%ED%98%84%EA%B9%8C%EC%A7%80-so3v8mi2#span-stylecolor0b6e990-%EC%9D%B4-%EA%B8%80%EC%9D%84-%EC%93%B0%EB%8A%94-%EC%9D%B4%EC%9C%A0--%EC%9D%B4-%EA%B8%B0%EB%8A%A5%EC%9D%84-%EA%B5%AC%ED%98%84%ED%95%9C-%EC%9D%B4%EC%9C%A0span

이렇게 custom cursor를 이용하는 방법도 있어서 시도해보려고 합니다... 

완전한 방법을 찾게되면 리뷰어로 정우님 등록하도록 하겠습니다.. 기다려주십시오..


## 결론
- offset based > cursor based 로 변경하고 싶은데, cursor는 클라이언트에서 마지막 row를 받아야하는데, 이 방식을 어떻게 받을 수 있을지 고민해야함
- custom cursor를 시도해봐야함 -> 뭐가 더 나은지, 중복은 해결되지만 누락되는 데이터가 있는지 확인해야함


아직 미완성입니다 ㅜ 0 ㅜ.. 2기 끝나기전에 무조건 끝나겠습니다 기다려주세용ㅠㅠ