### PR TITLE
[ADD] 메이커스 3기 추가

### DIFF
--- a/src/main/java/org/sopt/makers/internal/common/MakersMemberId.java
+++ b/src/main/java/org/sopt/makers/internal/common/MakersMemberId.java
@@ -8,10 +8,11 @@ import java.util.List;
 
 public class MakersMemberId {
     private static final List<Long> makersMember = List.of(
-            1L, 44L, 23L, 31L, 8L, 30L, 40L, 46L, 26L, 60L, 39L, 6L, 9L, 7L, 2L, 3L, 29L,
-            5L, 38L, 37L, 13L, 28L, 36L, 58L, 173L, 32L, 43L, 188L, 59L, 34L, 21L, 33L, 22L, 35L, 45L,
-            186L, 227L, 264L, 4L, 51L, 187L, 128L, 64L, 99L, 10L, 66L, 260L, 72L, 265L, 78L, 251L,
-            115L, 258L, 112L, 205L, 238L, 259L, 281L, 285L, 286L, 283L, 282L
+            1L, 2L, 258L, 3L, 259L, 4L, 260L, 5L, 6L, 7L, 8L, 264L, 9L, 265L, 10L, 13L, 21L, 22L, 23L, 281L,
+            26L, 282L, 283L, 28L, 29L, 285L, 30L, 286L, 31L, 32L, 33L, 34L, 35L, 36L, 37L, 38L, 294L, 39L, 40L, 554L,
+            43L, 44L, 45L, 46L, 303L, 559L, 51L, 563L, 569L, 58L, 570L, 59L, 60L, 61L, 64L, 66L, 72L, 78L, 85L,
+            99L, 357L, 358L, 107L, 112L, 370L, 115L, 128L, 390L, 396L, 143L, 144L, 401L, 410L, 171L, 173L, 180L,
+            186L, 187L, 188L, 192L, 203L, 204L, 205L, 227L, 238L, 251L
     );
 
     public static List<Long> getMakersMember() {


### PR DESCRIPTION
<img width="749" alt="image" src="https://github.com/sopt-makers/sopt-playground-backend/assets/78431728/391177e6-0aa4-4cfd-a58c-1db825fe416a">

### SUMMARY
메이커스 3기 ID를 추가하였습니다.