### PR TITLE
[Fix]: 멤버 크루 조회 에러처리

### DIFF
--- a/src/main/java/org/sopt/makers/internal/controller/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/makers/internal/controller/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package org.sopt.makers.internal.controller;
 
+import feign.FeignException;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.makers.internal.dto.CommonExceptionResponse;
 import org.sopt.makers.internal.dto.auth.RegisterTokenBySmsResponse;
@@ -111,6 +112,13 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(new SoulmateResponse(false, ex.getMessage(), null));
+    }
+
+    @ExceptionHandler(FeignException.class)
+    public ResponseEntity<String> feignClientException(FeignException ex) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body("Invalid external api request");
     }
 
     @ExceptionHandler(RuntimeException.class)


### PR DESCRIPTION
기존에는 없는 유저에 대한 에러 처리가 되어있지 않았습니다.
GlobalExceptionHandler.java에 OpenFeign에 대한 에러처리를 해줬습니다.

- GlobalExceptionHandler에 FeignClient Exception 추가

cloes: #331