### PR TITLE
Feature/#578 coffee chat

### DIFF
--- a/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/CoffeeChatController.java
+++ b/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/CoffeeChatController.java
@@ -140,7 +140,7 @@ public class CoffeeChatController {
     }
 
     @Operation(summary = "커피챗 리뷰 조회 API")
-    @GetMapping("/review")
+    @GetMapping("/reviews")
     public ResponseEntity<CoffeeChatReviewResponse> getCoffeeChatReview() {
 
         return ResponseEntity.status(HttpStatus.OK).body(new CoffeeChatReviewResponse(coffeeChatService.getRecentCoffeeChatReviews()));

--- a/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/CoffeeChatController.java
+++ b/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/CoffeeChatController.java
@@ -16,6 +16,7 @@ import org.sopt.makers.internal.member.controller.coffeechat.dto.response.Coffee
 import org.sopt.makers.internal.member.controller.coffeechat.dto.request.CoffeeChatDetailsRequest;
 import org.sopt.makers.internal.member.controller.coffeechat.dto.request.CoffeeChatOpenRequest;
 import org.sopt.makers.internal.member.controller.coffeechat.dto.request.CoffeeChatRequest;
+import org.sopt.makers.internal.member.controller.coffeechat.dto.response.CoffeeChatReviewResponse;
 import org.sopt.makers.internal.member.service.coffeechat.CoffeeChatService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -136,5 +137,12 @@ public class CoffeeChatController {
     ) {
         coffeeChatService.createCoffeeChatReview(memberDetails.getId(), request);
         return ResponseEntity.status(HttpStatus.OK).body(Map.of("success", true));
+    }
+
+    @Operation(summary = "커피챗 리뷰 조회 API")
+    @GetMapping("/review")
+    public ResponseEntity<CoffeeChatReviewResponse> getCoffeeChatReview() {
+
+        return ResponseEntity.status(HttpStatus.OK).body(new CoffeeChatReviewResponse(coffeeChatService.getRecentCoffeeChatReviews()));
     }
 }

--- a/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/CoffeeChatController.java
+++ b/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/CoffeeChatController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.sopt.makers.internal.domain.InternalMemberDetails;
 import org.sopt.makers.internal.dto.CommonResponse;
 import org.sopt.makers.internal.member.controller.coffeechat.dto.response.CoffeeChatDetailResponse;
+import org.sopt.makers.internal.member.controller.coffeechat.dto.response.CoffeeChatHistoryTitleResponse;
 import org.sopt.makers.internal.member.controller.coffeechat.dto.response.CoffeeChatResponse;
 import org.sopt.makers.internal.member.controller.coffeechat.dto.response.CoffeeChatResponse.CoffeeChatVo;
 import org.sopt.makers.internal.member.controller.coffeechat.dto.request.CoffeeChatDetailsRequest;
@@ -114,5 +115,14 @@ public class CoffeeChatController {
         coffeeChatService.deleteCoffeeChatDetails(memberDetails.getId());
         CommonResponse response = new CommonResponse(true, "커피챗 정보 삭제에 성공했습니다.");
         return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @Operation(summary = "진행한 커피챗 타이틀 조회 API")
+    @GetMapping("/history")
+    public ResponseEntity<CoffeeChatHistoryTitleResponse> getCoffeeChatHistoryTitle(
+            @Parameter(hidden = true) @AuthenticationPrincipal InternalMemberDetails memberDetails
+    ) {
+
+        return ResponseEntity.status(HttpStatus.OK).body(new CoffeeChatHistoryTitleResponse(coffeeChatService.getCoffeeChatHistories(memberDetails.getId())));
     }
 }

--- a/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/CoffeeChatController.java
+++ b/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/CoffeeChatController.java
@@ -123,6 +123,6 @@ public class CoffeeChatController {
             @Parameter(hidden = true) @AuthenticationPrincipal InternalMemberDetails memberDetails
     ) {
 
-        return ResponseEntity.status(HttpStatus.OK).body(new CoffeeChatHistoryTitleResponse(coffeeChatService.getCoffeeChatHistories(memberDetails.getId())));
+        return ResponseEntity.status(HttpStatus.OK).body(new CoffeeChatHistoryTitleResponse(coffeeChatService.getCoffeeChatHistories(208L)));
     }
 }

