### PR TITLE
[Chore] member profile response

### DIFF
--- a/src/main/java/org/sopt/makers/internal/dto/member/MemberProfileResponse.java
+++ b/src/main/java/org/sopt/makers/internal/dto/member/MemberProfileResponse.java
@@ -31,8 +31,7 @@ public record MemberProfileResponse(
     List<MemberLinkResponse> links,
     List<MemberCareerResponse> careers,
     Boolean allowOfficial,
-    Boolean isCoffeeChatActivate,
-    String coffeeChatBio
+    Boolean isCoffeeChatActivate
 ) {
 
     public record UserFavorResponse(
@@ -90,8 +89,7 @@ public record MemberProfileResponse(
             response.links(),
             response.careers(),
             response.allowOfficial(),
-            response.isCoffeeChatActivate(),
-            response.coffeeChatBio()
+            response.isCoffeeChatActivate()
         );
     }
 

--- a/src/main/java/org/sopt/makers/internal/mapper/MemberMapper.java
+++ b/src/main/java/org/sopt/makers/internal/mapper/MemberMapper.java
@@ -26,7 +26,7 @@ import org.sopt.makers.internal.dto.wordChainGame.WordChainGameRoomResponse;
 public interface MemberMapper {
     MemberResponse toResponse(Member member);
     InternalMemberResponse toInternalResponse(Member member, Integer latestGeneration);
-    MemberProfileResponse toProfileResponse (Member member);
+    MemberProfileResponse toProfileResponse (Member member, Boolean isCoffeeChatActivate);
     InternalMemberProfileResponse toInternalProfileResponse (Member member);
     WordChainGameGenerateResponse.UserResponse toUserResponse (Member member);
     WordChainGameRoomResponse.WordResponse.UserResponse toAllGameRoomResponse (Member member);

--- a/src/main/java/org/sopt/makers/internal/member/service/coffeechat/CoffeeChatRetriever.java
+++ b/src/main/java/org/sopt/makers/internal/member/service/coffeechat/CoffeeChatRetriever.java
@@ -21,10 +21,6 @@ public class CoffeeChatRetriever {
 
     private final CoffeeChatRepository coffeeChatRepository;
 
-    public List<CoffeeChat> findCoffeeChatActivate(boolean isCoffeeChatActivate) {
-        return coffeeChatRepository.findAllByIsCoffeeChatActivate(isCoffeeChatActivate);
-    }
-
     public CoffeeChat findCoffeeChatByMember(Member member) {
         return coffeeChatRepository.findCoffeeChatByMember(member)
                 .orElseThrow(() -> new NotFoundDBEntityException("커피챗 정보를 등록한적 없는 유저입니다. " + "member id: " + member.getId()));

--- a/src/main/java/org/sopt/makers/internal/member/service/coffeechat/CoffeeChatService.java
+++ b/src/main/java/org/sopt/makers/internal/member/service/coffeechat/CoffeeChatService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.makers.internal.domain.Member;
 import org.sopt.makers.internal.domain.MemberCareer;
+import org.sopt.makers.internal.exception.NotFoundDBEntityException;
 import org.sopt.makers.internal.external.MessageSender;
 import org.sopt.makers.internal.external.MessageSenderFactory;
 import org.sopt.makers.internal.member.controller.coffeechat.dto.response.CoffeeChatDetailResponse;
@@ -75,6 +76,17 @@ public class CoffeeChatService {
         MemberCareer memberCareer = memberCareerRetriever.findMemberLastCareerByMemberId(detailMemberId);
         Boolean isMine = Objects.equals(memberId, detailMemberId);
         return coffeeChatResponseMapper.toCoffeeChatDetailResponse(coffeeChat, member, memberCareer, isMine);
+    }
+
+    @Transactional(readOnly = true)
+    public Boolean getCoffeeChatActivate (Long memberId) {
+        Member member = memberRetriever.findMemberById(memberId);
+        try {
+            CoffeeChat coffeeChat = coffeeChatRetriever.findCoffeeChatByMember(member);
+            return coffeeChat.getIsCoffeeChatActivate();
+        } catch (NotFoundDBEntityException ex) {
+            return false;
+        }
     }
 
     @Transactional


### PR DESCRIPTION
## 🐬 요약
멤버 프로필 조회 시, isCoffeeChatActivate 필드는 신규 생성된 coffee_chat 테이블을 바라보도록 수정합니다. 

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [x] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
PR에 담긴 작업 내용을 작성해주세요!

- 커피챗 조회 시, 기존 로직 활용 (단, NotFoundDBException이 발생할 수 있으므로 try-catch로 예외처리 후 항상 false를 반환하도록 함)
- 기존 프로필 response에서 coffee_chat_bio는 제거
- 멤버 프로필 mapper 로직 수정: Controller 단에서 coffeeChat 정보를 가져오고 mapper에서 매핑하도록 함

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

related issue: #498 
