### PR TITLE
[Fix]: 커피챗 자기소개 필드 옵셔널로 변경

### DIFF
--- a/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/dto/request/CoffeeChatDetailsRequest.java
+++ b/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/dto/request/CoffeeChatDetailsRequest.java
@@ -21,8 +21,7 @@ public record CoffeeChatDetailsRequest(
 			@Schema(required = true)
 			Career career,
 
-			@Schema(required = true)
-			@NotBlank(message = "자기소개는 필수 입력 값입니다.")
+			@Schema
 			@Size(max = 200, message = "자기소개는 200자를 초과할 수 없습니다.")
 			String introduction
 	) { }

--- a/src/main/java/org/sopt/makers/internal/member/domain/coffeechat/CoffeeChat.java
+++ b/src/main/java/org/sopt/makers/internal/member/domain/coffeechat/CoffeeChat.java
@@ -33,7 +33,7 @@ public class CoffeeChat extends AuditingTimeEntity {
     @Enumerated(EnumType.STRING)
     private Career career;
 
-    @Column(nullable = false, length = 200)
+    @Column(length = 200)
     private String introduction;
 
     @Convert(converter = CoffeeChatSectionConverter.class)


### PR DESCRIPTION
Related to: #572

## 🐬 요약
커피챗 자기소개 필드 옵셔널로 변경
dev, prod db에서 해당 필드 optional로 바꿔줘야할 것 같습니다!

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [x] 버그 수정
- [ ] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
PR에 담긴 작업 내용을 작성해주세요!

- 커피챗 자기소개 필드 옵셔널로 변경

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #572 