--- a/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/CoffeeChatController.java
+++ b/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/CoffeeChatController.java
@@ -1,12 +1,14 @@
 package org.sopt.makers.internal.member.controller.coffeechat;
 
 import java.util.List;
+import java.util.Map;
 
 import javax.validation.Valid;
 
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.sopt.makers.internal.domain.InternalMemberDetails;
 import org.sopt.makers.internal.dto.CommonResponse;
+import org.sopt.makers.internal.member.controller.coffeechat.dto.request.CoffeeChatReviewRequest;
 import org.sopt.makers.internal.member.controller.coffeechat.dto.response.CoffeeChatDetailResponse;
 import org.sopt.makers.internal.member.controller.coffeechat.dto.response.CoffeeChatHistoryTitleResponse;
 import org.sopt.makers.internal.member.controller.coffeechat.dto.response.CoffeeChatResponse;
@@ -123,6 +125,16 @@ public class CoffeeChatController {
             @Parameter(hidden = true) @AuthenticationPrincipal InternalMemberDetails memberDetails
     ) {
 
-        return ResponseEntity.status(HttpStatus.OK).body(new CoffeeChatHistoryTitleResponse(coffeeChatService.getCoffeeChatHistories(208L)));
+        return ResponseEntity.status(HttpStatus.OK).body(new CoffeeChatHistoryTitleResponse(coffeeChatService.getCoffeeChatHistories(memberDetails.getId())));
+    }
+
+    @Operation(summary = "진행한 커피챗 리뷰 생성 API")
+    @PostMapping("/review")
+    public ResponseEntity<Map<String, Boolean>> reviewCoffeeChat(
+            @Parameter(hidden = true) @AuthenticationPrincipal InternalMemberDetails memberDetails,
+            @RequestBody @Valid CoffeeChatReviewRequest request
+    ) {
+        coffeeChatService.createCoffeeChatReview(memberDetails.getId(), request);
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of("success", true));
     }
 }

--- a/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/dto/request/CoffeeChatReviewRequest.java
+++ b/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/dto/request/CoffeeChatReviewRequest.java
@@ -1,0 +1,19 @@
+package org.sopt.makers.internal.member.controller.coffeechat.dto.request;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+public record CoffeeChatReviewRequest(
+
+        @NotNull
+        Long coffeeChatId,
+
+        @NotBlank
+        @Size(min = 1, max = 10)
+        String nickname,
+
+        @NotBlank
+        String content
+) {
+}

--- a/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/dto/response/CoffeeChatHistoryTitleResponse.java
+++ b/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/dto/response/CoffeeChatHistoryTitleResponse.java
@@ -1,0 +1,16 @@
+package org.sopt.makers.internal.member.controller.coffeechat.dto.response;
+
+import java.util.List;
+
+public record CoffeeChatHistoryTitleResponse(
+
+        List<CoffeeChatHistoryResponse> coffeeChatHistories
+) {
+
+    public record CoffeeChatHistoryResponse(
+
+            Long id,
+
+            String title
+    ) {}
+}

--- a/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/dto/response/CoffeeChatHistoryTitleResponse.java
+++ b/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/dto/response/CoffeeChatHistoryTitleResponse.java
@@ -1,5 +1,7 @@
 package org.sopt.makers.internal.member.controller.coffeechat.dto.response;
 
+import org.sopt.makers.internal.member.domain.coffeechat.Career;
+
 import java.util.List;
 
 public record CoffeeChatHistoryTitleResponse(
@@ -11,6 +13,10 @@ public record CoffeeChatHistoryTitleResponse(
 
             Long id,
 
-            String title
+            String title,
+
+            String name,
+
+            Career career
     ) {}
 }

--- a/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/dto/response/CoffeeChatHistoryTitleResponse.java
+++ b/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/dto/response/CoffeeChatHistoryTitleResponse.java
@@ -14,7 +14,7 @@ public record CoffeeChatHistoryTitleResponse(
 
             Long id,
 
-            String title,
+            String coffeeChatBio,
 
             String name,
 

--- a/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/dto/response/CoffeeChatHistoryTitleResponse.java
+++ b/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/dto/response/CoffeeChatHistoryTitleResponse.java
@@ -1,6 +1,7 @@
 package org.sopt.makers.internal.member.controller.coffeechat.dto.response;
 
 import org.sopt.makers.internal.member.domain.coffeechat.Career;
+import org.sopt.makers.internal.member.domain.coffeechat.CoffeeChatTopicType;
 
 import java.util.List;
 
@@ -17,6 +18,8 @@ public record CoffeeChatHistoryTitleResponse(
 
             String name,
 
-            Career career
+            Career career,
+
+            List<CoffeeChatTopicType> coffeeChatTopicType
     ) {}
 }

