### PR TITLE
[Feat] 마이 솝트 리포트 마이 플그 파트 데이터 조회 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,9 @@ dependencies {
 
 	// Prometheus
 	implementation 'io.micrometer:micrometer-registry-prometheus'
+
+	// Local Cache
+	implementation "com.github.ben-manes.caffeine:caffeine:3.1.6"
 }
 
 dependencyManagement {

--- a/src/main/java/org/sopt/makers/internal/common/Constant.java
+++ b/src/main/java/org/sopt/makers/internal/common/Constant.java
@@ -1,9 +1,16 @@
 package org.sopt.makers.internal.common;
 
+import java.time.LocalDateTime;
+
 public class Constant {
 
 	public final static int CURRENT_GENERATION = 35;
 
+	public final static Integer REPORT_FILTER_YEAR = 2024;
+	public final static LocalDateTime START_DATE_OF_YEAR = LocalDateTime.of(REPORT_FILTER_YEAR, 1, 1, 0, 0);
+	public final static LocalDateTime END_DATE_OF_YEAR = LocalDateTime.of(REPORT_FILTER_YEAR, 12, 31, 23, 59);
+
 	// Regex
 	public final static String PHONE_NUMBER_REGEX = "^(010|015)\\d{8}$";
+
 }

--- a/src/main/java/org/sopt/makers/internal/community/repository/CommunityPostLikeRepository.java
+++ b/src/main/java/org/sopt/makers/internal/community/repository/CommunityPostLikeRepository.java
@@ -3,6 +3,7 @@ package org.sopt.makers.internal.community.repository;
 import org.sopt.makers.internal.community.domain.CommunityPostLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface CommunityPostLikeRepository extends JpaRepository<CommunityPostLike, Long> {
@@ -15,6 +16,8 @@ public interface CommunityPostLikeRepository extends JpaRepository<CommunityPost
     Optional<CommunityPostLike> findCommunityPostLikeByMemberIdAndPostId(Long memberId, Long postId);
 
     Integer countAllByPostId(Long postId);
+
+    Integer countAllByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime start, LocalDateTime end);
 
     // UPDATE
 

--- a/src/main/java/org/sopt/makers/internal/community/repository/CommunityPostRepository.java
+++ b/src/main/java/org/sopt/makers/internal/community/repository/CommunityPostRepository.java
@@ -11,4 +11,6 @@ public interface CommunityPostRepository extends JpaRepository<CommunityPost, Lo
     Optional<CommunityPost> findById(Long id);
 
     List<CommunityPost> findAllByCreatedAtBetween(LocalDateTime start, LocalDateTime end);
+
+    Integer countAllByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/org/sopt/makers/internal/config/cache/CacheConfig.java
+++ b/src/main/java/org/sopt/makers/internal/config/cache/CacheConfig.java
@@ -1,0 +1,39 @@
+package org.sopt.makers.internal.config.cache;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+
+	@Bean
+	public List<CaffeineCache> caffeineCaches() {
+		return Arrays.stream(CacheType.values()).map( cache ->
+			new CaffeineCache(
+				cache.getCacheName(),
+				Caffeine.newBuilder().recordStats() // 통계 처리
+					.expireAfterWrite(cache.getExpireAfterWriteOfSeconds(), TimeUnit.SECONDS) // TTL
+					.maximumSize(cache.getMaximumSize())
+					.build()
+				)).collect(Collectors.toList());
+		}
+
+	@Bean
+	public CacheManager cacheManager(List<CaffeineCache> caffeineCaches) {
+		SimpleCacheManager cacheManager = new SimpleCacheManager();
+		cacheManager.setCaches(caffeineCaches);
+		return cacheManager;
+	}
+}

--- a/src/main/java/org/sopt/makers/internal/config/cache/CacheConstant.java
+++ b/src/main/java/org/sopt/makers/internal/config/cache/CacheConstant.java
@@ -1,0 +1,6 @@
+package org.sopt.makers.internal.config.cache;
+
+public class CacheConstant {
+	public static final String TYPE_COMMON_SOPT_REPORT_STATS = "commonSoptReportStats";
+	public static final String TYPE_MY_SOPT_REPORT_STATS = "mySoptReportStats";
+}

--- a/src/main/java/org/sopt/makers/internal/config/cache/CacheType.java
+++ b/src/main/java/org/sopt/makers/internal/config/cache/CacheType.java
@@ -1,0 +1,20 @@
+package org.sopt.makers.internal.config.cache;
+
+import static org.sopt.makers.internal.config.cache.CacheConstant.*;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CacheType {
+
+	TYPE_COMMON_SOPT_REPORT_STAS(TYPE_COMMON_SOPT_REPORT_STATS, 10L, 3600L),
+	MY_SOPT_REPORT_MY_PLAYGROUND_DATA(TYPE_MY_SOPT_REPORT_STATS, 1000L, 604800L)  // 일주일
+
+	;
+
+	private final String cacheName;
+	private final Long maximumSize;
+	private final Long expireAfterWriteOfSeconds;
+}

