### PR TITLE
[CHORE] 게임 예외처리 적용 추가

### DIFF
--- a/src/main/java/org/sopt/makers/internal/service/WordChainGameService.java
+++ b/src/main/java/org/sopt/makers/internal/service/WordChainGameService.java
@@ -75,6 +75,8 @@ public class WordChainGameService {
             val noInputWordInRoom = lastRoom.getWordList().isEmpty();
             if(!noInputWordInRoom) {
                 val lastWord = wordRepository.findFirstByRoomIdOrderByCreatedAtDesc(lastRoom.getId());
+                val isLastWordWriterIsMakingNewGame = lastWord.getMemberId().equals(member.getId());
+                if(isLastWordWriterIsMakingNewGame) throw new WordChainGameHasWrongInputException("마지막 단어 작성자는 새로 게임을 시작할 수 없어요.");
                 val winnerId = lastWord.getMemberId();
                 val score = wordChainGameWinnerRepository.findFirstByUserIdOrderByIdDesc(winnerId);
                 val userScore = Objects.isNull(score) ? 0 : score.getScore();


### PR DESCRIPTION
<img width="511" alt="image" src="https://github.com/sopt-makers/sopt-playground-backend/assets/78431728/c8568e54-3988-469e-96c2-2ae6714ce6d3">

### Summary
- 마지막 단어가 본인이 보낸 거면 새 게임 시작 못하도록 하기
`마지막 단어작성자는 새로 게임을 시작할 수 없어요.`
- 본인 단어에 잇지 못하도록 처리하기
`본인 단어에는 단어를 이을 수 없어요.`