--- a/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/dto/response/CoffeeChatReviewResponse.java
+++ b/src/main/java/org/sopt/makers/internal/member/controller/coffeechat/dto/response/CoffeeChatReviewResponse.java
@@ -1,0 +1,24 @@
+package org.sopt.makers.internal.member.controller.coffeechat.dto.response;
+
+import org.sopt.makers.internal.member.domain.coffeechat.CoffeeChatTopicType;
+
+import java.util.List;
+
+public record CoffeeChatReviewResponse(
+
+        List<CoffeeChatReviewInfo> coffeeChatReviewList
+) {
+
+    public record CoffeeChatReviewInfo(
+
+            String profileImage,
+
+            String nickname,
+
+            List<String> soptActivities,
+
+            List<CoffeeChatTopicType> coffeeChatTopicType,
+
+            String content
+    ) { }
+}

--- a/src/main/java/org/sopt/makers/internal/member/domain/coffeechat/CoffeeChatReview.java
+++ b/src/main/java/org/sopt/makers/internal/member/domain/coffeechat/CoffeeChatReview.java
@@ -1,0 +1,47 @@
+package org.sopt.makers.internal.member.domain.coffeechat;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.makers.internal.community.domain.anonymous.AnonymousProfileImage;
+import org.sopt.makers.internal.domain.Member;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CoffeeChatReview {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reviewer_id", nullable = false)
+    private Member reviewer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "coffee_chat_id", nullable = false)
+    private CoffeeChat coffeeChat;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "anonymous_profile_image", nullable = false)
+    private AnonymousProfileImage anonymousProfileImage;
+
+    @Column(nullable = false, length = 10)
+    String nickname;
+
+    @Column(nullable = false, length = 500)
+    String content;
+
+    @Builder
+    private CoffeeChatReview(Member reviewer, CoffeeChat coffeeChat, AnonymousProfileImage anonymousProfileImage, String nickname, String content) {
+        this.reviewer = reviewer;
+        this.coffeeChat = coffeeChat;
+        this.anonymousProfileImage = anonymousProfileImage;
+        this.nickname = nickname;
+        this.content = content;
+    }
+}

--- a/src/main/java/org/sopt/makers/internal/member/repository/coffeechat/CoffeeChatHistoryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/member/repository/coffeechat/CoffeeChatHistoryRepository.java
@@ -11,6 +11,7 @@ public interface CoffeeChatHistoryRepository extends JpaRepository<CoffeeChatHis
     // READ
     Long countBySender(Member sender);
     Long countByReceiver(Member receiver);
+    Boolean existsByReceiverAndSender(Member receiver, Member sender);
 
     // UPDATE
 

--- a/src/main/java/org/sopt/makers/internal/member/repository/coffeechat/CoffeeChatRepositoryCustom.java
+++ b/src/main/java/org/sopt/makers/internal/member/repository/coffeechat/CoffeeChatRepositoryCustom.java
@@ -1,5 +1,6 @@
 package org.sopt.makers.internal.member.repository.coffeechat;
 
+import org.sopt.makers.internal.member.controller.coffeechat.dto.response.CoffeeChatHistoryTitleResponse.CoffeeChatHistoryResponse;
 import org.sopt.makers.internal.member.domain.coffeechat.Career;
 import org.sopt.makers.internal.member.domain.coffeechat.CoffeeChatSection;
 import org.sopt.makers.internal.member.domain.coffeechat.CoffeeChatTopicType;
@@ -12,4 +13,5 @@ public interface CoffeeChatRepositoryCustom {
 
     List<RecentCoffeeChatInfoDto> findRecentCoffeeChatInfo();
     List<CoffeeChatInfoDto> findSearchCoffeeChatInfo(Long memberId, CoffeeChatSection section, CoffeeChatTopicType topicType, Career career, String part, String search);
+    List<CoffeeChatHistoryResponse> getCoffeeChatHistoryTitles(Long memberId);
 }

