### PR TITLE
[FIX] user_resolution의 generation을 사용하여 쿼리하도록 수정

### DIFF
--- a/src/main/java/org/sopt/makers/internal/resolution/repository/UserResolutionRepository.java
+++ b/src/main/java/org/sopt/makers/internal/resolution/repository/UserResolutionRepository.java
@@ -11,5 +11,5 @@ public interface UserResolutionRepository extends JpaRepository<UserResolution, 
     // READ
     Optional<UserResolution> findUserResolutionByMemberAndGeneration(Member member, int generation);
 
-    boolean existsByMemberAndMemberGeneration(Member member, int generation);
+    boolean existsByMemberAndGeneration(Member member, int generation);
 }

--- a/src/main/java/org/sopt/makers/internal/resolution/service/UserResolutionService.java
+++ b/src/main/java/org/sopt/makers/internal/resolution/service/UserResolutionService.java
@@ -67,7 +67,7 @@ public class UserResolutionService {
 	}
 
 	private boolean existsCurrentResolution(Member member) {
-		return userResolutionRepository.existsByMemberAndMemberGeneration(member, CURRENT_GENERATION);
+		return userResolutionRepository.existsByMemberAndGeneration(member, CURRENT_GENERATION);
 	}
 
 	private Member getMemberById(Long userId) {


### PR DESCRIPTION

## 🐬 요약
다짐 메시지 유효성 검사 및 등록을 위한 쿼리 조건을 수정합니다. 

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [x] 버그 수정
- [ ] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
- 기존에 유저 당 1개의 다짐메시지만 등록가능하도록 유효성 검사에서 반환하고 있어, 두 기수 이상의 회원이 다짐 메시지를 등록할 수 없는 이슈가 있었습니다. 
- user 테이블의 generation이 아닌 user_resolution 테이블의 generation을 조건으로 쿼리하도록 수정합니다. 

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

closed issue  #469
