### PR TITLE
[Feat] internal api for app

### DIFF
--- a/src/main/java/org/sopt/makers/internal/community/repository/CommunityPostRepositoryCustom.java
+++ b/src/main/java/org/sopt/makers/internal/community/repository/CommunityPostRepositoryCustom.java
@@ -1,0 +1,8 @@
+package org.sopt.makers.internal.community.repository;
+
+import org.sopt.makers.internal.dto.community.PostCategoryDao;
+
+public interface CommunityPostRepositoryCustom {
+
+	PostCategoryDao findRecentPostByCategory(String categoryName);
+}

--- a/src/main/java/org/sopt/makers/internal/community/repository/CommunityPostRepositoryCustomImpl.java
+++ b/src/main/java/org/sopt/makers/internal/community/repository/CommunityPostRepositoryCustomImpl.java
@@ -1,5 +1,6 @@
 package org.sopt.makers.internal.community.repository;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.sopt.makers.internal.community.domain.category.QCategory;
@@ -12,6 +13,11 @@ public class CommunityPostRepositoryCustomImpl implements CommunityPostRepositor
 
 	private final JPAQueryFactory queryFactory;
 
+	private BooleanExpression checkCategoryEqualsName(String categoryName) {
+		if (categoryName == null) return null;
+		return QCategory.category.name.eq(categoryName);
+	}
+
 	@Override
 	public PostCategoryDao findRecentPostByCategory(String categoryName) {
 		QCommunityPost posts = QCommunityPost.communityPost;
@@ -21,7 +27,7 @@ public class CommunityPostRepositoryCustomImpl implements CommunityPostRepositor
 				.select(new QPostCategoryDao(posts, category))
 				.from(posts)
 				.innerJoin(category).on(posts.categoryId.eq(category.id))
-				.where(category.name.eq(categoryName))
+				.where(checkCategoryEqualsName(categoryName))
 				.orderBy(posts.id.desc())
 				.fetchFirst();
 	}

--- a/src/main/java/org/sopt/makers/internal/community/repository/CommunityPostRepositoryCustomImpl.java
+++ b/src/main/java/org/sopt/makers/internal/community/repository/CommunityPostRepositoryCustomImpl.java
@@ -1,0 +1,28 @@
+package org.sopt.makers.internal.community.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.sopt.makers.internal.community.domain.category.QCategory;
+import org.sopt.makers.internal.domain.community.QCommunityPost;
+import org.sopt.makers.internal.dto.community.PostCategoryDao;
+import org.sopt.makers.internal.dto.community.QPostCategoryDao;
+
+@RequiredArgsConstructor
+public class CommunityPostRepositoryCustomImpl implements CommunityPostRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public PostCategoryDao findRecentPostByCategory(String categoryName) {
+		QCommunityPost posts = QCommunityPost.communityPost;
+		QCategory category = QCategory.category;
+
+		return queryFactory
+				.select(new QPostCategoryDao(posts, category))
+				.from(posts)
+				.innerJoin(category).on(posts.categoryId.eq(category.id))
+				.where(category.name.eq(categoryName))
+				.orderBy(posts.id.desc())
+				.fetchFirst();
+	}
+}

--- a/src/main/java/org/sopt/makers/internal/community/service/CommunityPostService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/CommunityPostService.java
@@ -281,8 +281,8 @@ public class CommunityPostService {
     }
 
     @Transactional(readOnly = true)