--- a/src/main/java/org/sopt/makers/internal/member/repository/coffeechat/CoffeeChatRepositoryCustomImpl.java
+++ b/src/main/java/org/sopt/makers/internal/member/repository/coffeechat/CoffeeChatRepositoryCustomImpl.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.makers.internal.domain.QMember;
 import org.sopt.makers.internal.domain.QMemberCareer;
 import org.sopt.makers.internal.domain.QMemberSoptActivity;
+import org.sopt.makers.internal.member.controller.coffeechat.dto.response.CoffeeChatHistoryTitleResponse.CoffeeChatHistoryResponse;
 import org.sopt.makers.internal.member.domain.coffeechat.*;
 import org.sopt.makers.internal.member.repository.coffeechat.dto.CoffeeChatInfoDto;
 import org.sopt.makers.internal.member.repository.coffeechat.dto.RecentCoffeeChatInfoDto;
@@ -100,6 +101,29 @@ public class CoffeeChatRepositoryCustomImpl implements CoffeeChatRepositoryCusto
                 .fetch();
     }
 
+    @Override
+    public List<CoffeeChatHistoryResponse> getCoffeeChatHistoryTitles(Long memberId) {
+
+        QCoffeeChatHistory coffeeChatHistory = QCoffeeChatHistory.coffeeChatHistory;
+        QCoffeeChat coffeeChat = QCoffeeChat.coffeeChat;
+
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                CoffeeChatHistoryResponse.class,
+                                coffeeChat.id,
+                                coffeeChat.coffeeChatBio
+                        )
+                )
+                .from(coffeeChat)
+                .where(coffeeChat.member.id.in(
+                        JPAExpressions.selectDistinct(coffeeChatHistory.receiver.id)
+                                .from(coffeeChatHistory)
+                                .where(coffeeChatHistory.sender.id.eq(memberId))
+                ))
+                .fetch();
+    }
+
     private BooleanExpression isInSection(CoffeeChatSection section) {
         if (section == null) {
             return null;
@@ -143,4 +167,6 @@ public class CoffeeChatRepositoryCustomImpl implements CoffeeChatRepositoryCusto
                 )
                 .exists();
     }
+
+
 }

--- a/src/main/java/org/sopt/makers/internal/member/repository/coffeechat/CoffeeChatRepositoryCustomImpl.java
+++ b/src/main/java/org/sopt/makers/internal/member/repository/coffeechat/CoffeeChatRepositoryCustomImpl.java
@@ -114,7 +114,8 @@ public class CoffeeChatRepositoryCustomImpl implements CoffeeChatRepositoryCusto
                                 coffeeChat.id,
                                 coffeeChat.coffeeChatBio,
                                 coffeeChat.member.name,
-                                coffeeChat.career
+                                coffeeChat.career,
+                                coffeeChat.coffeeChatTopicType
                         )
                 )
                 .from(coffeeChat)

--- a/src/main/java/org/sopt/makers/internal/member/repository/coffeechat/CoffeeChatRepositoryCustomImpl.java
+++ b/src/main/java/org/sopt/makers/internal/member/repository/coffeechat/CoffeeChatRepositoryCustomImpl.java
@@ -112,7 +112,9 @@ public class CoffeeChatRepositoryCustomImpl implements CoffeeChatRepositoryCusto
                         Projections.constructor(
                                 CoffeeChatHistoryResponse.class,
                                 coffeeChat.id,
-                                coffeeChat.coffeeChatBio
+                                coffeeChat.coffeeChatBio,
+                                coffeeChat.member.name,
+                                coffeeChat.career
                         )
                 )
                 .from(coffeeChat)

--- a/src/main/java/org/sopt/makers/internal/member/repository/coffeechat/CoffeeChatReviewRepository.java
+++ b/src/main/java/org/sopt/makers/internal/member/repository/coffeechat/CoffeeChatReviewRepository.java
@@ -1,0 +1,14 @@
+package org.sopt.makers.internal.member.repository.coffeechat;
+
+import org.sopt.makers.internal.domain.Member;
+import org.sopt.makers.internal.member.domain.coffeechat.CoffeeChat;
+import org.sopt.makers.internal.member.domain.coffeechat.CoffeeChatReview;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CoffeeChatReviewRepository extends JpaRepository<CoffeeChatReview, Long> {
+
+    List<CoffeeChatReview> findTop4ByOrderByIdDesc();
+    Boolean existsByReviewerAndCoffeeChat(Member member, CoffeeChat coffeeChat);
+}

