### PR TITLE
[CHORE] 커피챗 리스트 조회 API 수정 요청사항 반영

### DIFF
--- a/src/main/java/org/sopt/makers/internal/controller/MemberController.java
+++ b/src/main/java/org/sopt/makers/internal/controller/MemberController.java
@@ -284,13 +284,9 @@ public class MemberController {
 
     @Operation(summary = "커피챗 활성 유저 조회 API")
     @GetMapping("/coffeechat")
-    public ResponseEntity<CoffeeChatResponse> getCoffeeChatList(
-        @RequestParam(required = false, name = "limit") Integer limit,
-        @RequestParam(required = false, name = "cursor") Long cursor
-    ) {
-        val coffeechats = coffeeChatService.getCoffeeChatList(infiniteScrollUtil.checkLimitForPagination(limit), cursor);
-        val hasNextCoffeeChats = infiniteScrollUtil.checkHasNextElement(limit, coffeechats);
-        val response = new CoffeeChatResponse(coffeechats, hasNextCoffeeChats, coffeechats.size());
+    public ResponseEntity<CoffeeChatResponse> getCoffeeChatList() {
+        val coffeechats = coffeeChatService.getCoffeeChatList();
+        val response = new CoffeeChatResponse(coffeechats, coffeechats.size());
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 

--- a/src/main/java/org/sopt/makers/internal/dto/member/CoffeeChatResponse.java
+++ b/src/main/java/org/sopt/makers/internal/dto/member/CoffeeChatResponse.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 public record CoffeeChatResponse(
 	List<CoffeeChatVo> coffeeChatList,
-	Boolean hasNext,
 	Integer totalCount
 ) {
 	public record CoffeeChatVo(

--- a/src/main/java/org/sopt/makers/internal/repository/MemberProfileQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/repository/MemberProfileQueryRepository.java
@@ -361,14 +361,4 @@ public class MemberProfileQueryRepository {
                 .fetch()
                 .size();
     }
-
-    public List<Member> findAllLimitedCoffeeChatByCursor(Integer limit, Long cursor) {
-        val members = QMember.member;
-
-        return queryFactory.selectFrom(members)
-            .where(members.isCoffeeChatActivate.eq(true))
-            .offset(cursor)
-            .limit(limit)
-            .fetch();
-    }
 }

--- a/src/main/java/org/sopt/makers/internal/repository/MemberRepository.java
+++ b/src/main/java/org/sopt/makers/internal/repository/MemberRepository.java
@@ -19,6 +19,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     List<Member> findAllByHasProfileTrue();
 
+    List<Member> findAllByIsCoffeeChatActivateTrue();
+
     List<Member> findAllByHasProfileTrueAndIdIn(List<Long> memberIds);
     Long countByIdIn(Set<Long> memberIds);
 }

--- a/src/main/java/org/sopt/makers/internal/service/CoffeeChatService.java
+++ b/src/main/java/org/sopt/makers/internal/service/CoffeeChatService.java
@@ -27,7 +27,6 @@ import java.util.List;
 public class CoffeeChatService {
     private final EmailSender emailSender;
     private final MemberRepository memberRepository;
-    private final MemberProfileQueryRepository memberQueryRepository;
     private final EmailHistoryRepository emailHistoryRepository;
 
     private final ZoneId KST = ZoneId.of("Asia/Seoul");
@@ -68,17 +67,15 @@ public class CoffeeChatService {
 
     }
 
-    public List<CoffeeChatVo> getCoffeeChatList (Integer limit, Long cursor) {
-        if (limit == null || limit >= 50) limit = 50;
-        if (cursor == null) cursor = 0L;
-        val members = memberQueryRepository.findAllLimitedCoffeeChatByCursor(limit, cursor);
+    public List<CoffeeChatVo> getCoffeeChatList () {
+        val members = memberRepository.findAllByIsCoffeeChatActivateTrue();
         return members.stream().map(
             m -> {
                 val career = getCurrentMemberCareer(m);
                 return new CoffeeChatVo(
                     m.getId(), m.getName(), m.getProfileImage(),
                     career == null ? m.getUniversity() : career.getCompanyName(),
-                    career == null ? m.getIntroduction() : career.getTitle(),
+                    career == null ? m.getSkill() : career.getTitle(),
                     m.getCoffeeChatBio()
                 );
             }


### PR DESCRIPTION
## Context
- https://sopt-makers.slack.com/archives/C04326AHDRT/p1723362276946599?thread_ts=1722876020.622929&cid=C04326AHDRT
- related issue #433 

## Change Log
- pagination 기능 지원하지 않도록 수정
- career가 없는 유저의 경우, title을 introduction이 아닌 skill로 대체하도록 수정