### PR TITLE
[CHORE] 핸드폰 번호 - 제거 및 데이터 형식 통일

### DIFF
--- a/src/main/java/org/sopt/makers/internal/service/MemberService.java
+++ b/src/main/java/org/sopt/makers/internal/service/MemberService.java
@@ -218,7 +218,7 @@ public class MemberService {
                 .build();
 
         member.saveMemberProfile(
-                request.name(), request.profileImage(), request.birthday(), request.phone(), request.email(),
+                request.name(), request.profileImage(), request.birthday(), request.phone().replaceAll("[^0-9]", ""), request.email(),
                 request.address(), request.university(), request.major(), request.introduction(),
                 request.skill(), request.mbti(), request.mbtiDescription(), request.sojuCapacity(),
                 request.interest(), userFavor, request.idealType(),
@@ -327,7 +327,7 @@ public class MemberService {
                          .isHardPeachLover(request.userFavor().isHardPeachLover())
                                  .build();
         member.saveMemberProfile(
-                member.getName(), request.profileImage(), request.birthday(), request.phone(), request.email(),
+                member.getName(), request.profileImage(), request.birthday(), request.phone().replaceAll("[^0-9]", ""), request.email(),
                 request.address(), request.university(), request.major(), request.introduction(),
                 request.skill(), request.mbti(), request.mbtiDescription(), request.sojuCapacity(),
                 request.interest(), userFavor, request.idealType(),


### PR DESCRIPTION
## SUMMARY
<img width="471" alt="image" src="https://github.com/sopt-makers/sopt-playground-backend/assets/78431728/b37e625e-e781-4b70-9117-ff323e75878a">

연락처 데이터가 -가 필수적으로 붙어야함에 따라, 휴대폰 번호가 통일성이 깨지게 됨
- 를 없애는 방법으로 저장하게 함

## 추후
짝대기 없애는 쿼리 돌릴 예정