--- a/src/main/java/org/sopt/makers/internal/member/repository/coffeechat/CoffeeChatReviewRepository.java
+++ b/src/main/java/org/sopt/makers/internal/member/repository/coffeechat/CoffeeChatReviewRepository.java
@@ -10,5 +10,6 @@ import java.util.List;
 public interface CoffeeChatReviewRepository extends JpaRepository<CoffeeChatReview, Long> {
 
     List<CoffeeChatReview> findTop4ByOrderByIdDesc();
+    List<CoffeeChatReview> findTop6ByOrderByIdDesc();
     Boolean existsByReviewerAndCoffeeChat(Member member, CoffeeChat coffeeChat);
 }

--- a/src/main/java/org/sopt/makers/internal/member/service/coffeechat/CoffeeChatModifier.java
+++ b/src/main/java/org/sopt/makers/internal/member/service/coffeechat/CoffeeChatModifier.java
@@ -1,12 +1,15 @@
 package org.sopt.makers.internal.member.service.coffeechat;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.makers.internal.community.domain.anonymous.AnonymousProfileImage;
 import org.sopt.makers.internal.domain.Member;
 import org.sopt.makers.internal.member.domain.coffeechat.CoffeeChat;
 import org.sopt.makers.internal.member.controller.coffeechat.dto.request.CoffeeChatDetailsRequest;
 import org.sopt.makers.internal.member.domain.coffeechat.CoffeeChatHistory;
+import org.sopt.makers.internal.member.domain.coffeechat.CoffeeChatReview;
 import org.sopt.makers.internal.member.repository.coffeechat.CoffeeChatHistoryRepository;
 import org.sopt.makers.internal.member.repository.coffeechat.CoffeeChatRepository;
+import org.sopt.makers.internal.member.repository.coffeechat.CoffeeChatReviewRepository;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -15,6 +18,7 @@ public class CoffeeChatModifier {
 
     private final CoffeeChatRepository coffeeChatRepository;
     private final CoffeeChatHistoryRepository coffeeChatHistoryRepository;
+    private final CoffeeChatReviewRepository coffeeChatReviewRepository;
 
     // CREATE
 
@@ -39,7 +43,20 @@ public class CoffeeChatModifier {
                 .sender(sender)
                 .receiver(receiver)
                 .requestContent(content)
-                .build());
+                .build()
+        );
+    }
+
+    public void createCoffeeChatReview(Member reviewer, CoffeeChat coffeeChat, AnonymousProfileImage anonymousProfileImage, String nickname, String content) {
+
+        coffeeChatReviewRepository.save(CoffeeChatReview.builder()
+                .reviewer(reviewer)
+                .coffeeChat(coffeeChat)
+                .anonymousProfileImage(anonymousProfileImage)
+                .nickname(nickname)
+                .content(content)
+                .build()
+        );
     }
 
     // UPDATE

--- a/src/main/java/org/sopt/makers/internal/member/service/coffeechat/CoffeeChatRetriever.java
+++ b/src/main/java/org/sopt/makers/internal/member/service/coffeechat/CoffeeChatRetriever.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.makers.internal.domain.Member;
 import org.sopt.makers.internal.exception.ClientBadRequestException;
 import org.sopt.makers.internal.exception.NotFoundDBEntityException;
+import org.sopt.makers.internal.member.controller.coffeechat.dto.response.CoffeeChatHistoryTitleResponse.CoffeeChatHistoryResponse;
 import org.sopt.makers.internal.member.domain.coffeechat.*;
 import org.sopt.makers.internal.member.repository.coffeechat.CoffeeChatHistoryRepository;
 import org.sopt.makers.internal.member.repository.coffeechat.CoffeeChatRepository;
@@ -64,5 +65,9 @@ public class CoffeeChatRetriever {
         }
 
         return new MemberCoffeeChatPropertyDto(coffeeChatStatus, receivedCoffeeChatCount, sentCoffeeChatCount);
+    }
+
+    public List<CoffeeChatHistoryResponse> getCoffeeChatHistoryTitles(Long memberId) {
+        return coffeeChatRepository.getCoffeeChatHistoryTitles(memberId);
     }
 }

--- a/src/main/java/org/sopt/makers/internal/member/service/coffeechat/CoffeeChatRetriever.java
+++ b/src/main/java/org/sopt/makers/internal/member/service/coffeechat/CoffeeChatRetriever.java
@@ -99,4 +99,9 @@ public class CoffeeChatRetriever {
             throw new ClientBadRequestException("이미 리뷰를 등록한 커피챗입니다.");
         }
     }
