### PR TITLE
[Feat] 커피챗 정보 삭제 API

### DIFF
--- a/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/CoffeeChatController.java
+++ b/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/CoffeeChatController.java
@@ -12,11 +12,8 @@ import org.sopt.makers.internal.member.service.coffeechat.CoffeeChatService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
 import java.util.List;
 
 @RestController
@@ -41,6 +38,16 @@ public class CoffeeChatController {
     ) {
         coffeeChatService.createCoffeeChatDetails(memberDetails.getId(), request);
         CommonResponse response = new CommonResponse(true, "커피챗 정보 생성에 성공했습니다.");
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @Operation(summary = "커피챗 정보 삭제 API")
+    @DeleteMapping("/details")
+    public ResponseEntity<CommonResponse> deleteCoffeeChatDetails(
+            @Parameter(hidden = true) @AuthenticationPrincipal InternalMemberDetails memberDetails
+    ) {
+        coffeeChatService.deleteCoffeeChatDetails(memberDetails.getId());
+        CommonResponse response = new CommonResponse(true, "커피챗 정보 삭제에 성공했습니다.");
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/src/main/java/org/sopt/makers/internal/member/domain/coffeechat/CoffeeChat.java
+++ b/src/main/java/org/sopt/makers/internal/member/domain/coffeechat/CoffeeChat.java
@@ -57,7 +57,7 @@ public class CoffeeChat extends AuditingTimeEntity {
     @Column(length = 1000)
     private String guideline;
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 

--- a/src/main/java/org/sopt/makers/internal/member/service/coffeechat/CoffeeChatCreator.java
+++ b/src/main/java/org/sopt/makers/internal/member/service/coffeechat/CoffeeChatCreator.java
@@ -37,4 +37,9 @@ public class CoffeeChatCreator {
                 .guideline(request.coffeeChatInfo().guideline()).build()
         );
     }
+
+    public void deleteCoffeeChatDetails(CoffeeChat coffeeChat) {
+
+        coffeeChatRepository.delete(coffeeChat);
+    }
 }

--- a/src/main/java/org/sopt/makers/internal/member/service/coffeechat/CoffeeChatService.java
+++ b/src/main/java/org/sopt/makers/internal/member/service/coffeechat/CoffeeChatService.java
@@ -106,4 +106,12 @@ public class CoffeeChatService {
 
         coffeeChatCreator.createCoffeeChatDetails(member, request);
     }
+
+    @Transactional
+    public void deleteCoffeeChatDetails (Long memberId) {
+        Member member = memberRetriever.findMemberById(memberId);
+
+        CoffeeChat coffeeChat = coffeeChatRetriever.findCoffeeChatByMember(member);
+        coffeeChatCreator.deleteCoffeeChatDetails(coffeeChat);
+    }
 }


### PR DESCRIPTION
## 🐬 요약
SP1 커피챗 고도화에서 추가된 필드를 바탕으로 정보를 삭제하는 API를 추가합니다.
- 코드리뷰의 편의를 위해 https://github.com/sopt-makers/sopt-playground-backend/pull/494 와 분리하여 PR 생성합니다.
## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [x] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
PR에 담긴 작업 내용을 작성해주세요!

- 커피챗 정보 삭제 API
- CoffeeChat -> Member `Cascade.REMOVE` 제약 조건 제거

#### Test
<img width="818" alt="image" src="https://github.com/user-attachments/assets/cdba2381-c000-406a-abb0-d5a04b1e7ca4">
<img width="901" alt="image" src="https://github.com/user-attachments/assets/dec3f63c-b118-44bb-b800-113979193661">


## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

related issue: #482 
