### PR TITLE
[Chore] 개발 계정 whitelist 추가

### DIFF
--- a/src/main/java/org/sopt/makers/internal/repository/MemberProfileQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/repository/MemberProfileQueryRepository.java
@@ -1,21 +1,27 @@
 package org.sopt.makers.internal.repository;
 
-import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.jpa.impl.JPAQueryFactory;
-import lombok.RequiredArgsConstructor;
-import lombok.val;
+import java.util.List;
+import java.util.Objects;
+
 import org.sopt.makers.internal.common.MakersMemberId;
-import org.sopt.makers.internal.domain.*;
+import org.sopt.makers.internal.domain.Member;
+import org.sopt.makers.internal.domain.OrderByCondition;
+import org.sopt.makers.internal.domain.Part;
+import org.sopt.makers.internal.domain.QMember;
+import org.sopt.makers.internal.domain.QMemberProjectRelation;
+import org.sopt.makers.internal.domain.QMemberSoptActivity;
+import org.sopt.makers.internal.domain.QProject;
 import org.sopt.makers.internal.dto.member.MemberProfileProjectDao;
 import org.sopt.makers.internal.dto.member.QMemberProfileProjectDao;
 import org.springframework.stereotype.Repository;
-
 import org.springframework.util.StringUtils;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+import lombok.val;
 
 @Repository
 @RequiredArgsConstructor


### PR DESCRIPTION
## Issue
closed #383 

## Context 
메이커스 내부 QA용 개발 계정(활동 기수)을 추가하며, 플레이그라운드 전체 프로필 조회에 포함되어 뜨는 문제를 해결하기 위해 쿼리 필터링에 White List를 추가했습니다.

#### ✅ Todo
Prod 배포 이후에 users 테이블에서 has_profile 필드 true로 바꿔줘야 합니다