+
+    public List<CoffeeChatReview> getRecentSixCoffeeChatReviews() {
+
+        return coffeeChatReviewRepository.findTop6ByOrderByIdDesc();
+    }
 }

--- a/src/main/java/org/sopt/makers/internal/member/service/coffeechat/CoffeeChatRetriever.java
+++ b/src/main/java/org/sopt/makers/internal/member/service/coffeechat/CoffeeChatRetriever.java
@@ -8,12 +8,14 @@ import org.sopt.makers.internal.member.controller.coffeechat.dto.response.Coffee
 import org.sopt.makers.internal.member.domain.coffeechat.*;
 import org.sopt.makers.internal.member.repository.coffeechat.CoffeeChatHistoryRepository;
 import org.sopt.makers.internal.member.repository.coffeechat.CoffeeChatRepository;
+import org.sopt.makers.internal.member.repository.coffeechat.CoffeeChatReviewRepository;
 import org.sopt.makers.internal.member.repository.coffeechat.dto.CoffeeChatInfoDto;
 import org.sopt.makers.internal.member.repository.coffeechat.dto.RecentCoffeeChatInfoDto;
 import org.sopt.makers.internal.member.service.coffeechat.dto.MemberCoffeeChatPropertyDto;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
@@ -21,10 +23,16 @@ public class CoffeeChatRetriever {
 
     private final CoffeeChatRepository coffeeChatRepository;
     private final CoffeeChatHistoryRepository coffeeChatHistoryRepository;
+    private final CoffeeChatReviewRepository coffeeChatReviewRepository;
 
     public CoffeeChat findCoffeeChatByMember(Member member) {
         return coffeeChatRepository.findCoffeeChatByMember(member)
                 .orElseThrow(() -> new NotFoundDBEntityException("커피챗 정보를 등록한적 없는 유저입니다. " + "member id: " + member.getId()));
+    }
+
+    public CoffeeChat findCoffeeChatById(Long id) {
+        return coffeeChatRepository.findById(id)
+                .orElseThrow(() -> new NotFoundDBEntityException("존재하지 않는 커피챗입니다. " + "coffee chat id: " + id));
     }
 
     public void checkAlreadyExistCoffeeChat(Member member) {
@@ -69,5 +77,26 @@ public class CoffeeChatRetriever {
 
     public List<CoffeeChatHistoryResponse> getCoffeeChatHistoryTitles(Long memberId) {
         return coffeeChatRepository.getCoffeeChatHistoryTitles(memberId);
+    }
+
+    public void checkParticipateCoffeeChat(Member member, CoffeeChat coffeeChat) {
+
+        if (!coffeeChatHistoryRepository.existsByReceiverAndSender(coffeeChat.getMember(), member)) {
+            throw new ClientBadRequestException("해당 커피챗을 신청한 적 없는 유저입니다. " + "member id: " + member.getId());
+        }
+    }
+    public List<Long> getRecentUsedAnonymousProfileImageIdsInCoffeeChatReview() {
+
+        return coffeeChatReviewRepository.findTop4ByOrderByIdDesc()
+                .stream()
+                .map(review -> review.getAnonymousProfileImage().getId())
+                .collect(Collectors.toList());
+    }
+
+    public void checkAlreadyEnrollReview(Member member, CoffeeChat coffeeChat) {
+
+        if (coffeeChatReviewRepository.existsByReviewerAndCoffeeChat(member, coffeeChat)) {
+            throw new ClientBadRequestException("이미 리뷰를 등록한 커피챗입니다.");
+        }
     }
 }

--- a/src/main/java/org/sopt/makers/internal/member/service/coffeechat/CoffeeChatService.java
+++ b/src/main/java/org/sopt/makers/internal/member/service/coffeechat/CoffeeChatService.java
@@ -8,6 +8,7 @@ import org.sopt.makers.internal.exception.NotFoundDBEntityException;
 import org.sopt.makers.internal.external.MessageSender;
 import org.sopt.makers.internal.external.MessageSenderFactory;
 import org.sopt.makers.internal.member.controller.coffeechat.dto.response.CoffeeChatDetailResponse;
+import org.sopt.makers.internal.member.controller.coffeechat.dto.response.CoffeeChatHistoryTitleResponse.CoffeeChatHistoryResponse;
 import org.sopt.makers.internal.member.controller.coffeechat.dto.response.CoffeeChatResponse.CoffeeChatVo;
 import org.sopt.makers.internal.member.domain.coffeechat.*;
 import org.sopt.makers.internal.member.controller.coffeechat.dto.request.CoffeeChatDetailsRequest;
@@ -15,7 +16,6 @@ import org.sopt.makers.internal.member.controller.coffeechat.dto.request.CoffeeC
 import org.sopt.makers.internal.member.controller.coffeechat.dto.request.CoffeeChatOpenRequest;
 import org.sopt.makers.internal.member.mapper.coffeechat.CoffeeChatResponseMapper;
 import org.sopt.makers.internal.member.repository.coffeechat.dto.CoffeeChatInfoDto;
-import org.sopt.makers.internal.member.repository.coffeechat.dto.InternalCoffeeChatMemberDto;
 import org.sopt.makers.internal.member.repository.coffeechat.dto.RecentCoffeeChatInfoDto;
 import org.sopt.makers.internal.member.service.MemberRetriever;
 import org.sopt.makers.internal.member.service.career.MemberCareerRetriever;
@@ -127,6 +127,11 @@ public class CoffeeChatService {
             List<String> soptActivities = memberRetriever.concatPartAndGeneration(coffeeChatInfo.memberId());
             return coffeeChatResponseMapper.toCoffeeChatResponse(coffeeChatInfo, memberCareer, soptActivities);
         }).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<CoffeeChatHistoryResponse> getCoffeeChatHistories(Long memberId) {
+        return coffeeChatRetriever.getCoffeeChatHistoryTitles(memberId);
     }
 
     private String applyDefaultEmail(String requestEmail, String senderEmail) {


### PR DESCRIPTION
## 🐬 요약
참여한 커피챗 타이틀 조회 API를 구현했습니다.
coffee_chat_history 테이블이 coffee_chat 테이블과 직접적인 연관관계가 없어서
sender_id를 조건으로 coffee_chat_history 테이블의 receiver_id를 조회한 후 해당 receiver_id를 조건으로 coffee_chat 정보를 조회했습니다.

추가적으로 커피챗 리뷰 생성 API를 포함했습니다.
request body에 대한 valid를 모두 확인했습니다.
커피챗 타이틀 조회 시 해당 커피챗의 id값을 함께 포함하기 때문에 커피챗 리뷰에서 request에 커피챗 id값을 받습니다.
익명 프로필 이미지 생성은 커뮤니티의 게시글 익명 이미지 생성 로직과 동일하다는 답변을 기획측에 받아 동일하게 구현했습니다.

<img width="651" alt="스크린샷 2025-01-27 오후 7 11 54" src="https://github.com/user-attachments/assets/54ad4358-bdb2-4e0e-8b0d-7c6db3b55645" />

<img width="805" alt="스크린샷 2025-01-27 오후 7 12 17" src="https://github.com/user-attachments/assets/2059d30b-1928-4100-a398-353628c95621" />

<img width="641" alt="스크린샷 2025-01-27 오후 8 18 27" src="https://github.com/user-attachments/assets/f8320006-843c-4ada-a4b7-2f1256f58d20" />

<img width="843" alt="스크린샷 2025-01-27 오후 8 20 53" src="https://github.com/user-attachments/assets/4a36c341-c749-40ad-8263-5e783182fec5" />

---
마지막으로 구냥 최근 작성된 6개 커피챗 리뷰 조회 API도 넣었씀미다,,, 죄송합니다,, 하나씩은 분량이 작아서 붙였더니 커졌네요,,,
<img width="1033" alt="스크린샷 2025-01-27 오후 9 19 39" src="https://github.com/user-attachments/assets/40c7a33c-ac92-4008-b3a7-f4d6dfa20852" />
해당 이미지는 dev의 209번 유저가 제 계정인데 리뷰 생성을 제꺼로만해서 둘 다 35기 서버로만 활동 기수가 나오고 있는 점 확인해주시면 감사하겠습니다.

해당 PR에 담긴 기능이 main 브랜치에 머지될 때는 prod db에 테이블 반영이 필요합니다!


## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [x] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
PR에 담긴 작업 내용을 작성해주세요!

- API 구현
- 포스트맨 테스트
- DB 쿼리 테스트

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #578 
