### PR TITLE
[Hotfix] anonymous profile null 반환 로직 수정

### DIFF
--- a/src/main/java/org/sopt/makers/internal/community/service/AnonymousProfileImageService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/AnonymousProfileImageService.java
@@ -36,7 +36,8 @@ public class AnonymousProfileImageService {
         return profileImageMap.keySet().stream()
                 .filter(i -> !excludes.contains(i))
                 .findFirst()
-                .map(profileImageMap::get).orElse(null);
+                .map(profileImageMap::get)
+                .orElseGet(() -> shuffle((long)(Math.random() * 5)));
     }
 
     private AnonymousProfileImage shuffle(Long index) {


### PR DESCRIPTION
## 🐬 요약
댓글 생성 시 익명 프로필에 의해 500 애러가 발생하는 이슈를 해결합니다.

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [x] 버그 수정
- [ ] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
PR에 담긴 작업 내용을 작성해주세요!

- 게시글 익명 프로필과 댓글 프로필의 이미지가 겹치지 않게 하기 위한 filter 로직에서 필터링에 실패하면 null을 반환하게 됩니다.
- 필터링 실패 시에 shuffle 하여 반환하도록 수정했습니다. 

<img width="1431" alt="image" src="https://github.com/user-attachments/assets/4fb80050-f493-43ef-a5a2-3af845f58a36">

dev 서버에서 2개 계정으로 익명 댓글 생성 문제 없이 동작하는 것을 확인했습니다!

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #472

