### PR TITLE
feat: 유저 프로필 1회만 수정 가능하게 변경

### DIFF
--- a/src/main/java/org/sopt/makers/internal/domain/Member.java
+++ b/src/main/java/org/sopt/makers/internal/domain/Member.java
@@ -130,6 +130,10 @@ public class Member {
     @Column(name = "openToSoulmate")
     private Boolean openToSoulmate = false;
 
+    public void editActivityChangeToFalse() {
+        this.editActivitiesAble = false;
+    }
+
     public void updateMemberAuth (String authUserId, String idpType) {
         this.authUserId = authUserId;
         this.idpType = idpType;

--- a/src/main/java/org/sopt/makers/internal/dto/member/MemberResponse.java
+++ b/src/main/java/org/sopt/makers/internal/dto/member/MemberResponse.java
@@ -4,14 +4,18 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record MemberResponse(
         @Schema(required = true)
-    Long id,
+        Long id,
 
         @Schema(required = true)
-    String name,
+        String name,
         @Schema(required = true)
-    Integer generation,
-    String profileImage,
+        Integer generation,
+        String profileImage,
 
         @Schema(required = true)
-        Boolean hasProfile
-) {}
+        Boolean hasProfile,
+
+        @Schema(required = true)
+        Boolean editActivitiesAble
+) {
+}

--- a/src/main/java/org/sopt/makers/internal/service/MemberService.java
+++ b/src/main/java/org/sopt/makers/internal/service/MemberService.java
@@ -269,6 +269,11 @@ public class MemberService {
     @Transactional
     public Member updateMemberProfile (Long id, MemberProfileUpdateRequest request) {
         val member = getMemberById(id);
+
+        if (!member.getEditActivitiesAble()) {
+            throw new ClientBadRequestException("이미 프로필을 수정한 적이 있는 유저입니다.");
+        }
+
         val memberId = member.getId();
         val memberLinks = memberLinkRepository.saveAll(
                 request.links().stream().map(link ->
@@ -326,6 +331,7 @@ public class MemberService {
                 request.selfIntroduction(), request.allowOfficial(),
                 memberActivities, memberLinks, memberCareers
         );
+        member.editActivityChangeToFalse();
         return member;
     }
 


### PR DESCRIPTION
유저 프로필 업데이트 시 DB edit_activities_able -> false
유저 자신의 토큰으로 정보 조회시 editActivitiesAble 필드 추가

Related to: #235