### PR TITLE
[Chore] 대소문자 무관하게 검색 가능하도록 조건 수정

### DIFF
--- a/src/main/java/org/sopt/makers/internal/repository/ProjectQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/repository/ProjectQueryRepository.java
@@ -58,7 +58,7 @@ public class ProjectQueryRepository {
 
     private BooleanExpression checkProjectContainsName(String name) {
         val checkNameIsEmpty = Objects.isNull(name);
-        return checkNameIsEmpty ? null : QProject.project.name.contains(name);
+        return checkNameIsEmpty ? null : QProject.project.name.lower().contains(name.toLowerCase());
     }
 
     private BooleanExpression checkProjectCategory(String category) {


### PR DESCRIPTION
프로젝트명으로 검색 시, 알파벳이 포함된 경우에 대소문자 무관하게 검색 결과로 포함되도록 개선합니다. 