### PR TITLE
[Chore] enum title명 FE와 sync

### DIFF
--- a/src/main/java/org/sopt/makers/internal/member/domain/coffeechat/Career.java
+++ b/src/main/java/org/sopt/makers/internal/member/domain/coffeechat/Career.java
@@ -12,11 +12,11 @@ import java.util.Arrays;
 @AllArgsConstructor
 public enum Career {
 
-    NONE("없음"),
-    INTERN("인턴"),
-    JUNIOR("주니어"),
-    MIDDLE("미들"),
-    SENIOR("시니어")
+    NONE("아직 없어요"),
+    INTERN("인턴 경험만 있어요"),
+    JUNIOR("주니어 (0-3년)"),
+    MIDDLE("미들 (4-8년)"),
+    SENIOR("시니어 (9년 이상)")
     ;
 
     private final String title;

--- a/src/main/java/org/sopt/makers/internal/member/domain/coffeechat/CoffeeChatSection.java
+++ b/src/main/java/org/sopt/makers/internal/member/domain/coffeechat/CoffeeChatSection.java
@@ -15,7 +15,7 @@ public enum CoffeeChatSection {
     SOPT_ACTIVITY("SOPT 활동"),
     PLAN("기획"),
     DESIGN("디자인"),
-    FRONTEND("프론트엔드"),
+    FRONTEND("프론트"),
     BACKEND("백엔드"),
     APP("앱 개발"),
     ETC("기타")

--- a/src/main/java/org/sopt/makers/internal/member/domain/coffeechat/MeetingType.java
+++ b/src/main/java/org/sopt/makers/internal/member/domain/coffeechat/MeetingType.java
@@ -14,7 +14,7 @@ public enum MeetingType {
 
     ONLINE("온라인"),
     OFFLINE("오프라인"),
-    ANYTHING("무관")
+    ANYTHING("온/오프라인")
     ;
 
     final String title;


### PR DESCRIPTION
## 🐬 요약
- 개발 편의성을 위해 FE와 요청-응답에 주고받는 enum title 명을 통일합니다.
- [관련 스레드](https://sopt-makers.slack.com/archives/C04SPCUJ2DQ/p1729863225919029?thread_ts=1729863174.103309&cid=C04SPCUJ2DQ)

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [ ] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [x] 기타... (다음 줄에 사유를 입력해주세요) 간단한 변경사항

## 🍀 작업 내용
- Career
- CoffeeChatSection
- MeetingType

위 enum명을 FE와 통일합니다.

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

related issue #482
