### PR TITLE
chore: CoffeeChat meetingType not null로 제한

### DIFF
--- a/src/main/java/org/sopt/makers/internal/dto/member/MemberProfileUpdateRequest.java
+++ b/src/main/java/org/sopt/makers/internal/dto/member/MemberProfileUpdateRequest.java
@@ -1,21 +1,16 @@
 package org.sopt.makers.internal.dto.member;
 
-import static org.sopt.makers.internal.common.Constant.*;
-
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.extern.slf4j.Slf4j;
+import org.sopt.makers.internal.domain.MemberSoptActivity;
 
+import javax.validation.constraints.Pattern;
 import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
-import javax.validation.constraints.Size;
-
-import org.sopt.makers.internal.domain.MemberSoptActivity;
+import static org.sopt.makers.internal.common.Constant.PHONE_NUMBER_REGEX;
 
 @Slf4j
 public record MemberProfileUpdateRequest (

--- a/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/dto/request/CoffeeChatDetailsRequest.java
+++ b/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/dto/request/CoffeeChatDetailsRequest.java
@@ -47,7 +47,6 @@ public record CoffeeChatDetailsRequest(
 			String topic,
 
 			@Schema(required = true)
-			@NotBlank(message = "진행 방식은 필수 입력 값입니다.")
 			MeetingType meetingType,
 
 			@Size(max = 1000, message = "유의사항은 1000자를 초과할 수 없습니다.")

--- a/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/dto/request/CoffeeChatDetailsRequest.java
+++ b/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/dto/request/CoffeeChatDetailsRequest.java
@@ -47,6 +47,7 @@ public record CoffeeChatDetailsRequest(
 			String topic,
 
 			@Schema(required = true)
+			@NotBlank(message = "진행 방식은 필수 입력 값입니다.")
 			MeetingType meetingType,
 
 			@Size(max = 1000, message = "유의사항은 1000자를 초과할 수 없습니다.")

--- a/src/main/java/org/sopt/makers/internal/member/domain/coffeechat/CoffeeChat.java
+++ b/src/main/java/org/sopt/makers/internal/member/domain/coffeechat/CoffeeChat.java
@@ -50,7 +50,7 @@ public class CoffeeChat extends AuditingTimeEntity {
     @Column(nullable = false, length = 1000)
     private String topic;
 
-    @Column
+    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private MeetingType meetingType;
 


### PR DESCRIPTION
## 🐬 요약
PR의 요약을 작성해주세요!
커피챗 테이블의 meetingType을 not null 필드로 변경하고, production/dev 테이블의 스키마 변경 및 더미 데이터 추가를 반영합니다. 

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [x] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

related issue: #489
