### PR TITLE
feat: 커피챗 메일 발송 가능하도록 수정

### DIFF
--- a/src/main/java/org/sopt/makers/internal/external/MessageSenderFactory.java
+++ b/src/main/java/org/sopt/makers/internal/external/MessageSenderFactory.java
@@ -1,9 +1,9 @@
 package org.sopt.makers.internal.external;
 
 import lombok.RequiredArgsConstructor;
+
 import org.sopt.makers.internal.external.email.EmailChatSender;
 import org.sopt.makers.internal.external.gabia.SmsChatSender;
-import org.sopt.makers.internal.member.domain.coffeechat.ChatCategory;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -13,10 +13,13 @@ public class MessageSenderFactory {
 	private final SmsChatSender smsChatSender;
 	private final EmailChatSender emailChatSender;
 
-	public MessageSender getSender(ChatCategory category) {
-		return switch (category) {
-			case COFFEE_CHAT -> smsChatSender;
-			case FRIENDSHIP, APPJAM_TEAM_BUILD, PROJECT_PROPOSAL, OTHER -> emailChatSender;
-		};
+	public MessageSender getSender(String senderEmail, String senderPhone) {
+		if (senderEmail != null) {
+			return emailChatSender;
+		}
+		if (senderPhone != null) {
+			return smsChatSender;
+		}
+		return null;
 	}
 }

--- a/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/dto/request/CoffeeChatRequest.java
+++ b/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/dto/request/CoffeeChatRequest.java
@@ -2,6 +2,8 @@ package org.sopt.makers.internal.member.controller.coffeechat.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+import org.sopt.makers.internal.exception.ClientBadRequestException;
 import org.sopt.makers.internal.member.domain.coffeechat.ChatCategory;
 
 import javax.validation.constraints.NotBlank;
@@ -28,4 +30,13 @@ public record CoffeeChatRequest(
 		@NotBlank(message = "수신 본문은 필수 입력 값입니다.")
 		@Size(max = 500, message = "본문은 500자를 초과할 수 없습니다.")
 		String content
-) {}
+) {
+	public CoffeeChatRequest {
+		if (senderEmail == null && senderPhone == null) {
+			throw new ClientBadRequestException("발신자 이메일 또는 전화번호 중 하나는 필수 입력 값입니다.");
+		}
+		if (senderEmail != null && senderPhone != null) {
+			throw new ClientBadRequestException("발신자 이메일과 전화번호는 모두 요청이 불가능합니다.");
+		}
+	}
+}

--- a/src/main/java/org/sopt/makers/internal/member/service/coffeechat/CoffeeChatService.java
+++ b/src/main/java/org/sopt/makers/internal/member/service/coffeechat/CoffeeChatService.java
@@ -48,7 +48,7 @@ public class CoffeeChatService {
 
         String replyInfo = getReplyInfo(request, sender);
 
-        MessageSender senderStrategy = messageSenderFactory.getSender(request.category());
+        MessageSender senderStrategy = messageSenderFactory.getSender(request.senderEmail(), request.senderPhone());
         senderStrategy.sendMessage(sender, receiver, request.content(), replyInfo, request.category());
 
         createHistoryByCategory(request, sender, receiver);


### PR DESCRIPTION
## 🐬 요약
쪽지 보내기 API에서 커피챗 카테고리에 대해서도 메일 발송이 가능하도록 sender 구현체 판단 조건을 수정합니다. 

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [x] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
- request validation 추가
- sender return 조건 수정


## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #569 
