### PR TITLE
[Fix] 커뮤니티 게시글 좋아요 연관관계 updatable 속성 지정

### DIFF
--- a/src/main/java/org/sopt/makers/internal/community/domain/CommunityPostLike.java
+++ b/src/main/java/org/sopt/makers/internal/community/domain/CommunityPostLike.java
@@ -21,11 +21,11 @@ public class CommunityPostLike extends AuditingTimeEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", updatable = false)
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "post_id")
+    @JoinColumn(name = "post_id", updatable = false)
     private CommunityPost post;
 
     @Builder


### PR DESCRIPTION
## 🐬 요약

created_at이 null로 업데이트 되는 현상을 막기 위해 엔티티 연관관계 매핑에서 `updatable=false` 속성을 추가합니다. (default는 true)

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [x] 버그 수정
- [ ] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
PR에 담긴 작업 내용을 작성해주세요!

- 엔티티 연관관계 속성 추가
- createdAt 대신 updatedAt을 기준으로 정렬하는 것은 일단 보류 (문제 재발 시 긴급 조치로 updatedAt 내림차순 정렬로 수정하겠습니다)

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #507 
