### PR TITLE
[CHORE] DEV QA (name에 default값)

### DIFF
--- a/src/main/java/org/sopt/makers/internal/service/AuthService.java
+++ b/src/main/java/org/sopt/makers/internal/service/AuthService.java
@@ -107,6 +107,7 @@ public class AuthService {
                 Member.builder()
                         .authUserId(authUserId)
                         .idpType(socialType)
+                        .name("DEV TESTER")
                         .hasProfile(true)
                         .build()
         );


### PR DESCRIPTION
## SUMMARY 
DevMagicNumber로 가입시 name값이 null이여서 오류 발생.
name default값 넣어줌.
<img width="1134" alt="image" src="https://github.com/sopt-makers/sopt-playground-backend/assets/78431728/94cf5672-54e8-46f4-b4f0-6b51ba0cee5d">