--- a/src/main/java/org/sopt/makers/internal/dto/amplitude/AmplitudeEventResponse.java
+++ b/src/main/java/org/sopt/makers/internal/dto/amplitude/AmplitudeEventResponse.java
@@ -1,0 +1,22 @@
+package org.sopt.makers.internal.dto.amplitude;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record AmplitudeEventResponse(
+	List<EventDto> events,
+	Object userData,
+	Object metadata
+) {
+	public record EventDto(
+		@JsonProperty("event_type")
+		String eventType,
+		@JsonProperty("event_id")
+		Long eventId,
+		@JsonProperty("client_event_time")
+		String clientEventTime,
+		@JsonProperty("event_time")
+		String eventTime
+	) {}
+}

--- a/src/main/java/org/sopt/makers/internal/dto/amplitude/AmplitudeEventResponse.java
+++ b/src/main/java/org/sopt/makers/internal/dto/amplitude/AmplitudeEventResponse.java
@@ -17,6 +17,19 @@ public record AmplitudeEventResponse(
 		@JsonProperty("client_event_time")
 		String clientEventTime,
 		@JsonProperty("event_time")
-		String eventTime
+		String eventTime,
+		@JsonProperty("event_properties")
+		EventPropertyDto eventProperties
+	) {}
+
+	public record EventPropertyDto(
+		@JsonProperty("[Amplitude] Page URL")
+		String pageUrl,
+		@JsonProperty("[Amplitude] Page Path")
+		String pagePath,
+		@JsonProperty("[Amplitude] Page Title")
+		String pageTitle,
+		@JsonProperty("[Amplitude] Page Location")
+		String pageLocation
 	) {}
 }

--- a/src/main/java/org/sopt/makers/internal/dto/amplitude/AmplitudeUserResponse.java
+++ b/src/main/java/org/sopt/makers/internal/dto/amplitude/AmplitudeUserResponse.java
@@ -1,0 +1,18 @@
+package org.sopt.makers.internal.dto.amplitude;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record AmplitudeUserResponse(
+    List<Match> matches
+) {
+    public record Match (
+        @JsonProperty("user_id")
+        Long userId,
+        @JsonProperty("amplitude_id")
+        Long amplitudeId,
+        String platform,
+        String country
+    ) {}
+}

--- a/src/main/java/org/sopt/makers/internal/external/amplitude/AmplitudeClient.java
+++ b/src/main/java/org/sopt/makers/internal/external/amplitude/AmplitudeClient.java
@@ -1,0 +1,23 @@
+package org.sopt.makers.internal.external.amplitude;
+
+import org.sopt.makers.internal.dto.amplitude.AmplitudeEventResponse;
+import org.sopt.makers.internal.dto.amplitude.AmplitudeUserResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(value = "amplitudeClient", url = "https://amplitude.com/api/2")
+public interface AmplitudeClient {
+	@GetMapping("/usersearch")
+	AmplitudeUserResponse getAmplitudeUserId(
+		@RequestParam("user") Long userId,
+		@RequestHeader("Authorization") String authorization
+	);
+
+	@GetMapping(value = "/useractivity")
+	AmplitudeEventResponse getUserProperty(
+		@RequestParam("user") Long amplitudeUserId,
+		@RequestHeader("Authorization") String authorization
+	);
+}

--- a/src/main/java/org/sopt/makers/internal/external/amplitude/AmplitudeService.java
+++ b/src/main/java/org/sopt/makers/internal/external/amplitude/AmplitudeService.java
@@ -32,7 +32,6 @@ public class AmplitudeService {
 	public Map<String, Long> getUserEventData(Long userId) {
 		String authHeader = "Basic " + encodeBasicAuth(username, password);
 		AmplitudeUserResponse response = amplitudeClient.getAmplitudeUserId(userId, authHeader);
-		System.out.println("✅ 앰플 ID" + response.matches() + response.matches().get(0).amplitudeId());
 		Long amplitudeUserId = response.matches().get(0).amplitudeId();
 		List<AmplitudeEventResponse.EventDto> events = amplitudeClient.getUserProperty(amplitudeUserId, authHeader).events();
 

--- a/src/main/java/org/sopt/makers/internal/external/amplitude/AmplitudeService.java
+++ b/src/main/java/org/sopt/makers/internal/external/amplitude/AmplitudeService.java
@@ -1,0 +1,55 @@
+package org.sopt.makers.internal.external.amplitude;
+
+import static org.sopt.makers.internal.external.amplitude.EventData.*;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.sopt.makers.internal.dto.amplitude.AmplitudeEventResponse;
+import org.sopt.makers.internal.dto.amplitude.AmplitudeUserResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AmplitudeService {
+
+	private final AmplitudeClient amplitudeClient;
+
+	@Value("${amplitude.api-key}")
+	private String username;
+
+	@Value("${amplitude.secret-key}")
+	private String password;
+
+	public Map<String, Long> getUserEventData(Long userId) {
+		String authHeader = "Basic " + encodeBasicAuth(username, password);
+		AmplitudeUserResponse response = amplitudeClient.getAmplitudeUserId(userId, authHeader);
+		System.out.println("✅ 앰플 ID" + response.matches() + response.matches().get(0).amplitudeId());
+		Long amplitudeUserId = response.matches().get(0).amplitudeId();
+		List<AmplitudeEventResponse.EventDto> events = amplitudeClient.getUserProperty(amplitudeUserId, authHeader).events();
+
+		return countEventTypes(events);
+	}
+
+	private String encodeBasicAuth(String username, String password) {
+		String auth = username + ":" + password;
+		return Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.UTF_8));
+	}
+
+	private Map<String, Long> countEventTypes(List<AmplitudeEventResponse.EventDto> events) {
+		DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+		return events.stream()
+			.filter(event -> REPORT_EVENT_PROPERTY_LIST.contains(event.eventType()) &&
+				LocalDate.parse(event.eventTime().substring(0, 10), dateFormatter).getYear() == 2024)
+			.collect(Collectors.groupingBy(AmplitudeEventResponse.EventDto::eventType, Collectors.counting()));
+	}
+}

