### PR TITLE
[FIX] 소셜로그인 변경 로직에 토큰 검사 제외시키도록 로직 수정

### DIFF
--- a/src/main/java/org/sopt/makers/internal/controller/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/sopt/makers/internal/controller/filter/JwtAuthenticationFilter.java
@@ -29,7 +29,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         val isTokenAvailable = checkJwtAvailable(jwtToken);
         val uri = request.getRequestURI();
         if ((uri.startsWith("/api") || uri.startsWith("/internal"))
-                && !uri.contains("idp") && !uri.contains("registration")) {
+                && !uri.contains("idp") && !uri.contains("registration") && !uri.contains("change")) {
             if (!isTokenAvailable)
                 throw new WrongAccessTokenException("Token is empty or not verified");
         }


### PR DESCRIPTION
### SUMMARY
`/api/v1/change/sms/code` 에서 액세스 토큰을 요구하지 않도록 수정