### PR TITLE
[FIX} 프로젝트 전체 조회 API 오류 수정

### DIFF
--- a/src/main/java/org/sopt/makers/internal/repository/ProjectQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/repository/ProjectQueryRepository.java
@@ -1,19 +1,25 @@
 package org.sopt.makers.internal.repository;
 
-import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.jpa.impl.JPAQuery;
-import com.querydsl.jpa.impl.JPAQueryFactory;
-import lombok.RequiredArgsConstructor;
-import lombok.val;
-import org.sopt.makers.internal.domain.*;
+import java.util.List;
+import java.util.Objects;
+
+import org.sopt.makers.internal.domain.Project;
+import org.sopt.makers.internal.domain.QMember;
+import org.sopt.makers.internal.domain.QMemberProjectRelation;
+import org.sopt.makers.internal.domain.QProject;
+import org.sopt.makers.internal.domain.QProjectLink;
 import org.sopt.makers.internal.dto.project.ProjectLinkDao;
 import org.sopt.makers.internal.dto.project.ProjectMemberDao;
 import org.sopt.makers.internal.dto.project.QProjectLinkDao;
 import org.sopt.makers.internal.dto.project.QProjectMemberDao;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.Objects;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+import lombok.val;
 
 @Repository
 @RequiredArgsConstructor
@@ -62,12 +68,12 @@ public class ProjectQueryRepository {
 
     private BooleanExpression checkProjectIsFounding(Boolean isFounding) {
         val checkIsFoundingIsEmpty = Objects.isNull(isFounding);
-        return checkIsFoundingIsEmpty ? null : QProject.project.isFounding.eq(isFounding);
+        return checkIsFoundingIsEmpty || isFounding.equals(Boolean.FALSE) ? null : QProject.project.isFounding.eq(isFounding);
     }
 
     private BooleanExpression checkProjectIsAvailable(Boolean isAvailable) {
         val checkIsAvailableIsEmpty = Objects.isNull(isAvailable);
-        return checkIsAvailableIsEmpty ? null : QProject.project.isAvailable.eq(isAvailable);
+        return checkIsAvailableIsEmpty || isAvailable.equals(Boolean.FALSE) ? null : QProject.project.isAvailable.eq(isAvailable);
     }
 
     private BooleanExpression ltProjectId(Long projectId) {


### PR DESCRIPTION
## Context
- 프로젝트 전체 조회 API 에서 필터링 param의 값에 따라 쿼리 결과가 달라지는 문제가 있어 해당 오류를 수정했습니다
   - [관련 Slack 스레드](https://sopt-makers.slack.com/archives/C042T81PW80/p1716164581310319)
   - [Notion 이슈 정리](https://www.notion.so/sopt-makers/API-8336a070878e47c9abdcdaa81ed314f0?pvs=4)
- 현재 프로젝트 조회 페이지에서는 `isFounding`,  `isAvailable`이 true일 때만을 필터링하고 있으므로, false인 경우는 따로 쿼리 조건에 포함되지 않도록 수정했습니다

## Comment
- `category` param이 ETC나 STUDY로 설정된 경우, 버튼이 사라지는 문제가 있는데 이 부분은 FE분들께 공유드리려고 합니다 !!