### PR TITLE
[CHORE] non null column

### DIFF
--- a/src/main/java/org/sopt/makers/internal/domain/Member.java
+++ b/src/main/java/org/sopt/makers/internal/domain/Member.java
@@ -124,7 +124,7 @@ public class Member {
     @Builder.Default
     @Column(name = "edit_activities_able")
     @ColumnDefault("true")
-    private Boolean editActivitiesAble;
+    private Boolean editActivitiesAble = true;
 
     @Builder.Default
     @Column(name = "openToSoulmate")


### PR DESCRIPTION
#### 이슈

<img width="398" alt="image" src="https://github.com/sopt-makers/sopt-playground-backend/assets/78431728/c23d2fd3-c63d-4351-81e2-cef1b633a439">

#### 오류

`not-null property references a null or transient value : org.sopt.makers.internal.domain.Member.editActivitiesAble; nested exception is org.hibernate.PropertyValueException: not-null property references a null or transient value : org.sopt.makers.internal.domain.Member.editActivitiesAble`

#### SUMMARY
회원가입시, editActivitiesAble Column이 null하게 들어가서 소셜로그인이 되지않는 이슈 발생
해당 값이 null로 들어와도 default 값이 true로 저장되게 하였기에 nonull 제거함.