--- a/src/main/java/org/sopt/makers/internal/external/amplitude/EventData.java
+++ b/src/main/java/org/sopt/makers/internal/external/amplitude/EventData.java
@@ -1,0 +1,46 @@
+package org.sopt.makers.internal.external.amplitude;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.sopt.makers.internal.exception.BusinessLogicException;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum EventData {
+	// TOTAL_DURATION_TIME(),
+	// TOTAL_VISIT_COUNT(),
+	MEMBER_TAB_VISIT_COUNT("Click-memberCard"),
+	PROJECT_TAB_VISIT_COUNT("Click-projectCard"),
+	COFFEE_CHAT_TAB_VISIT_COUNT("Click-coffeechatCard")
+	// CREW_TAB_VISIT_COUNT(),
+	// MY_PROFILE_VIEW_COUNT(),
+	;
+
+	private final String property;
+
+	public static final List<String> REPORT_EVENT_PROPERTY_LIST = Stream.of(
+		MEMBER_TAB_VISIT_COUNT, PROJECT_TAB_VISIT_COUNT, COFFEE_CHAT_TAB_VISIT_COUNT
+	).map(EventData::getProperty).toList();
+
+	private static final Map<String, EventData> EVENT_DATA_MAP = new HashMap<>();
+
+	static {
+		for (EventData data : values()) {
+			EVENT_DATA_MAP.put(data.property, data);
+		}
+	}
+
+	public static EventData of(String property) {
+		EventData result = EVENT_DATA_MAP.get(property.toLowerCase());
+		if (result == null) {
+			throw new BusinessLogicException("Unknown property: " + property);
+		}
+		return result;
+	}
+}

--- a/src/main/java/org/sopt/makers/internal/external/amplitude/EventData.java
+++ b/src/main/java/org/sopt/makers/internal/external/amplitude/EventData.java
@@ -1,8 +1,10 @@
 package org.sopt.makers.internal.external.amplitude;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.sopt.makers.internal.exception.BusinessLogicException;
@@ -14,19 +16,25 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum EventData {
 	// TOTAL_DURATION_TIME(),
-	// TOTAL_VISIT_COUNT(),
-	MEMBER_TAB_VISIT_COUNT("Click-memberCard"),
-	PROJECT_TAB_VISIT_COUNT("Click-projectCard"),
-	COFFEE_CHAT_TAB_VISIT_COUNT("Click-coffeechatCard")
+	TOTAL_VISIT_COUNT("[Amplitude] Start Session", ""),
+	MEMBER_TAB_VISIT_COUNT("[Amplitude] Page Viewed", "/members"),
+	PROJECT_TAB_VISIT_COUNT("[Amplitude] Page Viewed", "/projects"),
+	COFFEE_CHAT_TAB_VISIT_COUNT("[Amplitude] Page Viewed", "/coffeechat"),
 	// CREW_TAB_VISIT_COUNT(),
-	// MY_PROFILE_VIEW_COUNT(),
+	MEMBER_PROFILE_CARD_VIEW_COUNT("Click-memberCard", ""),
 	;
 
-	private final String property;
+	final String property;
+	final String pagePath;
 
-	public static final List<String> REPORT_EVENT_PROPERTY_LIST = Stream.of(
-		MEMBER_TAB_VISIT_COUNT, PROJECT_TAB_VISIT_COUNT, COFFEE_CHAT_TAB_VISIT_COUNT
-	).map(EventData::getProperty).toList();
+	// Constant
+	public static final Set<String> REPORT_EVENT_PROPERTY_SET = Stream.of(EventData.values())
+		.map(EventData::getProperty).collect(Collectors.toSet());
+	public static final Map<String, Long> DEFAULT_REPORT_EVENT_PROPERTY_MAP = Stream.of(EventData.values())
+		.collect(Collectors.toMap(
+			EventData::generateEventKey,
+			v -> 0L
+		));
 
 	private static final Map<String, EventData> EVENT_DATA_MAP = new HashMap<>();
 
@@ -42,5 +50,12 @@ public enum EventData {
 			throw new BusinessLogicException("Unknown property: " + property);
 		}
 		return result;
+	}
+
+	public static String generateEventKey(EventData event) {
+		if (!Objects.equals(event.pagePath, "")) {
+			return event.property + "|" + event.pagePath;
+		}
+		return event.property;
 	}
 }

--- a/src/main/java/org/sopt/makers/internal/report/controller/SoptReportStatsController.java
+++ b/src/main/java/org/sopt/makers/internal/report/controller/SoptReportStatsController.java
@@ -2,12 +2,16 @@ package org.sopt.makers.internal.report.controller;
 
 import java.util.Map;
 
