### PR TITLE
[Fix]: 멤버 크루 조회 API id 파라미터 추가

### DIFF
--- a/src/main/java/org/sopt/makers/internal/controller/MemberController.java
+++ b/src/main/java/org/sopt/makers/internal/controller/MemberController.java
@@ -239,13 +239,13 @@ public class MemberController {
     }
 
     @Operation(summary = "멤버 크루 조회 API")
-    @GetMapping("/crew")
+    @GetMapping("/crew/{id}")
     public ResponseEntity<MemberCrewResponse> getUserCrew(
+            @PathVariable Long id,
             @RequestParam(required = false, name = "page") Integer page,
-            @RequestParam(required = false, name = "take") Integer take,
-            @Parameter(hidden = true) @AuthenticationPrincipal InternalMemberDetails memberDetails
+            @RequestParam(required = false, name = "take") Integer take
     ) {
-        val response = makersCrewDevClient.getUserAllCrew(page, take, memberDetails.getId());
+        val response = makersCrewDevClient.getUserAllCrew(page, take, id);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 


### PR DESCRIPTION

기존의 기능은 header에 access token을 받아서 본인의 crew만 조회할 수 있는 형태였습니다.

수정사항
- access token을 받지 않고, 유저의 고유 id값을 path variable로 받는 형태로 바꿨습니다.

Related to: #328