### PR TITLE
[UPDATE] 내부 API 전화번호 데이터 추가

### DIFF
--- a/src/main/java/org/sopt/makers/internal/dto/internal/InternalMemberActivityResponse.java
+++ b/src/main/java/org/sopt/makers/internal/dto/internal/InternalMemberActivityResponse.java
@@ -9,6 +9,7 @@ public record InternalMemberActivityResponse(
         @Schema(required = true)
         String name,
         String profileImage,
+        String phone,
         @Schema(required = true)
         List<InternalMemberActivityResponse.MemberSoptActivityResponse> activities
 ) {


### PR DESCRIPTION
# 어떤 맥락인지
- 안녕하세요..! 사전에 얘기도 없이 이렇게 갑작스럽게 이렇게 PR를 하게 된 부분 죄송하다는 말씀드립니다..!
- 다름이 아니라, 저희 크루 쪽에서 내부 API를 사용함에 있어 현재 굉장히 비효율적으로 사용하고 있는데요!
- 이를 개선하고자 저희 크루에서 사용하는 여러 API들을 살펴보았고, 살펴본 결과 `internal/api/v1/members/activity/me` 의 엔드포인트를 가지고 있는 API 하나만 있어도 충분하겠다라는 판단을 했습니다!
- 하지만 해당 API에는 핸드폰 번호 데이터가 없어서 이 데이터만 있으면 플그와의 의존성이 많이 사라질 것이라고 생각했습니다.

# 어떤 변화를 줬는지
- 그래서 해당 데이터를 한 번 추가해봤고, 기존에 이미 멤버 객체를 불러왔기 때문에 해당 데이터를 추가하는 것이 문제가 없을 것이라고 판단했습니다.
- 또한, 기존에 MapStruct 를 사용하신거를 확인했습니다. 그래서 빌드 성공 후에 아래와 같이 정상적으로 추가된 것을 확인했습니다.
![스크린샷 2024-07-24 오후 8 14 17](https://github.com/user-attachments/assets/f203b306-89a1-4a9a-870e-638b13524a7f)

# 사이드 이펙트
- 해당 API 를 혹시나 다른 팀에서 사용할 수 있기 때문에 다른 팀의 플그 API 사용도 면밀히 분석했고, 자세한 결과는 아래와 같습니다!
- 결론은 다른 팀에서 해당 API를 사용하지 않고 있음을 확인했습니다!

* 수정된 API : GET `internal/api/v1/members/activity/me`

### App 팀에서 사용하는 플그 API
![스크린샷 2024-07-24 오후 8 18 06](https://github.com/user-attachments/assets/8a13c883-d439-462d-8d8c-20d21d6ba632)

### 플랫폼 팀에서 사용하는 플그 API
![스크린샷 2024-07-24 오후 8 20 30](https://github.com/user-attachments/assets/f908b66f-db8a-4c74-8759-61da20f3ce12)
