### PR TITLE
[Feat] 마이 솝트 리포트 크루 데이터 추가

### DIFF
--- a/src/main/java/org/sopt/makers/internal/external/MakersCrewClient.java
+++ b/src/main/java/org/sopt/makers/internal/external/MakersCrewClient.java
@@ -12,9 +12,9 @@ public interface MakersCrewClient {
 
     @GetMapping("/meeting/v2/org-user")
     MemberCrewResponse getUserAllCrew(
-        @RequestParam("page") Integer page,
-        @RequestParam("take") Integer take,
-        @RequestParam("orgUserId") Long orgUserId
+            @RequestParam("page") Integer page,
+            @RequestParam("take") Integer take,
+            @RequestParam("orgUserId") Long orgUserId
     );
 
     @GetMapping("/internal/meeting/stats/fastest-applied/{orgId}")

--- a/src/main/java/org/sopt/makers/internal/external/MakersCrewClient.java
+++ b/src/main/java/org/sopt/makers/internal/external/MakersCrewClient.java
@@ -1,8 +1,10 @@
 package org.sopt.makers.internal.external;
 
 import org.sopt.makers.internal.dto.member.MemberCrewResponse;
+import org.sopt.makers.internal.report.dto.CrewFastestJoinedGroupResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(value = "makersCrewClient", url = "${internal.crew.url}")
@@ -10,8 +12,14 @@ public interface MakersCrewClient {
 
     @GetMapping("/meeting/v2/org-user")
     MemberCrewResponse getUserAllCrew(
-            @RequestParam("page") Integer page,
-            @RequestParam("take") Integer take,
-            @RequestParam("orgUserId") Long orgUserId
+        @RequestParam("page") Integer page,
+        @RequestParam("take") Integer take,
+        @RequestParam("orgUserId") Long orgUserId
+    );
+
+    @GetMapping("/internal/meeting/stats/fastest-applied/{orgId}")
+    CrewFastestJoinedGroupResponse getFastestAppliedGroups(
+            @PathVariable("orgId") Long orgUserId,
+            @RequestParam("query-count") Integer queryCount
     );
 }

--- a/src/main/java/org/sopt/makers/internal/external/MakersCrewClient.java
+++ b/src/main/java/org/sopt/makers/internal/external/MakersCrewClient.java
@@ -20,6 +20,7 @@ public interface MakersCrewClient {
     @GetMapping("/internal/meeting/stats/fastest-applied/{orgId}")
     CrewFastestJoinedGroupResponse getFastestAppliedGroups(
             @PathVariable("orgId") Long orgUserId,
-            @RequestParam("query-count") Integer queryCount
+            @RequestParam("query-count") Integer queryCount,
+            @RequestParam("query-year") Integer queryYear
     );
 }

--- a/src/main/java/org/sopt/makers/internal/external/amplitude/AmplitudeService.java
+++ b/src/main/java/org/sopt/makers/internal/external/amplitude/AmplitudeService.java
@@ -76,10 +76,10 @@ public class AmplitudeService {
 		return Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.UTF_8));
 	}
 
