### PR TITLE
[Fix]: 메이커스 이미지 방지

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ out/
 
 ### config yml ###
 application-**.yml
+
+### Mac OS .DS_Store ###
+.DS_Store

--- a/src/main/java/org/sopt/makers/internal/community/repository/AnonymousProfileImageRepository.java
+++ b/src/main/java/org/sopt/makers/internal/community/repository/AnonymousProfileImageRepository.java
@@ -3,5 +3,9 @@ package org.sopt.makers.internal.community.repository;
 import org.sopt.makers.internal.community.domain.AnonymousProfileImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface AnonymousProfileImageRepository extends JpaRepository<AnonymousProfileImage, Long> {
+
+    List<AnonymousProfileImage> findAllByIdNot(Long id);
 }

--- a/src/main/java/org/sopt/makers/internal/community/service/AnonymousProfileImageService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/AnonymousProfileImageService.java
@@ -16,6 +16,7 @@ import java.util.Map;
 public class AnonymousProfileImageService {
 
     private final AnonymousProfileImageRepository anonymousProfileImageRepository;
+    private final static Long MAKERS_LOGO_IMAGE_ID = 6L;
 
     public AnonymousProfileImageService(AnonymousProfileImageRepository anonymousProfileImageRepository) {
         this.anonymousProfileImageRepository = anonymousProfileImageRepository;
@@ -47,7 +48,9 @@ public class AnonymousProfileImageService {
     private void initializeProfileImageMap() {
         List<AnonymousProfileImage> anonymousProfileImages = anonymousProfileImageRepository.findAll();
         for (AnonymousProfileImage image : anonymousProfileImages) {
-            profileImageMap.put(image.getId(), image);
+            if (!image.getId().equals(MAKERS_LOGO_IMAGE_ID)) {
+                profileImageMap.put(image.getId(), image);
+            }
         }
     }
 }

--- a/src/main/java/org/sopt/makers/internal/community/service/AnonymousProfileImageService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/AnonymousProfileImageService.java
@@ -18,7 +18,6 @@ public class AnonymousProfileImageService {
     public AnonymousProfileImageService(AnonymousProfileImageRepository anonymousProfileImageRepository) {
         this.anonymousProfileImageRepository = anonymousProfileImageRepository;
         initializeProfileImageMap();
-        System.out.println(profileImageMap);
     }
 
     private static final Map<Long, AnonymousProfileImage> profileImageMap = new HashMap<>();

--- a/src/main/java/org/sopt/makers/internal/community/service/AnonymousProfileImageService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/AnonymousProfileImageService.java
@@ -1,10 +1,7 @@
 package org.sopt.makers.internal.community.service;
 
-import lombok.RequiredArgsConstructor;
 import org.sopt.makers.internal.community.domain.AnonymousProfileImage;
 import org.sopt.makers.internal.community.repository.AnonymousProfileImageRepository;
-import org.sopt.makers.internal.domain.community.AnonymousProfileImg;
-import org.sopt.makers.internal.exception.NotFoundDBEntityException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +18,7 @@ public class AnonymousProfileImageService {
     public AnonymousProfileImageService(AnonymousProfileImageRepository anonymousProfileImageRepository) {
         this.anonymousProfileImageRepository = anonymousProfileImageRepository;
         initializeProfileImageMap();
+        System.out.println(profileImageMap);
     }
 
     private static final Map<Long, AnonymousProfileImage> profileImageMap = new HashMap<>();
@@ -28,7 +26,7 @@ public class AnonymousProfileImageService {
     @Transactional(readOnly = true)
     public AnonymousProfileImage getRandomProfileImage(List<Long> excludes) {
         if (excludes.isEmpty() || excludes.size() >= profileImageMap.size()) {
-            return shuffle((long)(Math.random() * 5));
+            return shuffle((long) (Math.random() * 5));
         }
         return filtered(excludes);
     }
@@ -38,7 +36,7 @@ public class AnonymousProfileImageService {
                 .filter(i -> !excludes.contains(i))
                 .findFirst()
                 .map(profileImageMap::get)
-                .orElseGet(() -> shuffle((long)(Math.random() * 5)));
+                .orElseGet(() -> shuffle((long) (Math.random() * 5)));
     }
 
     private AnonymousProfileImage shuffle(Long index) {
@@ -46,11 +44,9 @@ public class AnonymousProfileImageService {
     }
 
     private void initializeProfileImageMap() {
-        List<AnonymousProfileImage> anonymousProfileImages = anonymousProfileImageRepository.findAll();
+        List<AnonymousProfileImage> anonymousProfileImages = anonymousProfileImageRepository.findAllByIdNot(MAKERS_LOGO_IMAGE_ID);
         for (AnonymousProfileImage image : anonymousProfileImages) {
-            if (!image.getId().equals(MAKERS_LOGO_IMAGE_ID)) {
-                profileImageMap.put(image.getId(), image);
-            }
+            profileImageMap.put(image.getId(), image);
         }
     }
 }


### PR DESCRIPTION
Related to: #535

## 🐬 요약
익명 댓글을 작성할 때 메이커스 로고가 선택되는 경우를 방지했습니다.
이미지 목록 Map에 초기화 할 때 id가 6인 이미지는 제외했습니다.

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [x] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
PR에 담긴 작업 내용을 작성해주세요!

- 작업 1
- 작업 2
- 작업 3

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #535 
