### PR TITLE
[FIX] Member 프로필 수정 API 

### DIFF
--- a/src/main/java/org/sopt/makers/internal/dto/member/MemberProfileUpdateRequest.java
+++ b/src/main/java/org/sopt/makers/internal/dto/member/MemberProfileUpdateRequest.java
@@ -53,7 +53,7 @@ public record MemberProfileUpdateRequest (
             String part,
             String team
     ){
-        public boolean equalsInfo (MemberSoptActivity activity) {
+        private boolean equalsInfo (MemberSoptActivity activity) {
             return generation.equals(activity.getGeneration()) && part.equals(activity.getPart()) &&
                 (team == null || team.equals(activity.getTeam()));
         }
@@ -69,4 +69,17 @@ public record MemberProfileUpdateRequest (
             String endDate,
             Boolean isCurrent
     ){}
+
+    public boolean compareProfileActivities (List<MemberSoptActivityUpdateRequest> requests, List<MemberSoptActivity> activities) {
+        if (requests.size() != activities.size()) {
+            return false;
+        }
+        for (int i=0; i<requests.size(); i++) {
+            if (!requests.get(i).equalsInfo(activities.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
 }

--- a/src/main/java/org/sopt/makers/internal/service/MemberService.java
+++ b/src/main/java/org/sopt/makers/internal/service/MemberService.java
@@ -296,11 +296,9 @@ public class MemberService {
     public Member updateMemberProfile (Long id, MemberProfileUpdateRequest request) {
         val member = getMemberById(id);
 
-        if (!member.getEditActivitiesAble() && member.getActivities().size() == request.activities().size()) {
-            for (int i=0; i<request.activities().size(); i++) {
-                if (!request.activities().get(i).equalsInfo(member.getActivities().get(i))) {
-                    throw new ClientBadRequestException("이미 프로필을 수정한 적이 있는 유저입니다.");
-                }
+        if (!member.getEditActivitiesAble()) {
+            if (!request.compareProfileActivities(request.activities(), member.getActivities())) {
+                throw new ClientBadRequestException("이미 프로필을 수정한 적이 있는 유저입니다.");
             }
         }
 


### PR DESCRIPTION
closed issue #327 

프로필 수정 API에서 Member의 editActivitiesAble 필드로 활동 정보는 한번만 수정이 가능하도록 허용하는데, 이때의 예외처리에 대한 조건이 잘못 처리되어 있어 다음과 같이 조건을 추가했습니다.

**[프로필 수정이 가능한 조건]**
1) editActivitiesAble = true
2) editActivitiesAble = false 이면? request의 activites가 담고 있는 정보 = 기존 Member 객체의 activites 정보가 동일

따라서, DTO 단에 동등성을 비교하는 함수를 추가했고 (id는 객체를 생성할 때마다 다르게 가지므로 비교 메서드를 별도로 구현), Service 계층에서 조건을 추가하여 버그를 해결했습니다.

fyi. 현재 PUT으로 전체 프로필 정보를 요청 바디에 넣어서 보내야만 하도록 구현되어 있어 위와 같이 수정했는데, 정보를 분리하여 Update API를 쪼개거나 PATCH로 필요한 정보만 요청 바디에 실어 수정할 수 있도록 하는 방향도 좋을 것 같습니다!! 