### PR TITLE
[CHORE] 기수 이름 정보 수정 못하게 수정

### DIFF
--- a/src/main/java/org/sopt/makers/internal/service/MemberService.java
+++ b/src/main/java/org/sopt/makers/internal/service/MemberService.java
@@ -327,7 +327,7 @@ public class MemberService {
                          .isHardPeachLover(request.userFavor().isHardPeachLover())
                                  .build();
         member.saveMemberProfile(
-                request.name(), request.profileImage(), request.birthday(), request.phone(), request.email(),
+                member.getName(), request.profileImage(), request.birthday(), request.phone(), request.email(),
                 request.address(), request.university(), request.major(), request.introduction(),
                 request.skill(), request.mbti(), request.mbtiDescription(), request.sojuCapacity(),
                 request.interest(), userFavor, request.idealType(),


### PR DESCRIPTION
## SUMMARY
- API 요청은 받되, 처리하지 못하도록 정리
<img width="543" alt="image" src="https://github.com/sopt-makers/sopt-playground-backend/assets/78431728/d6756f2e-5bf6-4415-ab4c-89e6101fd7b8">