-	private Map<String, Long> mergeEventCounts(Map<String, Long> map1, Map<String, Long> map2) {
-		Map<String, Long> merged = new HashMap<>(map1);
-		map2.forEach((key, value) -> merged.merge(key, value, Long::sum));
-		return merged;
+	private Map<String, Long> mergeEventCounts(Map<String, Long> userEvents, Map<String, Long> crewEvents) {
+		Map<String, Long> allEvents = new HashMap<>(userEvents);
+		crewEvents.forEach((key, value) -> allEvents.merge(key, value, Long::sum));
+		return allEvents;
 	}
 
 	private Map<String, Long> countEventTypes(List<AmplitudeEventResponse.EventDto> events) {

--- a/src/main/java/org/sopt/makers/internal/external/amplitude/AmplitudeService.java
+++ b/src/main/java/org/sopt/makers/internal/external/amplitude/AmplitudeService.java
@@ -31,23 +31,23 @@ public class AmplitudeService {
 	private final AmplitudeClient amplitudeClient;
 
 	@Value("${amplitude.api-key}")
-	private String username;
+	private String apiKey;
 
 	@Value("${amplitude.secret-key}")
-	private String password;
+	private String secretKey;
 
 	@Value("${amplitude.crew-api-key}")
-	private String crewUsername;
+	private String crewApiKey;
 
 	@Value("${amplitude.crew-secret-key}")
-	private String crewPassword;
+	private String crewSecretKey;
 
 	public Map<String, Long> getUserEventData(Long userId) {
-		return fetchUserEventData(userId, username, password);
+		return fetchUserEventData(userId, apiKey, secretKey);
 	}
 
 	public Map<String, Long> getCrewUserEventData(Long userId) {
-		return fetchUserEventData(userId, crewUsername, crewPassword);
+		return fetchUserEventData(userId, crewApiKey, crewSecretKey);
 	}
 
 	public Map<String, Long> getAllUserEventData(Long userId) {
@@ -57,9 +57,9 @@ public class AmplitudeService {
 		return mergeEventCounts(userEvents, crewEvents);
 	}
 
-	private Map<String, Long> fetchUserEventData(Long userId, String apiKey, String secretKey) {
+	private Map<String, Long> fetchUserEventData(Long userId, String username, String password) {
 		try {
-			String authHeader = "Basic " + encodeBasicAuth(apiKey, secretKey);
+			String authHeader = "Basic " + encodeBasicAuth(username, password);
 			AmplitudeUserResponse response = amplitudeClient.getAmplitudeUserId(userId, authHeader);
 			Long amplitudeUserId = response.matches().get(0).amplitudeId();
 			List<AmplitudeEventResponse.EventDto> events = amplitudeClient.getUserProperty(amplitudeUserId, authHeader)

--- a/src/main/java/org/sopt/makers/internal/external/amplitude/EventData.java
+++ b/src/main/java/org/sopt/makers/internal/external/amplitude/EventData.java
@@ -15,12 +15,11 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum EventData {
-	// TOTAL_DURATION_TIME(),
 	TOTAL_VISIT_COUNT("[Amplitude] Start Session", ""),
 	MEMBER_TAB_VISIT_COUNT("[Amplitude] Page Viewed", "/members"),
 	PROJECT_TAB_VISIT_COUNT("[Amplitude] Page Viewed", "/projects"),
 	COFFEE_CHAT_TAB_VISIT_COUNT("[Amplitude] Page Viewed", "/coffeechat"),
-	// CREW_TAB_VISIT_COUNT(),
+	CREW_TAB_VISIT_COUNT("[Amplitude] Page Viewed", "/group/"),
 	MEMBER_PROFILE_CARD_VIEW_COUNT("Click-memberCard", ""),
 	;
 

--- a/src/main/java/org/sopt/makers/internal/report/dto/CrewFastestJoinedGroupResponse.java
+++ b/src/main/java/org/sopt/makers/internal/report/dto/CrewFastestJoinedGroupResponse.java
@@ -1,0 +1,12 @@
+package org.sopt.makers.internal.report.dto;
+
+import java.util.List;
+
+public record CrewFastestJoinedGroupResponse(
+	List<CrewGroupDto> topFastestAppliedMeetings
+) {
+	public record CrewGroupDto(
+		Long meetingId,
+		String title
+	) { }
+}

--- a/src/main/java/org/sopt/makers/internal/report/service/SoptReportStatsService.java
+++ b/src/main/java/org/sopt/makers/internal/report/service/SoptReportStatsService.java
@@ -15,10 +15,12 @@ import java.util.stream.Collectors;
 import org.sopt.makers.internal.community.repository.CommunityPostLikeRepository;
 import org.sopt.makers.internal.community.repository.CommunityPostRepository;
 import org.sopt.makers.internal.domain.Word;
+import org.sopt.makers.internal.external.MakersCrewClient;
 import org.sopt.makers.internal.external.amplitude.AmplitudeService;
 import org.sopt.makers.internal.report.domain.PlaygroundType;
 import org.sopt.makers.internal.report.domain.SoptReportCategory;
 import org.sopt.makers.internal.report.domain.SoptReportStats;
+import org.sopt.makers.internal.report.dto.CrewFastestJoinedGroupResponse;
 import org.sopt.makers.internal.report.dto.PlayGroundTypeStatsDto;
 import org.sopt.makers.internal.report.dto.response.MySoptReportStatsResponse;
 import org.sopt.makers.internal.report.repository.SoptReportStatsRepository;
@@ -43,6 +45,10 @@ public class SoptReportStatsService {
 
 	private final CommunityPostRepository communityPostRepository;
 	private final CommunityCommentRepository communityCommentRepository;
+
+	private final MakersCrewClient makersCrewClient;
+
+	private final Integer CREW_TOP_FASTEST_JOINED_GROUP_LIMIT = 3;
 
 	@Cacheable(cacheNames = TYPE_COMMON_SOPT_REPORT_STATS, key = "#category")
 	@Transactional(readOnly = true)
@@ -73,7 +79,10 @@ public class SoptReportStatsService {
 
 		// Profile
 		long viewCount = events.get(generateEventKey(MEMBER_PROFILE_CARD_VIEW_COUNT));
-		List<String> topFastestJoinedGroupList = Arrays.asList("모임1","모임2");
+
+		// Crew
+		List<String> topFastestJoinedGroupList = makersCrewClient.getFastestAppliedGroups(memberId, CREW_TOP_FASTEST_JOINED_GROUP_LIMIT).topFastestAppliedMeetings().stream().map(
+			CrewFastestJoinedGroupResponse.CrewGroupDto::title).toList();
 
 		return new MySoptReportStatsResponse(
 			calculatePlaygroundType(memberId, events, likeCount, playCount).getTitle(),
@@ -85,7 +94,7 @@ public class SoptReportStatsService {
 				viewCount
 			),
 			new MySoptReportStatsResponse.CrewStatsDto(
-				topFastestJoinedGroupList  // TODO Crew API 응답 활용
+				topFastestJoinedGroupList
 			),
 			new MySoptReportStatsResponse.WordChainGameStatsDto(
 				playCount, winCount, wordList

--- a/src/main/java/org/sopt/makers/internal/report/service/SoptReportStatsService.java
+++ b/src/main/java/org/sopt/makers/internal/report/service/SoptReportStatsService.java
@@ -64,7 +64,7 @@ public class SoptReportStatsService {
 	@Cacheable(cacheNames = TYPE_MY_SOPT_REPORT_STATS, key = "#memberId")
 	@Transactional(readOnly = true)
 	public MySoptReportStatsResponse getMySoptReportStats(Long memberId) {
-		Map<String, Long> events = amplitudeService.getUserEventData(memberId);
+		Map<String, Long> events = amplitudeService.getAllUserEventData(memberId);
 
 		long totalVisitCount = events.get(generateEventKey(TOTAL_VISIT_COUNT));
 
@@ -121,7 +121,7 @@ public class SoptReportStatsService {
 		long memberVisitCount = events.get(generateEventKey(MEMBER_TAB_VISIT_COUNT));
 		long projectVisitCount = events.get(generateEventKey(PROJECT_TAB_VISIT_COUNT));
 		long coffeeChatVisitCount = events.get(generateEventKey(COFFEE_CHAT_TAB_VISIT_COUNT));
-		long crewVisitCount = 1; // TODO AMpl
+		long crewVisitCount = events.get(generateEventKey(CREW_TAB_VISIT_COUNT));
 
 		return new PlayGroundTypeStatsDto(
 			((postCount + commentCount + likeCount) / totalVisitCount) *100,

--- a/src/main/java/org/sopt/makers/internal/report/service/SoptReportStatsService.java
+++ b/src/main/java/org/sopt/makers/internal/report/service/SoptReportStatsService.java
@@ -31,6 +31,7 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -81,8 +82,14 @@ public class SoptReportStatsService {
 		long viewCount = events.get(generateEventKey(MEMBER_PROFILE_CARD_VIEW_COUNT));
 
 		// Crew
-		List<String> topFastestJoinedGroupList = makersCrewClient.getFastestAppliedGroups(memberId, CREW_TOP_FASTEST_JOINED_GROUP_LIMIT).topFastestAppliedMeetings().stream().map(
-			CrewFastestJoinedGroupResponse.CrewGroupDto::title).toList();
+		List<String> topFastestJoinedGroupList;
+		try {
+			topFastestJoinedGroupList = makersCrewClient.getFastestAppliedGroups(memberId,
+				CREW_TOP_FASTEST_JOINED_GROUP_LIMIT).topFastestAppliedMeetings().stream().map(
+				CrewFastestJoinedGroupResponse.CrewGroupDto::title).toList();
+		} catch (FeignException ex) {
+			topFastestJoinedGroupList = Collections.emptyList();
+		}
 
 		return new MySoptReportStatsResponse(
 			calculatePlaygroundType(memberId, events, likeCount, playCount).getTitle(),

--- a/src/main/java/org/sopt/makers/internal/report/service/SoptReportStatsService.java
+++ b/src/main/java/org/sopt/makers/internal/report/service/SoptReportStatsService.java
@@ -84,8 +84,11 @@ public class SoptReportStatsService {
 		// Crew
 		List<String> topFastestJoinedGroupList;
 		try {
-			topFastestJoinedGroupList = makersCrewClient.getFastestAppliedGroups(memberId,
-				CREW_TOP_FASTEST_JOINED_GROUP_LIMIT).topFastestAppliedMeetings().stream().map(
+			topFastestJoinedGroupList = makersCrewClient.getFastestAppliedGroups(
+				memberId,
+				CREW_TOP_FASTEST_JOINED_GROUP_LIMIT,
+				REPORT_FILTER_YEAR
+			).topFastestAppliedMeetings().stream().map(
 				CrewFastestJoinedGroupResponse.CrewGroupDto::title).toList();
 		} catch (FeignException ex) {
 			topFastestJoinedGroupList = Collections.emptyList();

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -84,6 +84,8 @@ slack:
 amplitude:
   api-key: test
   secret-key: test
+  crew-api-key: test
+  crew-secret-key: test
 internal:
   official:
     url: test


### PR DESCRIPTION
## 🐬 요약
SP3 마이 솝트 리포트 공통 데이터 / 마이 데이터 조회 API에서 크루 데이터를 조회하는 로직을 추가합니다.

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [x] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용

- 크루 외부 API 통신 추가
  - 플그 유저 단위 가장 빠르게 신청한 모임 타이틀 리스트를 조회하는 부분 
- 크루 앰플리튜드 데이터 조회 로직 추가
   - 모임 탭 조회 카운트를 Crew Amplitude ApiKey와  SecretKey로 조회하도록 추가

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #581
