### PR TITLE
[Chore] 특정 actuator endpoint 허용하도록 security config 설정 추가

### DIFF
--- a/src/main/java/org/sopt/makers/internal/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/makers/internal/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.sopt.makers.internal.controller.filter.JwtAuthenticationFilter;
 import org.sopt.makers.internal.controller.filter.JwtExceptionFilter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -23,6 +24,9 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtExceptionFilter jwtExceptionFilter;
 
+    @Value("${management.endpoints.web.base-path}")
+    private String actuatorEndpoint;
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http.antMatcher("/**")
@@ -34,7 +38,7 @@ public class SecurityConfig {
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                     .authorizeHttpRequests()
-                    .antMatchers("/v3/api-docs/**", "/swagger-ui.html", "/webjars/swagger-ui/**", "/swagger-ui/**", "/makers/**").permitAll()
+                    .antMatchers("/v3/api-docs/**", "/swagger-ui.html", "/webjars/swagger-ui/**", "/swagger-ui/**", "/makers/**", actuatorEndpoint+"/prometheus", actuatorEndpoint+"/metrics").permitAll()
                 .and()
                     .authorizeHttpRequests()
                         .antMatchers("/internal/api/v1/projects/**", "/internal/api/v1/members/**", "/internal/api/v1/sopticles/**", "/internal/api/v1/profile",

--- a/src/main/java/org/sopt/makers/internal/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/makers/internal/config/SecurityConfig.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.sopt.makers.internal.controller.filter.JwtAuthenticationFilter;
 import org.sopt.makers.internal.controller.filter.JwtExceptionFilter;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -23,12 +23,13 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtExceptionFilter jwtExceptionFilter;
+    private final WebEndpointProperties webEndpointProperties;
 
-    @Value("${management.endpoints.web.base-path}")
-    private String actuatorEndpoint;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        String actuatorEndpoint = webEndpointProperties.getBasePath();
+
         return http.antMatcher("/**")
                 .httpBasic().disable()
                 .formLogin().disable()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -100,7 +100,7 @@ push-notification:
   action: test
   x-api-key: test
   service: test
-  
+
 crew:
   server-url: test
 
@@ -112,8 +112,3 @@ gabia:
   sms-id: test
   api-key: test
   send-number: test
-
-management:
-  endpoints:
-    web:
-      base-path: test

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -112,3 +112,8 @@ gabia:
   sms-id: test
   api-key: test
   send-number: test
+
+management:
+  endpoints:
+    web:
+      base-path: test

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -115,5 +115,6 @@ gabia:
 
 management:
   endpoints:
+    enabled-by-default: false
     web:
       base-path: test

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -115,6 +115,5 @@ gabia:
 
 management:
   endpoints:
-    enabled-by-default: false
     web:
       base-path: test

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -109,3 +109,8 @@ gabia:
   sms-id: test
   api-key: test
   send-number: test
+
+management:
+  endpoints:
+    web:
+      base-path: test

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -109,8 +109,3 @@ gabia:
   sms-id: test
   api-key: test
   send-number: test
-
-management:
-  endpoints:
-    web:
-      base-path: test


### PR DESCRIPTION
## 🐬 요약
Actuator 활성화에 대한 보안 설정을 위해 application.yml에서 default endpoint를 변경하고, /prometheus와 /metrics만 선택적으로 전체 접근 허용하도록 Security Config에서 설정을 추가합니다.

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [ ] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [x] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
PR에 담긴 작업 내용을 작성해주세요!

- SecurityConfig에 모니터링 서버 관련 엔드포인트 접근 권한 변경
- 모니터링 서버에서 메트릭에 접근 가능하도록 허용하기 위함
- prod, dev application.yml에서 모니터링 서버 관련 설정 및 actuator endpoint 변경

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

related issue #453
