### PR TITLE
chore: prometheus 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,9 @@ dependencies {
 
 	// Slack
 	implementation 'com.slack.api:slack-api-client:1.41.0'
+
+	// Prometheus
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 dependencyManagement {


### PR DESCRIPTION
## Related Issue
related issue #453

## Context
모니터링 서버를 별도로 구축하여 스프링 서버의 메트릭을 수집할 수 있도록 prometheus 관련 의존성을 추가하고, application.yml 설정파일의 구성을 추가합니다. 

우선 테스트를 위해 dev 서버를 바라보도록 설정합니다. 테스트 이후에는 다시 롤백 후 상세 메트릭을 논의할 계획입니다

application-dev.yml에서 추가될 사항
``` yaml
management:  ## 애플리케이션의 관리(management) 및 모니터링을 위한 설정: Prometheus와 같은 모니터링 도구와의 통합을 설정

  # 특정 관리 엔드포인트의 활성화 여부를 정의
  endpoint:
    metrics:
      enabled: true  # Spring Boot Actuator의 메트릭 기능을 활성화 (metric 수집 활성)
    prometheus:
      enabled: true  # Prometheus 포맷으로 메트릭 데이터를 제공하는 엔드포인트(/actuator/prometheus) 활성화 (Prometheus를 통해 애플리케이션 메트릭을 수집할 수 있도록)

  # 특정 Actuator 엔드포인트들을 외부에 노출할 수 있도록 허용
  endpoints:
    web:
      exposure:  # 특정 Actuator 엔드포인트들을 외부에 노출할 수 있도록 허용
        include: health, info, metrics, prometheus

  # 애플리케이션의 메트릭 수집과 태그 관리에 대한 설정
  metrics:
    tags:
      application: ${spring.application.name}  # Spring 애플리케이션 이름을 태그로 사용 (application.yml에서 정의 필요)
```