+import org.sopt.makers.internal.domain.InternalMemberDetails;
+import org.sopt.makers.internal.report.dto.response.MySoptReportStatsResponse;
 import org.sopt.makers.internal.report.service.SoptReportStatsService;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -21,6 +25,13 @@ public class SoptReportStatsController {
 		@RequestParam(required = false, defaultValue = "SOPT") String category
 	) {
 		return soptReportStatsService.getSoptReportStats(category);
+	}
+
+	@GetMapping("/me")
+	public MySoptReportStatsResponse getMySoptReportStats(
+		@Parameter(hidden = true) @AuthenticationPrincipal InternalMemberDetails memberDetails
+	) {
+		return soptReportStatsService.getMySoptReportStats(memberDetails.getId());
 	}
 
 }

--- a/src/main/java/org/sopt/makers/internal/report/domain/PlaygroundType.java
+++ b/src/main/java/org/sopt/makers/internal/report/domain/PlaygroundType.java
@@ -11,7 +11,7 @@ public enum PlaygroundType {
 	PROJECT("서비스 익솝플로러"),
 	WORD_CHAIN_GAME("우리말 솝고수"),
 	COFFEE_CHAT("얼죽솝"),
-	GROUP("솝만추");
+	CREW("솝만추");
 
 	private final String title;
 }

