### PR TITLE
[FEAT] 커피챗 활성 기능 추가

### DIFF
--- a/src/main/java/org/sopt/makers/internal/controller/MemberController.java
+++ b/src/main/java/org/sopt/makers/internal/controller/MemberController.java
@@ -15,6 +15,7 @@ import org.sopt.makers.internal.domain.InternalMemberDetails;
 import org.sopt.makers.internal.dto.CommonResponse;
 import org.sopt.makers.internal.dto.member.CheckActivityRequest;
 import org.sopt.makers.internal.dto.member.CoffeeChatRequest;
+import org.sopt.makers.internal.dto.member.CoffeeChatResponse;
 import org.sopt.makers.internal.dto.member.MemberAllProfileResponse;
 import org.sopt.makers.internal.dto.member.MemberCrewResponse;
 import org.sopt.makers.internal.dto.member.MemberProfileProjectVo;
@@ -281,7 +282,19 @@ public class MemberController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    @Operation(summary = "커피챗")
+    @Operation(summary = "커피챗 활성 유저 조회 API")
+    @GetMapping("/coffeechat")
+    public ResponseEntity<CoffeeChatResponse> getCoffeeChatList(
+        @RequestParam(required = false, name = "limit") Integer limit,
+        @RequestParam(required = false, name = "cursor") Long cursor
+    ) {
+        val coffeechats = coffeeChatService.getCoffeeChatList(infiniteScrollUtil.checkLimitForPagination(limit), cursor);
+        val hasNextCoffeeChats = infiniteScrollUtil.checkHasNextElement(limit, coffeechats);
+        val response = new CoffeeChatResponse(coffeechats, hasNextCoffeeChats, coffeechats.size());
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @Operation(summary = "커피챗 수신 API")
     @PostMapping("/coffeechat")
     public ResponseEntity<CommonResponse> requestCoffeeChat(
             @RequestBody CoffeeChatRequest request,

--- a/src/main/java/org/sopt/makers/internal/domain/Member.java
+++ b/src/main/java/org/sopt/makers/internal/domain/Member.java
@@ -135,6 +135,14 @@ public class Member {
     @ColumnDefault("true")
     private Boolean isPhoneBlind = true;
 
+    @Builder.Default
+    @Column(nullable = false)
+    @ColumnDefault("false")
+    private Boolean isCoffeeChatActivate = false;
+
+    @Column(name = "coffee_chat_bio")
+    private String coffeeChatBio;
+
     public void editActivityChange(Boolean isCheck) {
         this.editActivitiesAble = isCheck;
     }
@@ -143,6 +151,7 @@ public class Member {
         this.authUserId = authUserId;
         this.idpType = idpType;
     }
+
 
     public void agreeToUseSoulmate () {
         this.openToSoulmate = true;
@@ -174,7 +183,9 @@ public class Member {
             List<MemberSoptActivity> activities,
             List<MemberLink> links,
             List<MemberCareer> careers,
-            Boolean isPhoneBlind
+            Boolean isPhoneBlind,
+            Boolean isCoffeeChatActivate,
+            String coffeeChatBio
     ) {
         this.name = name;
         this.profileImage = profileImage;
@@ -199,5 +210,7 @@ public class Member {
         this.careers.clear(); this.careers.addAll(careers);
         this.hasProfile = true;
         this.isPhoneBlind = isPhoneBlind;
+        this.isCoffeeChatActivate = isCoffeeChatActivate;
+        this.coffeeChatBio = coffeeChatBio;
     }
 }

--- a/src/main/java/org/sopt/makers/internal/dto/member/CoffeeChatResponse.java
+++ b/src/main/java/org/sopt/makers/internal/dto/member/CoffeeChatResponse.java
@@ -1,0 +1,18 @@
+package org.sopt.makers.internal.dto.member;
+
+import java.util.List;
+
+public record CoffeeChatResponse(
+	List<CoffeeChatVo> coffeeChatList,
+	Boolean hasNext,
+	Integer totalCount
+) {
+	public record CoffeeChatVo(
+		Long memberId,
+		String name,
+		String memberProfileImage,
+		String organization,
+		String careerTitle,
+		String coffeeChatBio
+	) { }
+}

--- a/src/main/java/org/sopt/makers/internal/dto/member/MemberProfileResponse.java
+++ b/src/main/java/org/sopt/makers/internal/dto/member/MemberProfileResponse.java
@@ -30,7 +30,9 @@ public record MemberProfileResponse(
     List<MemberSoptActivityResponse> activities,
     List<MemberLinkResponse> links,
     List<MemberCareerResponse> careers,
-    Boolean allowOfficial
+    Boolean allowOfficial,
+    Boolean isCoffeeChatActivate,
+    String coffeeChatBio
 ) {
 
     public record UserFavorResponse(
@@ -87,7 +89,9 @@ public record MemberProfileResponse(
             response.activities(),
             response.links(),
             response.careers(),
-            response.allowOfficial()
+            response.allowOfficial(),
+            response.isCoffeeChatActivate(),
+            response.coffeeChatBio()
         );
     }
 

--- a/src/main/java/org/sopt/makers/internal/dto/member/MemberProfileSaveRequest.java
+++ b/src/main/java/org/sopt/makers/internal/dto/member/MemberProfileSaveRequest.java
@@ -36,7 +36,9 @@ public record MemberProfileSaveRequest(
 		List<MemberSoptActivitySaveRequest> activities,
 		List<MemberCareerSaveRequest> careers,
 		Boolean allowOfficial,
-		Boolean isPhoneBlind
+		Boolean isPhoneBlind,
+		Boolean isCoffeeChatActivate,
+		String coffeeChatBio
 ) {
 	public record UserFavorRequest(
 			Boolean isPourSauceLover,

--- a/src/main/java/org/sopt/makers/internal/dto/member/MemberProfileUpdateRequest.java
+++ b/src/main/java/org/sopt/makers/internal/dto/member/MemberProfileUpdateRequest.java
@@ -42,7 +42,9 @@ public record MemberProfileUpdateRequest (
         List<MemberSoptActivityUpdateRequest> activities,
         List<MemberCareerUpdateRequest> careers,
         Boolean allowOfficial,
-        Boolean isPhoneBlind
+        Boolean isPhoneBlind,
+        Boolean isCoffeeChatActivate,
+        String coffeeChatBio
 ){
 
     public record UserFavorRequest(

--- a/src/main/java/org/sopt/makers/internal/repository/MemberProfileQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/repository/MemberProfileQueryRepository.java
@@ -361,4 +361,14 @@ public class MemberProfileQueryRepository {
                 .fetch()
                 .size();
     }
+
+    public List<Member> findAllLimitedCoffeeChatByCursor(Integer limit, Long cursor) {
+        val members = QMember.member;
+
+        return queryFactory.selectFrom(members)
+            .where(members.isCoffeeChatActivate.eq(true))
+            .offset(cursor)
+            .limit(limit)
+            .fetch();
+    }
 }

--- a/src/main/java/org/sopt/makers/internal/service/MemberService.java
+++ b/src/main/java/org/sopt/makers/internal/service/MemberService.java
@@ -264,7 +264,7 @@ public class MemberService {
                 request.interest(), userFavor, request.idealType(),
                 request.selfIntroduction(), request.allowOfficial(),
                 memberActivities, memberLinks, memberCareers,
-                request.isPhoneBlind()
+                request.isPhoneBlind(), request.isCoffeeChatActivate(), request.coffeeChatBio()
         );
         try {
             if (Objects.equals(activeProfile, "prod")) {
@@ -363,7 +363,7 @@ public class MemberService {
                 request.interest(), userFavor, request.idealType(),
                 request.selfIntroduction(), request.allowOfficial(),
                 memberActivities, memberLinks, memberCareers,
-                request.isPhoneBlind()
+                request.isPhoneBlind(), request.isCoffeeChatActivate(), request.coffeeChatBio()
         );
         return member;
     }


### PR DESCRIPTION
## Related Issue
related issue #431

## Context
#### `users` 테이블 컬럼 추가
- isCoffeeChatActivate 
- coffeeChatBio 
``` sql
ALTER TABLE internal_prod.users
    ADD COLUMN is_coffee_chat_activate BOOL DEFAULT false NOT NULL;

ALTER TABLE internal_prod.users
    ADD COLUMN coffee_chat_bio VARCHAR(255) NULL;

ALTER TABLE internal.prod.users
    ADD COLUMN coffee_chat_updated_at TIMESTAMP NULL;   -- 커피챗 관련 필드 업데이트 시에만 유의미한 값이 들어가도록 지정 (default 값이 now()가 아닌 이유)
```

#### API 변경사항
- 프로필 관련 API 수정
  - 신규 등록 Request
  - 수정 Request
  - 조회 Response
- CoffeeChatService 로직 추가
  - 페이지네이션 구현 

## Screenshot
<img width="979" alt="image" src="https://github.com/user-attachments/assets/deb0340b-8b94-4e77-82ed-38f82c8a880e">