-    public PostCategoryDao getRecentPost() {
-        return communityQueryRepository.findRecentPost();
+    public PostCategoryDao getRecentPost(String category) {
+        return communityQueryRepository.findRecentPost(category);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/makers/internal/community/service/CommunityPostService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/CommunityPostService.java
@@ -42,28 +42,33 @@ import java.util.stream.Collectors;
 @Service
 public class CommunityPostService {
 
-    private final AnonymousProfileImageService anonymousProfileImageService;
-
-    @Value("${spring.profiles.active}")
-    private String activeProfile;
     private final CommunityCommentRepository communityCommentRepository;
-    private final AnonymousPostProfileRepository anonymousPostProfileRepository;
-    private final AnonymousNicknameRepository anonymousNicknameRepository;
     private final CommunityPostLikeRepository communityPostLikeRepository;
-    private final MemberRepository memberRepository;
-    private final CategoryRepository categoryRepository;
-    private final PostRepository postRepository;
-    private final ReportPostRepository reportPostRepository;
     private final CommunityPostRepository communityPostRepository;
+
+    private final CommunityQueryRepository communityQueryRepository;
+
     private final DeletedCommunityPostRepository deletedCommunityPostRepository;
     private final DeletedCommunityCommentRepository deletedCommunityCommentRepository;
-    private final CommunityMapper communityMapper;
-    private final CommunityQueryRepository communityQueryRepository;
+
+    private final ReportPostRepository reportPostRepository;
+    private final PostRepository postRepository;
+    private final CategoryRepository categoryRepository;
+    private final MemberRepository memberRepository;
     private final MemberBlockRepository memberBlockRepository;
+
+    private final AnonymousProfileImageService anonymousProfileImageService;
+    private final AnonymousPostProfileRepository anonymousPostProfileRepository;
+    private final AnonymousNicknameRepository anonymousNicknameRepository;
+
+    private final CommunityMapper communityMapper;
     private final CommunityResponseMapper communityResponseMapper;
+
     private final SlackMessageUtil slackMessageUtil;
     private final SlackClient slackClient;
 
+    @Value("${spring.profiles.active}")
+    private String activeProfile;
 
     private final ZoneId KST = ZoneId.of("Asia/Seoul");
     private static final int MIN_POINTS_FOR_HOT_POST = 10;
@@ -282,7 +287,7 @@ public class CommunityPostService {
 
     @Transactional(readOnly = true)
     public PostCategoryDao getRecentPostByCategory(String category) {
-        return communityQueryRepository.findRecentPostByCategory(category);
+        return communityPostRepository.findRecentPostByCategory(category);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/makers/internal/community/service/CommunityPostService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/CommunityPostService.java
@@ -281,8 +281,8 @@ public class CommunityPostService {
     }
 
     @Transactional(readOnly = true)
-    public PostCategoryDao getRecentPost(String category) {
-        return communityQueryRepository.findRecentPost(category);
+    public PostCategoryDao getRecentPostByCategory(String category) {
+        return communityQueryRepository.findRecentPostByCategory(category);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/makers/internal/community/service/CommunityPostService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/CommunityPostService.java
@@ -281,6 +281,11 @@ public class CommunityPostService {
     }
 
     @Transactional(readOnly = true)
+    public PostCategoryDao getRecentPost() {
+        return communityQueryRepository.findRecentPost();
+    }
+
+    @Transactional(readOnly = true)
     public CommunityPost findTodayHotPost(List<CommunityPost> posts) {
         return posts.stream()
             .map(this::createPostWithPoints)

--- a/src/main/java/org/sopt/makers/internal/controller/InternalOpenApiController.java
+++ b/src/main/java/org/sopt/makers/internal/controller/InternalOpenApiController.java
@@ -23,6 +23,7 @@ import org.sopt.makers.internal.member.controller.coffeechat.dto.response.Intern
 import org.sopt.makers.internal.dto.internal.InternalMemberProjectResponse;
 import org.sopt.makers.internal.member.mapper.coffeechat.CoffeeChatResponseMapper;
 import org.sopt.makers.internal.member.repository.coffeechat.dto.InternalCoffeeChatMemberDto;
+import org.sopt.makers.internal.member.service.coffeechat.CoffeeChatService;
 import org.sopt.makers.internal.service.InternalApiService;
 import org.sopt.makers.internal.service.MemberService;
 import org.sopt.makers.internal.service.ProjectService;
@@ -50,6 +51,8 @@ public class InternalOpenApiController {
     private final InternalApiService internalApiService;
     private final MemberService memberService;
     private final MemberMapper memberMapper;
+
+    private final CoffeeChatService coffeeChatService;
     private final CoffeeChatResponseMapper coffeeChatResponseMapper;
 
     private final ProjectService projectService;
@@ -328,7 +331,7 @@ public class InternalOpenApiController {
     @Operation(summary = "커피챗 오픈 유저 리스트 조회 API")
     @GetMapping("/members/coffeechat")
     public ResponseEntity<List<InternalCoffeeChatMemberResponse>> getCoffeeChatActivateMembers() {
-        List<InternalCoffeeChatMemberDto> members = memberService.getCoffeeChatActivateMembers();
+        List<InternalCoffeeChatMemberDto> members = coffeeChatService.getCoffeeChatActivateMembers();
         List<InternalCoffeeChatMemberResponse> response = coffeeChatResponseMapper.toInternalCoffeeChatMemberResponse(members);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }

--- a/src/main/java/org/sopt/makers/internal/controller/InternalOpenApiController.java
+++ b/src/main/java/org/sopt/makers/internal/controller/InternalOpenApiController.java
@@ -7,12 +7,16 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.sopt.makers.internal.community.service.CommunityPostService;
 import org.sopt.makers.internal.config.AuthConfig;
 import org.sopt.makers.internal.domain.*;
+import org.sopt.makers.internal.dto.community.InternalCommunityPost;
+import org.sopt.makers.internal.dto.community.PostCategoryDao;
 import org.sopt.makers.internal.dto.internal.*;
 import org.sopt.makers.internal.dto.member.MemberProfileSpecificResponse;
 import org.sopt.makers.internal.dto.project.ProjectLinkDao;
 import org.sopt.makers.internal.exception.ClientBadRequestException;
+import org.sopt.makers.internal.mapper.CommunityResponseMapper;
 import org.sopt.makers.internal.mapper.MemberMapper;
 import org.sopt.makers.internal.mapper.ProjectResponseMapper;
 import org.sopt.makers.internal.service.InternalApiService;
@@ -42,11 +46,13 @@ public class InternalOpenApiController {
     private final MemberService memberService;
     private final ProjectResponseMapper projectMapper;
     private final MemberMapper memberMapper;
+    private final CommunityResponseMapper communityMapper;
 
     private final AuthConfig authConfig;
     private final List<String> organizerPartName = List.of(
             "운영 팀장", "미디어 팀장", "총무", "회장", "부회장", "웹 파트장", "기획 파트장",
             "서버 파트장", "디자인 파트장", "안드로이드 파트장", "iOS 파트장", "메이커스 리드");
+    private final CommunityPostService communityPostService;
 
     @Operation(summary = "Project id로 조회 API")
     @GetMapping("/projects/{id}")
@@ -280,5 +286,13 @@ public class InternalOpenApiController {
             response.careers().add(0, currentCareer);
             response.careers().remove(index+1);
         }
+    }
+
+    @Operation(summary = "최근 Community Post 조회 API")
+    @GetMapping("/community/post/recent")
+    public ResponseEntity<InternalCommunityPost> getRecentPost () {
+        PostCategoryDao recentPost = communityPostService.getRecentPost();
+        InternalCommunityPost response = communityMapper.toInternalCommunityPostResponse(recentPost);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/src/main/java/org/sopt/makers/internal/controller/InternalOpenApiController.java
+++ b/src/main/java/org/sopt/makers/internal/controller/InternalOpenApiController.java
@@ -312,14 +312,14 @@ public class InternalOpenApiController {
     @Operation(
             summary = "최근 Community Post 조회 API",
             description= """
-                    요청 category별 가장 최근의 게시물을 반환하는 API입니다.
+                    요청 category별 가장 최근의 게시물을 반환하는 API입니다. (default는 전체 중 최근 게시물을 반환)
                     
                     [대분류] 전체, 자유, 파트, SOPT 활동, 취업/진로, 홍보 \n
                     * 각 대분류의 소분류로도 조회 가능합니다. 
             """)
     @GetMapping("/community/post/recent")
     public ResponseEntity<InternalCommunityPost> getRecentPostByCategory (
-            @RequestParam String category
+            @RequestParam(required = false) String category
     ) {
         PostCategoryDao recentPost = communityPostService.getRecentPostByCategory(category);
         InternalCommunityPost response = communityMapper.toInternalCommunityPostResponse(recentPost);

--- a/src/main/java/org/sopt/makers/internal/controller/InternalOpenApiController.java
+++ b/src/main/java/org/sopt/makers/internal/controller/InternalOpenApiController.java
@@ -317,10 +317,10 @@ public class InternalOpenApiController {
                     * 각 대분류의 소분류로도 조회 가능합니다. 
             """)
     @GetMapping("/community/post/{category}/recent")
-    public ResponseEntity<InternalCommunityPost> getRecentPost (
+    public ResponseEntity<InternalCommunityPost> getRecentPostByCategory (
             @RequestParam String category
     ) {
-        PostCategoryDao recentPost = communityPostService.getRecentPost(category);
+        PostCategoryDao recentPost = communityPostService.getRecentPostByCategory(category);
         InternalCommunityPost response = communityMapper.toInternalCommunityPostResponse(recentPost);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }

--- a/src/main/java/org/sopt/makers/internal/controller/InternalOpenApiController.java
+++ b/src/main/java/org/sopt/makers/internal/controller/InternalOpenApiController.java
@@ -158,7 +158,7 @@ public class InternalOpenApiController {
     @Operation(summary = "회원 프로필 및 활동 정보 조회 API")
     @GetMapping("members/{memberId}/project")
     public ResponseEntity<InternalMemberProjectResponse> getMemberProject(
-            @RequestParam Long memberId
+            @PathVariable Long memberId
     ) {
         Member member = memberService.getMemberById(memberId);
         int count = projectService.getProjectCountByMemberId(memberId);
@@ -317,7 +317,7 @@ public class InternalOpenApiController {
                     [대분류] 전체, 자유, 파트, SOPT 활동, 취업/진로, 홍보 \n
                     * 각 대분류의 소분류로도 조회 가능합니다. 
             """)
-    @GetMapping("/community/post/{category}/recent")
+    @GetMapping("/community/post/recent")
     public ResponseEntity<InternalCommunityPost> getRecentPostByCategory (
             @RequestParam String category
     ) {

--- a/src/main/java/org/sopt/makers/internal/controller/InternalOpenApiController.java
+++ b/src/main/java/org/sopt/makers/internal/controller/InternalOpenApiController.java
@@ -19,6 +19,9 @@ import org.sopt.makers.internal.exception.ClientBadRequestException;
 import org.sopt.makers.internal.mapper.CommunityResponseMapper;
 import org.sopt.makers.internal.mapper.MemberMapper;
 import org.sopt.makers.internal.mapper.ProjectResponseMapper;
+import org.sopt.makers.internal.member.controller.coffeechat.dto.response.InternalCoffeeChatMemberResponse;
+import org.sopt.makers.internal.member.mapper.coffeechat.CoffeeChatResponseMapper;
+import org.sopt.makers.internal.member.repository.coffeechat.dto.InternalCoffeeChatMemberDto;
 import org.sopt.makers.internal.service.InternalApiService;
 import org.sopt.makers.internal.service.MemberService;
 import org.springframework.http.HttpStatus;
@@ -53,6 +56,7 @@ public class InternalOpenApiController {
             "운영 팀장", "미디어 팀장", "총무", "회장", "부회장", "웹 파트장", "기획 파트장",
             "서버 파트장", "디자인 파트장", "안드로이드 파트장", "iOS 파트장", "메이커스 리드");
     private final CommunityPostService communityPostService;
+    private final CoffeeChatResponseMapper coffeeChatResponseMapper;
 
     @Operation(summary = "Project id로 조회 API")
     @GetMapping("/projects/{id}")
@@ -293,6 +297,14 @@ public class InternalOpenApiController {
     public ResponseEntity<InternalCommunityPost> getRecentPost () {
         PostCategoryDao recentPost = communityPostService.getRecentPost();
         InternalCommunityPost response = communityMapper.toInternalCommunityPostResponse(recentPost);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @Operation(summary = "커피챗 오픈 유저 리스트 조회 API")
+    @GetMapping("/members/coffeechat")
+    public ResponseEntity<List<InternalCoffeeChatMemberResponse>> getCoffeeChatActivateMembers() {
+        List<InternalCoffeeChatMemberDto> members = memberService.getCoffeeChatActivateMembers();
+        List<InternalCoffeeChatMemberResponse> response = coffeeChatResponseMapper.toInternalCoffeeChatMemberResponse(members);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/src/main/java/org/sopt/makers/internal/controller/InternalOpenApiController.java
+++ b/src/main/java/org/sopt/makers/internal/controller/InternalOpenApiController.java
@@ -20,11 +20,12 @@ import org.sopt.makers.internal.mapper.CommunityResponseMapper;
 import org.sopt.makers.internal.mapper.MemberMapper;
 import org.sopt.makers.internal.mapper.ProjectResponseMapper;
 import org.sopt.makers.internal.member.controller.coffeechat.dto.response.InternalCoffeeChatMemberResponse;
-import org.sopt.makers.internal.member.controller.dto.response.InternalMemberInfoResponse;
+import org.sopt.makers.internal.dto.internal.InternalMemberProjectResponse;
 import org.sopt.makers.internal.member.mapper.coffeechat.CoffeeChatResponseMapper;
 import org.sopt.makers.internal.member.repository.coffeechat.dto.InternalCoffeeChatMemberDto;
 import org.sopt.makers.internal.service.InternalApiService;
 import org.sopt.makers.internal.service.MemberService;
+import org.sopt.makers.internal.service.ProjectService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -48,16 +49,19 @@ public class InternalOpenApiController {
 
     private final InternalApiService internalApiService;
     private final MemberService memberService;
-    private final ProjectResponseMapper projectMapper;
     private final MemberMapper memberMapper;
+    private final CoffeeChatResponseMapper coffeeChatResponseMapper;
+
+    private final ProjectService projectService;
+    private final ProjectResponseMapper projectMapper;
+
+    private final CommunityPostService communityPostService;
     private final CommunityResponseMapper communityMapper;
 
     private final AuthConfig authConfig;
     private final List<String> organizerPartName = List.of(
             "운영 팀장", "미디어 팀장", "총무", "회장", "부회장", "웹 파트장", "기획 파트장",
             "서버 파트장", "디자인 파트장", "안드로이드 파트장", "iOS 파트장", "메이커스 리드");
-    private final CommunityPostService communityPostService;
-    private final CoffeeChatResponseMapper coffeeChatResponseMapper;
 
     @Operation(summary = "Project id로 조회 API")
     @GetMapping("/projects/{id}")
@@ -152,11 +156,13 @@ public class InternalOpenApiController {
 
     @Operation(summary = "회원 프로필 및 활동 정보 조회 API")
     @GetMapping("members/{memberId}/project")
-    public ResponseEntity<InternalMemberInfoResponse> getMemberProject(
+    public ResponseEntity<InternalMemberProjectResponse> getMemberProject(
             @RequestParam Long memberId
     ) {
-        Member member = memberService.getMemberProfileProjects(memberId);
-
+        Member member = memberService.getMemberById(memberId);
+        int count = projectService.getProjectCountByMemberId(memberId);
+        InternalMemberProjectResponse response = projectMapper.toInternalMemberProjectResponse(member,count);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
     @Operation(

--- a/src/main/java/org/sopt/makers/internal/controller/InternalOpenApiController.java
+++ b/src/main/java/org/sopt/makers/internal/controller/InternalOpenApiController.java
@@ -20,6 +20,7 @@ import org.sopt.makers.internal.mapper.CommunityResponseMapper;
 import org.sopt.makers.internal.mapper.MemberMapper;
 import org.sopt.makers.internal.mapper.ProjectResponseMapper;
 import org.sopt.makers.internal.member.controller.coffeechat.dto.response.InternalCoffeeChatMemberResponse;
+import org.sopt.makers.internal.member.controller.dto.response.InternalMemberInfoResponse;
 import org.sopt.makers.internal.member.mapper.coffeechat.CoffeeChatResponseMapper;
 import org.sopt.makers.internal.member.repository.coffeechat.dto.InternalCoffeeChatMemberDto;
 import org.sopt.makers.internal.service.InternalApiService;
@@ -147,6 +148,15 @@ public class InternalOpenApiController {
             request.getValueByKey(SearchContent.MBTI));
         val response = new InternalRecommendMemberListResponse(memberIds);
         return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @Operation(summary = "회원 프로필 및 활동 정보 조회 API")
+    @GetMapping("members/{memberId}/project")
+    public ResponseEntity<InternalMemberInfoResponse> getMemberProject(
+            @RequestParam Long memberId
+    ) {
+        Member member = memberService.getMemberProfileProjects(memberId);
+
     }
 
     @Operation(
@@ -292,10 +302,19 @@ public class InternalOpenApiController {
         }
     }
 
-    @Operation(summary = "최근 Community Post 조회 API")
-    @GetMapping("/community/post/recent")
-    public ResponseEntity<InternalCommunityPost> getRecentPost () {
-        PostCategoryDao recentPost = communityPostService.getRecentPost();
+    @Operation(
+            summary = "최근 Community Post 조회 API",
+            description= """
+                    요청 category별 가장 최근의 게시물을 반환하는 API입니다.
+                    
+                    [대분류] 전체, 자유, 파트, SOPT 활동, 취업/진로, 홍보 \n
+                    * 각 대분류의 소분류로도 조회 가능합니다. 
+            """)
+    @GetMapping("/community/post/{category}/recent")
+    public ResponseEntity<InternalCommunityPost> getRecentPost (
+            @RequestParam String category
+    ) {
+        PostCategoryDao recentPost = communityPostService.getRecentPost(category);
         InternalCommunityPost response = communityMapper.toInternalCommunityPostResponse(recentPost);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }

--- a/src/main/java/org/sopt/makers/internal/controller/InternalOpenApiController.java
+++ b/src/main/java/org/sopt/makers/internal/controller/InternalOpenApiController.java
@@ -23,7 +23,6 @@ import org.sopt.makers.internal.member.controller.coffeechat.dto.response.Intern
 import org.sopt.makers.internal.dto.internal.InternalMemberProjectResponse;
 import org.sopt.makers.internal.member.mapper.coffeechat.CoffeeChatResponseMapper;
 import org.sopt.makers.internal.member.repository.coffeechat.dto.InternalCoffeeChatMemberDto;
-import org.sopt.makers.internal.member.service.coffeechat.CoffeeChatService;
 import org.sopt.makers.internal.service.InternalApiService;
 import org.sopt.makers.internal.service.MemberService;
 import org.sopt.makers.internal.service.ProjectService;
@@ -52,7 +51,6 @@ public class InternalOpenApiController {
     private final MemberService memberService;
     private final MemberMapper memberMapper;
 
-    private final CoffeeChatService coffeeChatService;
     private final CoffeeChatResponseMapper coffeeChatResponseMapper;
 
     private final ProjectService projectService;
@@ -331,7 +329,7 @@ public class InternalOpenApiController {
     @Operation(summary = "커피챗 오픈 유저 리스트 조회 API")
     @GetMapping("/members/coffeechat")
     public ResponseEntity<List<InternalCoffeeChatMemberResponse>> getCoffeeChatActivateMembers() {
-        List<InternalCoffeeChatMemberDto> members = coffeeChatService.getCoffeeChatActivateMembers();
+        List<InternalCoffeeChatMemberDto> members = memberService.getAllMemberByCoffeeChatActivate();
         List<InternalCoffeeChatMemberResponse> response = coffeeChatResponseMapper.toInternalCoffeeChatMemberResponse(members);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }

--- a/src/main/java/org/sopt/makers/internal/dto/community/InternalCommunityPost.java
+++ b/src/main/java/org/sopt/makers/internal/dto/community/InternalCommunityPost.java
@@ -1,0 +1,9 @@
+package org.sopt.makers.internal.dto.community;
+
+public record InternalCommunityPost(
+		Long id,
+		String title,
+		String category,
+		String[] images,
+		Boolean isHotPost
+) { }

--- a/src/main/java/org/sopt/makers/internal/dto/community/PostCategoryDao.java
+++ b/src/main/java/org/sopt/makers/internal/dto/community/PostCategoryDao.java
@@ -1,0 +1,13 @@
+package org.sopt.makers.internal.dto.community;
+
+import com.querydsl.core.annotations.QueryProjection;
+import org.sopt.makers.internal.community.domain.category.Category;
+import org.sopt.makers.internal.domain.community.CommunityPost;
+
+public record PostCategoryDao(
+		CommunityPost post,
+		Category category
+) {
+	@QueryProjection
+	public PostCategoryDao {}
+}

--- a/src/main/java/org/sopt/makers/internal/dto/internal/InternalMemberProjectResponse.java
+++ b/src/main/java/org/sopt/makers/internal/dto/internal/InternalMemberProjectResponse.java
@@ -1,0 +1,8 @@
+package org.sopt.makers.internal.dto.internal;
+
+public record InternalMemberProjectResponse(
+		Long id,
+		String profileImage,
+		Integer soptProjectCount
+) {
+}

--- a/src/main/java/org/sopt/makers/internal/mapper/CommunityResponseMapper.java
+++ b/src/main/java/org/sopt/makers/internal/mapper/CommunityResponseMapper.java
@@ -90,4 +90,8 @@ public class CommunityResponseMapper {
     public AnonymousProfileVo toAnonymousCommentProfileVo(AnonymousCommentProfile profile) {
         return new AnonymousProfileVo(profile.getNickname().getNickname(), profile.getProfileImg().getImageUrl());
     }
+
+    public InternalCommunityPost toInternalCommunityPostResponse(PostCategoryDao dao) {
+        return new InternalCommunityPost(dao.post().getId(), dao.post().getTitle(), dao.category().getName(), dao.post().getImages(), dao.post().getIsHot());
+    }
 }

--- a/src/main/java/org/sopt/makers/internal/mapper/ProjectResponseMapper.java
+++ b/src/main/java/org/sopt/makers/internal/mapper/ProjectResponseMapper.java
@@ -1,7 +1,9 @@
 package org.sopt.makers.internal.mapper;
 
 import lombok.val;
+import org.sopt.makers.internal.domain.Member;
 import org.sopt.makers.internal.domain.Project;
+import org.sopt.makers.internal.dto.internal.InternalMemberProjectResponse;
 import org.sopt.makers.internal.dto.internal.InternalProjectDetailResponse;
 import org.sopt.makers.internal.dto.internal.InternalProjectResponse;
 import org.sopt.makers.internal.dto.project.ProjectDetailResponse;
@@ -146,6 +148,10 @@ public class ProjectResponseMapper {
 
     public InternalProjectDetailResponse.ProjectLinkResponse toInternalProjectDetailLinkResponse (ProjectLinkDao project) {
         return new InternalProjectDetailResponse.ProjectLinkResponse(project.linkId(), project.linkTitle(), project.linkUrl());
+    }
+
+    public InternalMemberProjectResponse toInternalMemberProjectResponse (Member member, int count) {
+        return new InternalMemberProjectResponse(member.getId(), member.getProfileImage(), count);
     }
 
     private String truncateString(String str) {

--- a/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/dto/response/InternalCoffeeChatMemberResponse.java
+++ b/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/dto/response/InternalCoffeeChatMemberResponse.java
@@ -1,0 +1,11 @@
+package org.sopt.makers.internal.member.controller.coffeechat.dto.response;
+
+import java.util.List;
+
+public record InternalCoffeeChatMemberResponse(
+		Long id,
+		List<String> parts,
+		String name,
+		String profileImageUrl
+) {
+}

--- a/src/main/java/org/sopt/makers/internal/member/controller/dto/response/InternalMemberInfoResponse.java
+++ b/src/main/java/org/sopt/makers/internal/member/controller/dto/response/InternalMemberInfoResponse.java
@@ -1,0 +1,8 @@
+package org.sopt.makers.internal.member.controller.dto.response;
+
+public record InternalMemberInfoResponse(
+		Long id,
+		String profileImage,
+		Integer soptProjectCount
+) {
+}

--- a/src/main/java/org/sopt/makers/internal/member/controller/dto/response/InternalMemberInfoResponse.java
+++ b/src/main/java/org/sopt/makers/internal/member/controller/dto/response/InternalMemberInfoResponse.java
@@ -1,8 +1,0 @@
-package org.sopt.makers.internal.member.controller.dto.response;
-
-public record InternalMemberInfoResponse(
-		Long id,
-		String profileImage,
-		Integer soptProjectCount
-) {
-}

--- a/src/main/java/org/sopt/makers/internal/member/mapper/coffeechat/CoffeeChatResponseMapper.java
+++ b/src/main/java/org/sopt/makers/internal/member/mapper/coffeechat/CoffeeChatResponseMapper.java
@@ -6,10 +6,12 @@ import org.sopt.makers.internal.domain.MemberCareer;
 import org.sopt.makers.internal.exception.BusinessLogicException;
 import org.sopt.makers.internal.member.controller.coffeechat.dto.response.CoffeeChatDetailResponse;
 import org.sopt.makers.internal.member.controller.coffeechat.dto.response.CoffeeChatResponse.CoffeeChatVo;
+import org.sopt.makers.internal.member.controller.coffeechat.dto.response.InternalCoffeeChatMemberResponse;
 import org.sopt.makers.internal.member.domain.coffeechat.CoffeeChat;
 import org.sopt.makers.internal.member.domain.coffeechat.CoffeeChatSection;
 import org.sopt.makers.internal.member.domain.coffeechat.CoffeeChatTopicType;
 import org.sopt.makers.internal.member.repository.coffeechat.dto.CoffeeChatInfoDto;
+import org.sopt.makers.internal.member.repository.coffeechat.dto.InternalCoffeeChatMemberDto;
 import org.sopt.makers.internal.member.repository.coffeechat.dto.RecentCoffeeChatInfoDto;
 import org.springframework.stereotype.Component;
 
@@ -18,25 +20,6 @@ import java.util.List;
 @Component
 @RequiredArgsConstructor
 public class CoffeeChatResponseMapper {
-
-//    public List<CoffeeChatVo> toCoffeeChatResponse(List<CoffeeChat> coffeeChatList, List<Member> memberList, List<MemberCareer> memberCareerList) {
-//        return IntStream.range(0, coffeeChatList.size())
-//                .mapToObj(index -> new CoffeeChatVo(
-//                        memberList.get(index).getId(),
-//                        memberList.get(index).getName(),
-//                        memberList.get(index).getProfileImage(),
-//                        Optional.ofNullable(memberCareerList.get(index))
-//                                .map(MemberCareer::getCompanyName)
-//                                .orElse(memberList.get(index).getUniversity()),
-//                        Optional.ofNullable(memberCareerList.get(index))
-//                                .map(MemberCareer::getTitle)
-//                                .orElse(memberList.get(index).getSkill()),
-//                        coffeeChatList.get(index).getCoffeeChatBio(),
-//                        coffeeChatList.get(index).getCoffeeChatTopicType(),
-//                        coffeeChatList.get(index).getSection()
-//                ))
-//                .collect(Collectors.toList());
-//    }
 
     public CoffeeChatDetailResponse toCoffeeChatDetailResponse(CoffeeChat coffeeChat, Member member, MemberCareer memberCareer, Boolean isMine) {
 
@@ -96,5 +79,13 @@ public class CoffeeChatResponseMapper {
                 coffeeChatInfo.isMine(),
                 coffeeChatInfo.isBlind()
         );
+    }
+
+    public List<InternalCoffeeChatMemberResponse> toInternalCoffeeChatMemberResponse(List<InternalCoffeeChatMemberDto> coffeeChatMembers) {
+        return coffeeChatMembers.stream().map(
+                member -> new InternalCoffeeChatMemberResponse(
+                    member.id(), member.parts(), member.name(), member.profileImage()
+                )
+        ).toList();
     }
 }

--- a/src/main/java/org/sopt/makers/internal/member/repository/coffeechat/dto/InternalCoffeeChatMemberDto.java
+++ b/src/main/java/org/sopt/makers/internal/member/repository/coffeechat/dto/InternalCoffeeChatMemberDto.java
@@ -1,0 +1,18 @@
+package org.sopt.makers.internal.member.repository.coffeechat.dto;
+
+import org.sopt.makers.internal.domain.Member;
+
+import java.util.List;
+
+public record InternalCoffeeChatMemberDto(
+		Long id,
+		List<String> parts,
+		String name,
+		String profileImage
+) {
+	public static InternalCoffeeChatMemberDto of(Member member, List<String> parts) {
+		return new InternalCoffeeChatMemberDto(
+				member.getId(), parts, member.getName(), member.getProfileImage()
+		);
+	}
+}

--- a/src/main/java/org/sopt/makers/internal/member/repository/coffeechat/dto/InternalCoffeeChatMemberDto.java
+++ b/src/main/java/org/sopt/makers/internal/member/repository/coffeechat/dto/InternalCoffeeChatMemberDto.java
@@ -6,13 +6,13 @@ import java.util.List;
 
 public record InternalCoffeeChatMemberDto(
 		Long id,
-		List<String> parts,
 		String name,
+		List<String> parts,
 		String profileImage
 ) {
 	public static InternalCoffeeChatMemberDto of(Member member, List<String> parts) {
 		return new InternalCoffeeChatMemberDto(
-				member.getId(), parts, member.getName(), member.getProfileImage()
+				member.getId(), member.getName(), parts, member.getProfileImage()
 		);
 	}
 }

--- a/src/main/java/org/sopt/makers/internal/member/service/MemberRetriever.java
+++ b/src/main/java/org/sopt/makers/internal/member/service/MemberRetriever.java
@@ -3,6 +3,7 @@ package org.sopt.makers.internal.member.service;
 import lombok.RequiredArgsConstructor;
 import org.sopt.makers.internal.domain.Member;
 import org.sopt.makers.internal.exception.NotFoundDBEntityException;
+import org.sopt.makers.internal.repository.MemberProfileQueryRepository;
 import org.sopt.makers.internal.repository.MemberRepository;
 import org.sopt.makers.internal.member.repository.soptactivity.MemberSoptActivityRepository;
 import org.springframework.stereotype.Component;
@@ -14,6 +15,7 @@ import java.util.List;
 public class MemberRetriever {
 
     private final MemberRepository memberRepository;
+    private final MemberProfileQueryRepository memberProfileQueryRepository;;
     private final MemberSoptActivityRepository memberSoptActivityRepository;
 
     public Member findMemberById(Long memberId) {
@@ -32,5 +34,9 @@ public class MemberRetriever {
         return memberSoptActivityRepository.findAllByMemberId(memberId).stream()
                 .map(activity -> String.format("%d기 %s", activity.getGeneration(), activity.getPart()))
                 .toList();
+    }
+
+    public List<Member> findAllMembersByCoffeeChatActivate() {
+        return memberProfileQueryRepository.findAllMembersByCoffeeChatActivate();
     }
 }

--- a/src/main/java/org/sopt/makers/internal/member/service/coffeechat/CoffeeChatService.java
+++ b/src/main/java/org/sopt/makers/internal/member/service/coffeechat/CoffeeChatService.java
@@ -15,6 +15,7 @@ import org.sopt.makers.internal.member.controller.coffeechat.dto.request.CoffeeC
 import org.sopt.makers.internal.member.controller.coffeechat.dto.request.CoffeeChatOpenRequest;
 import org.sopt.makers.internal.member.mapper.coffeechat.CoffeeChatResponseMapper;
 import org.sopt.makers.internal.member.repository.coffeechat.dto.CoffeeChatInfoDto;
+import org.sopt.makers.internal.member.repository.coffeechat.dto.InternalCoffeeChatMemberDto;
 import org.sopt.makers.internal.member.repository.coffeechat.dto.RecentCoffeeChatInfoDto;
 import org.sopt.makers.internal.member.service.MemberRetriever;
 import org.sopt.makers.internal.member.service.career.MemberCareerRetriever;
@@ -87,6 +88,14 @@ public class CoffeeChatService {
         } catch (NotFoundDBEntityException ex) {
             return false;
         }
+    }
+
+    @Transactional(readOnly = true)
+    public List<InternalCoffeeChatMemberDto> getCoffeeChatActivateMembers() {
+        List<Member> members = memberRetriever.findAllMembersByCoffeeChatActivate();
+        return members.stream().map(member -> InternalCoffeeChatMemberDto.of(
+                member, memberRetriever.concatPartAndGeneration(member.getId())
+        )).toList();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/makers/internal/member/service/coffeechat/CoffeeChatService.java
+++ b/src/main/java/org/sopt/makers/internal/member/service/coffeechat/CoffeeChatService.java
@@ -91,14 +91,6 @@ public class CoffeeChatService {
     }
 
     @Transactional(readOnly = true)
-    public List<InternalCoffeeChatMemberDto> getCoffeeChatActivateMembers() {
-        List<Member> members = memberRetriever.findAllMembersByCoffeeChatActivate();
-        return members.stream().map(member -> InternalCoffeeChatMemberDto.of(
-                member, memberRetriever.concatPartAndGeneration(member.getId())
-        )).toList();
-    }
-
-    @Transactional(readOnly = true)
     public Boolean isCoffeeChatExist (Long memberId) {
         Member member = memberRetriever.findMemberById(memberId);
         return coffeeChatRetriever.existsCoffeeChat(member);

--- a/src/main/java/org/sopt/makers/internal/repository/MemberProfileQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/repository/MemberProfileQueryRepository.java
@@ -369,8 +369,8 @@ public class MemberProfileQueryRepository {
 
         return queryFactory
                 .selectFrom(member)
-                .join(coffeeChat.member, member)
-                .where(coffeeChat.isCoffeeChatActivate.eq(true))
+                .innerJoin(coffeeChat).on(coffeeChat.member.eq(member))
+                .where(coffeeChat.isCoffeeChatActivate.isTrue())
                 .fetch();
     }
 }

--- a/src/main/java/org/sopt/makers/internal/repository/MemberProfileQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/repository/MemberProfileQueryRepository.java
@@ -16,6 +16,7 @@ import org.sopt.makers.internal.domain.QMemberSoptActivity;
 import org.sopt.makers.internal.domain.QProject;
 import org.sopt.makers.internal.dto.member.MemberProfileProjectDao;
 import org.sopt.makers.internal.dto.member.QMemberProfileProjectDao;
+import org.sopt.makers.internal.member.domain.coffeechat.QCoffeeChat;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
@@ -360,5 +361,16 @@ public class MemberProfileQueryRepository {
                 .groupBy(member.id)
                 .fetch()
                 .size();
+    }
+
+    public List<Member> findAllMembersByCoffeeChatActivate() {
+        QMember member = QMember.member;
+        QCoffeeChat coffeeChat = QCoffeeChat.coffeeChat;
+
+        return queryFactory
+                .selectFrom(member)
+                .join(coffeeChat.member, member)
+                .where(coffeeChat.isCoffeeChatActivate.eq(true))
+                .fetch();
     }
 }

--- a/src/main/java/org/sopt/makers/internal/repository/ProjectQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/repository/ProjectQueryRepository.java
@@ -147,4 +147,20 @@ public class ProjectQueryRepository {
                 .fetch()
                 .size();
     }
+
+    public int countProjectsExcludeSopkathon(Long memberId) {
+        QMember member = QMember.member;
+        QProject project = QProject.project;
+        QMemberProjectRelation relation = QMemberProjectRelation.memberProjectRelation;
+
+        return queryFactory.select(project.id)
+                .from(project)
+                .innerJoin(relation).on(relation.projectId.eq(project.id))
+                .innerJoin(member).on(relation.userId.eq(member.id))
+                .where(
+                    member.id.eq(memberId)
+                    .and(project.category.ne("SOPKATHON")))
+                .fetch()
+                .size();
+    }
 }

--- a/src/main/java/org/sopt/makers/internal/repository/community/CommunityPostRepository.java
+++ b/src/main/java/org/sopt/makers/internal/repository/community/CommunityPostRepository.java
@@ -4,10 +4,11 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import org.sopt.makers.internal.community.repository.CommunityPostRepositoryCustom;
 import org.sopt.makers.internal.domain.community.CommunityPost;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CommunityPostRepository extends JpaRepository<CommunityPost, Long> {
+public interface CommunityPostRepository extends JpaRepository<CommunityPost, Long>, CommunityPostRepositoryCustom {
     Optional<CommunityPost> findById(Long id);
 
     List<CommunityPost> findAllByCreatedAtBetween(LocalDateTime start, LocalDateTime end);

--- a/src/main/java/org/sopt/makers/internal/repository/community/CommunityQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/repository/community/CommunityQueryRepository.java
@@ -136,7 +136,7 @@ public class CommunityQueryRepository {
             .fetchFirst();
     }
 
-    public PostCategoryDao findRecentPost() {
+    public PostCategoryDao findRecentPost(String categoryName) {
         QCommunityPost posts = QCommunityPost.communityPost;
         QCategory category = QCategory.category;
 
@@ -144,6 +144,7 @@ public class CommunityQueryRepository {
                 .select(new QPostCategoryDao(posts, category))
                 .from(posts)
                 .innerJoin(category).on(posts.categoryId.eq(category.id))
+                .where(category.name.eq(categoryName))
                 .orderBy(posts.id.desc())
                 .fetchFirst();
     }

--- a/src/main/java/org/sopt/makers/internal/repository/community/CommunityQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/repository/community/CommunityQueryRepository.java
@@ -9,10 +9,7 @@ import org.sopt.makers.internal.community.domain.category.QCategory;
 import org.sopt.makers.internal.domain.*;
 import org.sopt.makers.internal.domain.community.*;
 import org.sopt.makers.internal.domain.member.QMemberBlock;
-import org.sopt.makers.internal.dto.community.CategoryPostMemberDao;
-import org.sopt.makers.internal.dto.community.CommentDao;
-import org.sopt.makers.internal.dto.community.QCategoryPostMemberDao;
-import org.sopt.makers.internal.dto.community.QCommentDao;
+import org.sopt.makers.internal.dto.community.*;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -137,6 +134,18 @@ public class CommunityQueryRepository {
             .where(post.isHot.eq(true))
             .orderBy(post.id.desc())
             .fetchFirst();
+    }
+
+    public PostCategoryDao findRecentPost() {
+        QCommunityPost posts = QCommunityPost.communityPost;
+        QCategory category = QCategory.category;
+
+        return queryFactory
+                .select(new QPostCategoryDao(posts, category))
+                .from(posts)
+                .innerJoin(category).on(posts.categoryId.eq(category.id))
+                .orderBy(posts.id.desc())
+                .fetchFirst();
     }
 
     public void updateHitsByPostId(List<Long> postIdList) {

--- a/src/main/java/org/sopt/makers/internal/repository/community/CommunityQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/repository/community/CommunityQueryRepository.java
@@ -136,19 +136,6 @@ public class CommunityQueryRepository {
             .fetchFirst();
     }
 
-    public PostCategoryDao findRecentPostByCategory(String categoryName) {
-        QCommunityPost posts = QCommunityPost.communityPost;
-        QCategory category = QCategory.category;
-
-        return queryFactory
-                .select(new QPostCategoryDao(posts, category))
-                .from(posts)
-                .innerJoin(category).on(posts.categoryId.eq(category.id))
-                .where(category.name.eq(categoryName))
-                .orderBy(posts.id.desc())
-                .fetchFirst();
-    }
-
     public void updateHitsByPostId(List<Long> postIdList) {
         val post = QCommunityPost.communityPost;
 

--- a/src/main/java/org/sopt/makers/internal/repository/community/CommunityQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/repository/community/CommunityQueryRepository.java
@@ -136,7 +136,7 @@ public class CommunityQueryRepository {
             .fetchFirst();
     }
 
-    public PostCategoryDao findRecentPost(String categoryName) {
+    public PostCategoryDao findRecentPostByCategory(String categoryName) {
         QCommunityPost posts = QCommunityPost.communityPost;
         QCategory category = QCategory.category;
 

--- a/src/main/java/org/sopt/makers/internal/service/MemberService.java
+++ b/src/main/java/org/sopt/makers/internal/service/MemberService.java
@@ -210,6 +210,14 @@ public class MemberService {
         else return team;
     }
 
+    @Transactional(readOnly = true)
+    public List<InternalCoffeeChatMemberDto> getAllMemberByCoffeeChatActivate() {
+        List<Member> members = memberRetriever.findAllMembersByCoffeeChatActivate();
+        return members.stream().map(member -> InternalCoffeeChatMemberDto.of(
+                member, memberRetriever.concatPartAndGeneration(member.getId())
+        )).toList();
+    }
+
     @Transactional
     public Member saveMemberProfile(Long id, MemberProfileSaveRequest request) {
         val member = memberRepository.findById(id).orElseThrow(() -> new NotFoundDBEntityException("Member"));

--- a/src/main/java/org/sopt/makers/internal/service/MemberService.java
+++ b/src/main/java/org/sopt/makers/internal/service/MemberService.java
@@ -28,6 +28,7 @@ import org.sopt.makers.internal.mapper.MemberMapper;
 import org.sopt.makers.internal.member.controller.dto.response.MemberPropertiesResponse;
 import org.sopt.makers.internal.member.mapper.MemberResponseMapper;
 import org.sopt.makers.internal.member.repository.career.MemberCareerRepository;
+import org.sopt.makers.internal.member.repository.coffeechat.dto.InternalCoffeeChatMemberDto;
 import org.sopt.makers.internal.member.repository.soptactivity.MemberSoptActivityRepository;
 import org.sopt.makers.internal.member.service.MemberRetriever;
 import org.sopt.makers.internal.member.service.career.MemberCareerRetriever;
@@ -207,6 +208,14 @@ public class MemberService {
         val isNullResult = teamIsEmpty.or(teamIsNullString).test(team);
         if (isNullResult) return null;
         else return team;
+    }
+
+    @Transactional(readOnly = true)
+    public List<InternalCoffeeChatMemberDto> getCoffeeChatActivateMembers() {
+        List<Member> members = memberProfileQueryRepository.findAllMembersByCoffeeChatActivate();
+        return members.stream().map(member -> InternalCoffeeChatMemberDto.of(
+                member, memberRetriever.concatPartAndGeneration(member.getId())
+        )).toList();
     }
 
     @Transactional

--- a/src/main/java/org/sopt/makers/internal/service/MemberService.java
+++ b/src/main/java/org/sopt/makers/internal/service/MemberService.java
@@ -210,14 +210,6 @@ public class MemberService {
         else return team;
     }
 
-    @Transactional(readOnly = true)
-    public List<InternalCoffeeChatMemberDto> getCoffeeChatActivateMembers() {
-        List<Member> members = memberProfileQueryRepository.findAllMembersByCoffeeChatActivate();
-        return members.stream().map(member -> InternalCoffeeChatMemberDto.of(
-                member, memberRetriever.concatPartAndGeneration(member.getId())
-        )).toList();
-    }
-
     @Transactional
     public Member saveMemberProfile(Long id, MemberProfileSaveRequest request) {
         val member = memberRepository.findById(id).orElseThrow(() -> new NotFoundDBEntityException("Member"));

--- a/src/main/java/org/sopt/makers/internal/service/ProjectService.java
+++ b/src/main/java/org/sopt/makers/internal/service/ProjectService.java
@@ -186,6 +186,11 @@ public class ProjectService {
     }
 
     @Transactional(readOnly = true)
+    public int getProjectCountByMemberId(Long memberId) {
+        return projectQueryRepository.countProjectsExcludeSopkathon(memberId);
+    }
+
+    @Transactional(readOnly = true)
     public Long getAllCount() {
         return projectRepository.count();
     }


### PR DESCRIPTION
## 🐬 요약
앱팀에서 요청한 internal api를 구현했습니다.
- [관련 스레드](https://sopt-makers.slack.com/archives/C042T81PW80/p1730802286241589)

작업하면서 느낀 건데, 타 팀의 internal api 요청에 의해 중복 코드를 남발하는 구조인 것 같습니다.
최대한 중복 로직을 줄이고, 같은 엔티티에 대해 여러 개의 mapper, dto를 만들지 않도록 구조 리팩토링이 우선일 것 같고 타 팀의 요청자와 작업자 간의 요구사항 싱크를 위해 체계화된 워크플로우가 있으면 좋겠다는 생각이 듭니다 

코드는 좀 급하게 짜느라.. 맘껏 리뷰해주십쇼 ..!

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [x] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
PR에 담긴 작업 내용을 작성해주세요!

- category별 최근 커뮤니티 게시글 조회 API
- 커피챗 활성 유저 리스트 조회 API
- 회원 id로 프로젝트 정보 조회 API

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #548 