--- a/src/main/java/org/sopt/makers/internal/report/domain/PlaygroundType.java
+++ b/src/main/java/org/sopt/makers/internal/report/domain/PlaygroundType.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum PlaygroundType {
+	DEFAULT("새로 오솝군요!"),
 	COMMUNITY("솝플루언서"),
 	MEMBER("인간 솝크드인"),
 	PROJECT("서비스 익솝플로러"),

--- a/src/main/java/org/sopt/makers/internal/report/domain/PlaygroundType.java
+++ b/src/main/java/org/sopt/makers/internal/report/domain/PlaygroundType.java
@@ -1,0 +1,17 @@
+package org.sopt.makers.internal.report.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PlaygroundType {
+	COMMUNITY("솝플루언서"),
+	MEMBER("인간 솝크드인"),
+	PROJECT("서비스 익솝플로러"),
+	WORD_CHAIN_GAME("우리말 솝고수"),
+	COFFEE_CHAT("얼죽솝"),
+	GROUP("솝만추");
+
+	private final String title;
+}

--- a/src/main/java/org/sopt/makers/internal/report/dto/PlayGroundTypeStatsDto.java
+++ b/src/main/java/org/sopt/makers/internal/report/dto/PlayGroundTypeStatsDto.java
@@ -11,10 +11,10 @@ public record PlayGroundTypeStatsDto(
 	Integer project,
 	Integer wordChainGame,
 	Integer coffeeChat,
-	Integer group
+	Integer crew
 ) {
 	public PlaygroundType getTopStats() {
-		List<Integer> values = Arrays.asList(community, member, project, wordChainGame, coffeeChat, group);
+		List<Integer> values = Arrays.asList(community, member, project, wordChainGame, coffeeChat, crew);
 		int max = values.stream().max(Integer::compareTo).orElse(0);
 
 		if (max == community) {
@@ -28,7 +28,7 @@ public record PlayGroundTypeStatsDto(
 		} else if (max == coffeeChat) {
 			return PlaygroundType.COFFEE_CHAT;
 		} else {
-			return PlaygroundType.GROUP;
+			return PlaygroundType.CREW;
 		}
 	}
 }

--- a/src/main/java/org/sopt/makers/internal/report/dto/PlayGroundTypeStatsDto.java
+++ b/src/main/java/org/sopt/makers/internal/report/dto/PlayGroundTypeStatsDto.java
@@ -1,0 +1,34 @@
+package org.sopt.makers.internal.report.dto;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.sopt.makers.internal.report.domain.PlaygroundType;
+
+public record PlayGroundTypeStatsDto(
+	Integer community,
+	Integer member,
+	Integer project,
+	Integer wordChainGame,
+	Integer coffeeChat,
+	Integer group
+) {
+	public PlaygroundType getTopStats() {
+		List<Integer> values = Arrays.asList(community, member, project, wordChainGame, coffeeChat, group);
+		int max = values.stream().max(Integer::compareTo).orElse(0);
+
+		if (max == community) {
+			return PlaygroundType.COMMUNITY;
+		} else if (max == member) {
+			return PlaygroundType.MEMBER;
+		} else if (max == project) {
+			return PlaygroundType.PROJECT;
+		} else if (max == wordChainGame) {
+			return PlaygroundType.WORD_CHAIN_GAME;
+		} else if (max == coffeeChat) {
+			return PlaygroundType.COFFEE_CHAT;
+		} else {
+			return PlaygroundType.GROUP;
+		}
+	}
+}

--- a/src/main/java/org/sopt/makers/internal/report/dto/PlayGroundTypeStatsDto.java
+++ b/src/main/java/org/sopt/makers/internal/report/dto/PlayGroundTypeStatsDto.java
@@ -6,16 +6,16 @@ import java.util.List;
 import org.sopt.makers.internal.report.domain.PlaygroundType;
 
 public record PlayGroundTypeStatsDto(
-	Integer community,
-	Integer member,
-	Integer project,
-	Integer wordChainGame,
-	Integer coffeeChat,
-	Integer crew
+	Long community,
+	Long member,
+	Long project,
+	Long wordChainGame,
+	Long coffeeChat,
+	Long crew
 ) {
 	public PlaygroundType getTopStats() {
-		List<Integer> values = Arrays.asList(community, member, project, wordChainGame, coffeeChat, crew);
-		int max = values.stream().max(Integer::compareTo).orElse(0);
+		List<Long> values = Arrays.asList(community, member, project, wordChainGame, coffeeChat, crew);
+		long max = values.stream().max(Long::compareTo).orElse(0L);
 
 		if (max == community) {
 			return PlaygroundType.COMMUNITY;

--- a/src/main/java/org/sopt/makers/internal/report/dto/response/MySoptReportStatsResponse.java
+++ b/src/main/java/org/sopt/makers/internal/report/dto/response/MySoptReportStatsResponse.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 public record MySoptReportStatsResponse(
 	String myType,
-	Long totalDurationTime,
 	Long totalVisitCount,
 	CommunityStatsDto myCommunityStats,
 	ProfileStatsDto myProfileStats,

--- a/src/main/java/org/sopt/makers/internal/report/dto/response/MySoptReportStatsResponse.java
+++ b/src/main/java/org/sopt/makers/internal/report/dto/response/MySoptReportStatsResponse.java
@@ -8,7 +8,7 @@ public record MySoptReportStatsResponse(
 	Integer totalVisitCount,
 	CommunityStatsDto myCommunityStats,
 	ProfileStatsDto myProfileStats,
-	GroupStatsDto myGroupStats,
+	CrewStatsDto myCrewStats,
 	WordChainGameStatsDto myWordChainGameStats
 ) {
 	public record CommunityStatsDto(
@@ -19,7 +19,7 @@ public record MySoptReportStatsResponse(
 		Integer viewCount
 	) {}
 
-	public record GroupStatsDto(
+	public record CrewStatsDto(
 		List<String> topFastestJoinedGroupList
 	) {}
 

--- a/src/main/java/org/sopt/makers/internal/report/dto/response/MySoptReportStatsResponse.java
+++ b/src/main/java/org/sopt/makers/internal/report/dto/response/MySoptReportStatsResponse.java
@@ -4,8 +4,8 @@ import java.util.List;
 
 public record MySoptReportStatsResponse(
 	String myType,
-	Integer totalDurationTime,
-	Integer totalVisitCount,
+	Long totalDurationTime,
+	Long totalVisitCount,
 	CommunityStatsDto myCommunityStats,
 	ProfileStatsDto myProfileStats,
 	CrewStatsDto myCrewStats,
@@ -16,7 +16,7 @@ public record MySoptReportStatsResponse(
 	) {}
 
 	public record ProfileStatsDto(
-		Integer viewCount
+		Long viewCount
 	) {}
 
 	public record CrewStatsDto(

--- a/src/main/java/org/sopt/makers/internal/report/dto/response/MySoptReportStatsResponse.java
+++ b/src/main/java/org/sopt/makers/internal/report/dto/response/MySoptReportStatsResponse.java
@@ -1,0 +1,31 @@
+package org.sopt.makers.internal.report.dto.response;
+
+import java.util.List;
+
+public record MySoptReportStatsResponse(
+	String myType,
+	Integer totalDurationTime,
+	Integer totalVisitCount,
+	CommunityStatsDto myCommunityStats,
+	ProfileStatsDto myProfileStats,
+	GroupStatsDto myGroupStats,
+	WordChainGameStatsDto myWordChainGameStats
+) {
+	public record CommunityStatsDto(
+		Integer likeCount
+	) {}
+
+	public record ProfileStatsDto(
+		Integer viewCount
+	) {}
+
+	public record GroupStatsDto(
+		List<String> topFastestJoinedGroupList
+	) {}
+
+	public record WordChainGameStatsDto(
+		Integer playCount,
+		Integer winCount,
+		List<String> wordList
+	) {}
+}

--- a/src/main/java/org/sopt/makers/internal/report/service/SoptReportStatsService.java
+++ b/src/main/java/org/sopt/makers/internal/report/service/SoptReportStatsService.java
@@ -2,6 +2,7 @@ package org.sopt.makers.internal.report.service;
 
 import static org.sopt.makers.internal.common.Constant.*;
 import static org.sopt.makers.internal.common.JsonDataSerializer.*;
+import static org.sopt.makers.internal.config.cache.CacheConstant.*;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -23,6 +24,7 @@ import org.sopt.makers.internal.report.repository.SoptReportStatsRepository;
 import org.sopt.makers.internal.repository.WordChainGameQueryRepository;
 import org.sopt.makers.internal.repository.WordRepository;
 import org.sopt.makers.internal.repository.community.CommunityCommentRepository;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -40,7 +42,9 @@ public class SoptReportStatsService {
 	private final CommunityPostRepository communityPostRepository;
 	private final CommunityCommentRepository communityCommentRepository;
 
+	@Cacheable(cacheNames = TYPE_COMMON_SOPT_REPORT_STATS, key = "#category")
 	public Map<String, Object> getSoptReportStats(String category) {
+		System.out.println("왜 아무것도 안 나오?");
 		return soptReportStatsRepository.findByCategory(category).stream().collect(
 			Collectors.toMap(
 				SoptReportStats::getTemplateKey,
@@ -49,6 +53,7 @@ public class SoptReportStatsService {
 		);
 	}
 
+	@Cacheable(cacheNames = TYPE_MY_SOPT_REPORT_STATS, key = "#memberId")
 	public MySoptReportStatsResponse getMySoptReportStats(Long memberId) {
 		// Community
 		int likeCount = communityPostLikeRepository.countAllByMemberIdAndCreatedAtBetween(memberId, START_DATE_OF_YEAR, END_DATE_OF_YEAR);
@@ -110,5 +115,4 @@ public class SoptReportStatsService {
 			(crewVisitCount / totalVisitCount) * 100
 		).getTopStats();
 	}
-
 }

--- a/src/main/java/org/sopt/makers/internal/report/service/SoptReportStatsService.java
+++ b/src/main/java/org/sopt/makers/internal/report/service/SoptReportStatsService.java
@@ -103,7 +103,7 @@ public class SoptReportStatsService {
 		// Playground Visit Count (Amplitude)
 		long totalVisitCount = events.get(generateEventKey(TOTAL_VISIT_COUNT));
 		if (totalVisitCount == 0) {
-			return PlaygroundType.MEMBER;
+			return PlaygroundType.DEFAULT;
 		}
 
 		int postCount = communityPostRepository.countAllByMemberIdAndCreatedAtBetween(memberId, START_DATE_OF_YEAR, END_DATE_OF_YEAR);

--- a/src/main/java/org/sopt/makers/internal/report/service/SoptReportStatsService.java
+++ b/src/main/java/org/sopt/makers/internal/report/service/SoptReportStatsService.java
@@ -2,12 +2,25 @@ package org.sopt.makers.internal.report.service;
 
 import static org.sopt.makers.internal.common.JsonDataSerializer.*;
 
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.sopt.makers.internal.community.repository.CommunityPostLikeRepository;
+import org.sopt.makers.internal.community.repository.CommunityPostRepository;
+import org.sopt.makers.internal.domain.Word;
+import org.sopt.makers.internal.report.domain.PlaygroundType;
 import org.sopt.makers.internal.report.domain.SoptReportStats;
+import org.sopt.makers.internal.report.dto.PlayGroundTypeStatsDto;
+import org.sopt.makers.internal.report.dto.response.MySoptReportStatsResponse;
 import org.sopt.makers.internal.report.repository.SoptReportStatsRepository;
+import org.sopt.makers.internal.repository.WordChainGameQueryRepository;
+import org.sopt.makers.internal.repository.WordRepository;
+import org.sopt.makers.internal.repository.community.CommunityCommentRepository;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -16,6 +29,15 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SoptReportStatsService {
 	private final SoptReportStatsRepository soptReportStatsRepository;
+	private final CommunityPostLikeRepository communityPostLikeRepository;
+	private final WordRepository wordRepository;
+	private final WordChainGameQueryRepository wordChainGameWinnerRepository;
+
+	private final Integer REPORT_FILTER_YEAR = 2024;
+	private final LocalDateTime startDate = LocalDateTime.of(REPORT_FILTER_YEAR, 1, 1, 0, 0);
+	private final LocalDateTime endDate = LocalDateTime.of(REPORT_FILTER_YEAR, 12, 31, 23, 59);
+	private final CommunityPostRepository communityPostRepository;
+	private final CommunityCommentRepository communityCommentRepository;
 
 	public Map<String, Object> getSoptReportStats(String category) {
 		return soptReportStatsRepository.findByCategory(category).stream().collect(
@@ -25,4 +47,77 @@ public class SoptReportStatsService {
 			)
 		);
 	}
+
+	public MySoptReportStatsResponse getMySoptReportStats(Long memberId) {
+		// Community
+		int likeCount = communityPostLikeRepository.countAllByMemberIdAndCreatedAtBetween(memberId, startDate, endDate);
+
+		// WordChainGame
+		List<Word> memberWords = wordRepository.findAllByMemberIdAndCreatedAtBetween(memberId, startDate, endDate);
+		List<String> wordList = getShuffledWordList(memberWords);
+		int playCount = memberWords.size();
+		int winCount = (int) wordChainGameWinnerRepository.countByUserIdAndCreatedAtBetween(memberId, startDate, endDate);
+
+		int viewCount = 100;
+		List<String> topFastestJoinedGroupList = Arrays.asList("모임1","모임2");
+
+		return new MySoptReportStatsResponse(
+			calculatePlaygroundType(memberId).getTitle(),
+			100, // TODO Amplitude
+			100, // TODO Amplitude,
+			new MySoptReportStatsResponse.CommunityStatsDto(
+				likeCount
+			),
+			new MySoptReportStatsResponse.ProfileStatsDto(
+				viewCount // TODO Amplitude
+			),
+			new MySoptReportStatsResponse.GroupStatsDto(
+				topFastestJoinedGroupList  // TODO Crew API 응답 활용
+			),
+			new MySoptReportStatsResponse.WordChainGameStatsDto(
+				playCount, winCount, wordList
+			)
+		);
+	}
+
+	private List<String> getShuffledWordList(List<Word> memberWords) {
+		List<String> wordList = memberWords.stream().map(Word::getWord).collect(Collectors.toList());
+		Collections.shuffle(wordList);
+		return wordList.size() > 6 ? wordList.subList(0, 6) : wordList;
+	}
+
+	private PlaygroundType calculatePlaygroundType(Long memberId) {
+		// Playground Visit Count (Amplitude)
+		int totalVisitCount = 100;
+
+		// Community
+		int postCount = communityPostRepository.countAllByMemberIdAndCreatedAtBetween(memberId, startDate, endDate);
+		int commentCount = communityCommentRepository.countAllByWriterIdAndCreatedAtBetween(memberId, startDate, endDate);
+		int likeCount = communityPostLikeRepository.countAllByMemberIdAndCreatedAtBetween(memberId, startDate, endDate);
+
+		// Member
+		int memberVisitCount = 100; // TODO Ampl
+
+		// Project
+		int projectVisitCount = 100; // TODO AMpl
+
+		// WordChainGame
+		int wordChainGameVisitCount = 100; // TODO Ampl
+
+		// CoffeeChat
+		int coffeeChatVisitCount = 100; // TODO Ampl
+
+		// Group
+		int groupVisitCount = 100; // TODO AMpl
+
+		return new PlayGroundTypeStatsDto(
+			((postCount + commentCount + likeCount) / totalVisitCount) *100,
+			(memberVisitCount / totalVisitCount) * 100,
+			(projectVisitCount / totalVisitCount) * 100,
+			(wordChainGameVisitCount / totalVisitCount) * 100,
+			(coffeeChatVisitCount / totalVisitCount) * 100,
+			(groupVisitCount / totalVisitCount) * 100
+		).getTopStats();
+	}
+
 }

--- a/src/main/java/org/sopt/makers/internal/report/service/SoptReportStatsService.java
+++ b/src/main/java/org/sopt/makers/internal/report/service/SoptReportStatsService.java
@@ -44,7 +44,7 @@ public class SoptReportStatsService {
 
 	@Cacheable(cacheNames = TYPE_COMMON_SOPT_REPORT_STATS, key = "#category")
 	public Map<String, Object> getSoptReportStats(String category) {
-		System.out.println("왜 아무것도 안 나오?");
+
 		return soptReportStatsRepository.findByCategory(category).stream().collect(
 			Collectors.toMap(
 				SoptReportStats::getTemplateKey,
@@ -95,7 +95,6 @@ public class SoptReportStatsService {
 	private PlaygroundType calculatePlaygroundType(Long memberId, int likeCount, int wordChainGamePlayCount) {
 		// Playground Visit Count (Amplitude)
 		Map<String, Long> events = amplitudeService.getUserEventData(memberId);
-		System.out.println("events: " + events);
 		long totalVisitCount = 100;
 
 		int postCount = communityPostRepository.countAllByMemberIdAndCreatedAtBetween(memberId, START_DATE_OF_YEAR, END_DATE_OF_YEAR);

--- a/src/main/java/org/sopt/makers/internal/report/service/SoptReportStatsService.java
+++ b/src/main/java/org/sopt/makers/internal/report/service/SoptReportStatsService.java
@@ -74,7 +74,6 @@ public class SoptReportStatsService {
 
 		return new MySoptReportStatsResponse(
 			calculatePlaygroundType(memberId, events, likeCount, playCount).getTitle(),
-			100L, // TODO Amplitude
 			totalVisitCount,
 			new MySoptReportStatsResponse.CommunityStatsDto(
 				likeCount

--- a/src/main/java/org/sopt/makers/internal/report/service/SoptReportStatsService.java
+++ b/src/main/java/org/sopt/makers/internal/report/service/SoptReportStatsService.java
@@ -106,7 +106,7 @@ public class SoptReportStatsService {
 		long memberVisitCount = events.get(generateEventKey(MEMBER_TAB_VISIT_COUNT));
 		long projectVisitCount = events.get(generateEventKey(PROJECT_TAB_VISIT_COUNT));
 		long coffeeChatVisitCount = events.get(generateEventKey(COFFEE_CHAT_TAB_VISIT_COUNT));
-		long crewVisitCount = 100; // TODO AMpl
+		long crewVisitCount = 1; // TODO AMpl
 
 		return new PlayGroundTypeStatsDto(
 			((postCount + commentCount + likeCount) / totalVisitCount) *100,

--- a/src/main/java/org/sopt/makers/internal/report/service/SoptReportStatsService.java
+++ b/src/main/java/org/sopt/makers/internal/report/service/SoptReportStatsService.java
@@ -71,7 +71,7 @@ public class SoptReportStatsService {
 			new MySoptReportStatsResponse.ProfileStatsDto(
 				viewCount // TODO Amplitude
 			),
-			new MySoptReportStatsResponse.GroupStatsDto(
+			new MySoptReportStatsResponse.CrewStatsDto(
 				topFastestJoinedGroupList  // TODO Crew API 응답 활용
 			),
 			new MySoptReportStatsResponse.WordChainGameStatsDto(
@@ -107,8 +107,8 @@ public class SoptReportStatsService {
 		// CoffeeChat
 		int coffeeChatVisitCount = 100; // TODO Ampl
 
-		// Group
-		int groupVisitCount = 100; // TODO AMpl
+		// Crew
+		int crewVisitCount = 100; // TODO AMpl
 
 		return new PlayGroundTypeStatsDto(
 			((postCount + commentCount + likeCount) / totalVisitCount) *100,
@@ -116,7 +116,7 @@ public class SoptReportStatsService {
 			(projectVisitCount / totalVisitCount) * 100,
 			(wordChainGameVisitCount / totalVisitCount) * 100,
 			(coffeeChatVisitCount / totalVisitCount) * 100,
-			(groupVisitCount / totalVisitCount) * 100
+			(crewVisitCount / totalVisitCount) * 100
 		).getTopStats();
 	}
 

--- a/src/main/java/org/sopt/makers/internal/repository/WordChainGameQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/repository/WordChainGameQueryRepository.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -83,13 +84,14 @@ public class WordChainGameQueryRepository {
         QWordChainGameRoom gameRoom = QWordChainGameRoom.wordChainGameRoom;
 
 
-        return queryFactory.select(winner.count())
+        return Optional.ofNullable(queryFactory.select(winner.count())
             .from(winner)
             .innerJoin(gameRoom).on(winner.roomId.eq(gameRoom.id))
             .where(
                 winner.userId.eq(userId)
                     .and(gameRoom.createdAt.between(startDate, endDate))
             )
-            .fetchOne();
+            .fetchOne()
+        ).orElse(0L);
     }
 }

--- a/src/main/java/org/sopt/makers/internal/repository/WordChainGameQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/repository/WordChainGameQueryRepository.java
@@ -9,6 +9,7 @@ import org.sopt.makers.internal.dto.wordChainGame.QWinnerDao;
 import org.sopt.makers.internal.dto.wordChainGame.WinnerDao;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -75,5 +76,20 @@ public class WordChainGameQueryRepository {
         val room = QWordChainGameRoom.wordChainGameRoom;
         if(gameRoomId == null || gameRoomId == 0) return null;
         return room.id.lt(gameRoomId);
+    }
+
+    public long countByUserIdAndCreatedAtBetween(Long userId, LocalDateTime startDate, LocalDateTime endDate) {
+        QWordChainGameWinner winner = QWordChainGameWinner.wordChainGameWinner;
+        QWordChainGameRoom gameRoom = QWordChainGameRoom.wordChainGameRoom;
+
+
+        return queryFactory.select(winner.count())
+            .from(winner)
+            .innerJoin(gameRoom).on(winner.roomId.eq(gameRoom.id))
+            .where(
+                winner.userId.eq(userId)
+                    .and(gameRoom.createdAt.between(startDate, endDate))
+            )
+            .fetchOne();
     }
 }

--- a/src/main/java/org/sopt/makers/internal/repository/WordRepository.java
+++ b/src/main/java/org/sopt/makers/internal/repository/WordRepository.java
@@ -3,9 +3,11 @@ package org.sopt.makers.internal.repository;
 import org.sopt.makers.internal.domain.Word;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface WordRepository extends JpaRepository<Word, Long> {
     Boolean existsByWordAndRoomId(String word, Long roomId);
     Word findFirstByRoomIdOrderByCreatedAtDesc(Long roomId);
+    List<Word> findAllByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/org/sopt/makers/internal/repository/community/CommunityCommentRepository.java
+++ b/src/main/java/org/sopt/makers/internal/repository/community/CommunityCommentRepository.java
@@ -3,10 +3,13 @@ package org.sopt.makers.internal.repository.community;
 import org.sopt.makers.internal.domain.community.CommunityComment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface CommunityCommentRepository extends JpaRepository<CommunityComment, Long> {
     List<CommunityComment> findAllByPostId(Long postId);
 
     int countAllByPostId(Long postId);
+
+    int countAllByWriterIdAndCreatedAtBetween(Long memberId, LocalDateTime start, LocalDateTime end);
 }


### PR DESCRIPTION
## 🐬 요약
SP3 마이 솝트 리포트에서 `마이 플그` 파트에 해당하는 유저 개인화 데이터를 조회하는 API를 구현합니다.
[API 명세서
](https://www.notion.so/sopt-makers/API-6fa331660d334ad4940fb3574b8f5e2e?pvs=4)

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [x] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용

- Amplitude Dashboard API를 호출하여 playground user id -> amplitude user id 조회 -> 해당 id로 유저 이벤트 프로퍼티 목록을 조회합니다. 
  - 리포트에 포함되는 데이터를 서버 내부에서 전처리하여 내려주기 위함입니다. (웹 페이지 상에서 호출하면 CORS가 발생하고, 응답 데이터가 커서 가공이 필요)
- 호출 시마다 변화되는 동적 데이터가 아니라, 2024년도 기준의 고정 데이터이므로 로컬 캐싱을 적용하여 DB 호출 수를 최소화하고 성능을 향상시키고자 했습니다.
  - amplitude api를 호출하는 빈도 역시 최소화하기 위해 유저마다 일주일의 ttl을 갖도록 했습니다. 


+) 추후 크루 API 개발이 완료되면 작업이 필요한데, FE분들 작업을 위해 해당 PR 배포 후에 별도 PR로 올리겠습니다!

### Self QA
<img width="1282" alt="image" src="https://github.com/user-attachments/assets/3f8fc297-2a1c-4f28-a83c-badf2a4f171e" />

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #581
