### PR TITLE
[Feat] LMS endpoint 추가

### DIFF
--- a/src/main/java/org/sopt/makers/internal/external/gabia/GabiaService.java
+++ b/src/main/java/org/sopt/makers/internal/external/gabia/GabiaService.java
@@ -21,6 +21,7 @@ public class GabiaService {
     private final AuthConfig authConfig;
     private static final String SMS_OAUTH_TOKEN_URL = "https://sms.gabia.com/oauth/token";
     private static final String SMS_SEND_URL = "https://sms.gabia.com/api/send/sms";
+    private static final String LMS_SEND_URL = "https://sms.gabia.com/api/send/lms";
 
     private GabiaAuthResponse getGabiaAccessToken() {
         String authValue = Base64.getEncoder().encodeToString(String.format("%s:%s", authConfig.getGabiaSMSId(), authConfig.getGabiaApiKey()).getBytes(StandardCharsets.UTF_8));
@@ -73,6 +74,13 @@ public class GabiaService {
         String authValue = Base64.getEncoder().encodeToString(String.format("%s:%s", authConfig.getGabiaSMSId(), gabiaAuthResponse.access_token()).getBytes(StandardCharsets.UTF_8));
         OkHttpClient client = new OkHttpClient();
 
+        String targetUrl;
+        if (message.length() <= 45) {
+            targetUrl = SMS_SEND_URL;
+        } else {
+            targetUrl = LMS_SEND_URL;
+        }
+
         RequestBody requestBody = new MultipartBody.Builder().setType(MultipartBody.FORM)
                 .addFormDataPart("phone", phone)
                 .addFormDataPart("callback", authConfig.getGabiaSendNumber())
@@ -81,7 +89,7 @@ public class GabiaService {
                 .build();
 
         Request request = new Request.Builder()
-                .url(SMS_SEND_URL)
+                .url(targetUrl)
                 .post(requestBody)
                 .addHeader("Content-Type", "application/x-www-form-urlencoded")
                 .addHeader("Authorization", "Basic " + authValue)


### PR DESCRIPTION
## 🐬 요약
커피챗 문자 발송 시 장문의 문자도 발신이 가능하도록 합니다.

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [x] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
- 메시지 본문 길이에 따라 호출하는 가비아 API의 endpoint를 다르게 지정합니다. (비용 한도를 효율적으로 사용하기 위함)

### Test
<img width="657" alt="image" src="https://github.com/user-attachments/assets/90110538-0ea3-416a-af95-bf1d3b4a3778">

- API 는 정상적으로 처리되는 것을 확인했습니다. 
- dev 서버에서 테스트했을 때 문자가 정상적으로 수신되는지 확인해야 qa가 완료됩니다.

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #518 
