### PR TITLE
[Chore] 프로젝트명 검색 조건 변경

### DIFF
--- a/src/main/java/org/sopt/makers/internal/repository/ProjectQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/repository/ProjectQueryRepository.java
@@ -58,7 +58,7 @@ public class ProjectQueryRepository {
 
     private BooleanExpression checkProjectContainsName(String name) {
         val checkNameIsEmpty = Objects.isNull(name);
-        return checkNameIsEmpty ? null : QProject.project.name.eq(name);
+        return checkNameIsEmpty ? null : QProject.project.name.contains(name);
     }
 
     private BooleanExpression checkProjectCategory(String category) {


### PR DESCRIPTION
## Change Log
- Querydsl에서 eq() -> contains()로 where 조건 수정
- 프로젝트 조회 API에서 name param의 포함여부로 결과를 반환하도록 개선

## Related Issue
closed issue #447