### PR TITLE
[Chore] 타임캡솝 태그 유형 수정

### DIFF
--- a/src/main/java/org/sopt/makers/internal/resolution/controller/UserResolutionController.java
+++ b/src/main/java/org/sopt/makers/internal/resolution/controller/UserResolutionController.java
@@ -18,6 +18,8 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
+import javax.validation.Valid;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/resolution")
@@ -37,12 +39,12 @@ public class UserResolutionController {
 
 	@Operation(summary = "다짐 메세지 생성")
 	@PostMapping
-	public ResponseEntity<Map<String, Boolean>> createResolution(
+	public ResponseEntity<Void> createResolution(
 		@Parameter(hidden = true) @AuthenticationPrincipal InternalMemberDetails memberDetails,
-		@RequestBody ResolutionSaveRequest request
+		@Valid @RequestBody ResolutionSaveRequest request
 	) {
 		userResolutionService.createResolution(memberDetails.getId(), request);
-		return ResponseEntity.status(HttpStatus.CREATED).body(Map.of("다짐 메시지 생성 성공", true));
+		return ResponseEntity.status(HttpStatus.CREATED).build();
 	}
 
 	@Operation(summary = "다짐 메세지 유효성 검사")

--- a/src/main/java/org/sopt/makers/internal/resolution/domain/ResolutionTag.java
+++ b/src/main/java/org/sopt/makers/internal/resolution/domain/ResolutionTag.java
@@ -19,16 +19,18 @@ public enum ResolutionTag {
 
 	private final String description;
 
+	@JsonCreator
+	public static ResolutionTag fromString(String value) {
+		try {
+			return ResolutionTag.valueOf(value);
+		} catch (IllegalArgumentException e) {
+			throw new ClientBadRequestException("Unknown Timecapsop Tag Name: " + value);
 		}
-		return value;
 	}
 
-	public static List<String> getTagNames(String tagIds) {
-		List<String> indexList = Arrays.asList(tagIds.split(","));
-
-		return Arrays.stream(ResolutionTag.values())
-				.filter(tag -> indexList.contains(String.valueOf(tag.index)))
-				.map(tag -> tag.value)
-				.collect(Collectors.toList());
+	public static List<ResolutionTag> fromStringArray(List<String> values) {
+		return values.stream()
+				.map(ResolutionTag::fromString)
+				.toList();
 	}
 }

--- a/src/main/java/org/sopt/makers/internal/resolution/domain/ResolutionTag.java
+++ b/src/main/java/org/sopt/makers/internal/resolution/domain/ResolutionTag.java
@@ -1,41 +1,24 @@
 package org.sopt.makers.internal.resolution.domain;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.sopt.makers.internal.exception.ClientBadRequestException;
 
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
 public enum ResolutionTag {
 
-	STARTUP_FOUNDATION("창업 기반", 1),
-	PROBLEM_SOLVING("문제해결 능력", 2),
-	EXPERTISE_DEVELOPMENT("전문성 강화", 3),
-	COLLABORATION_EXPERIENCE("협업 경험", 4),
-	PRODUCT_RELEASE("프로덕트 릴리즈", 5),
-	NETWORKING("네트워킹", 6);
+	PRODUCT_RELEASE("제품 출시"),
+	NETWORKING("네트워킹"),
+	COLLABORATION_EXPERIENCE("협업 경험"),
+	STARTUP("창업"),
+	SKILL_UP("스킬업");
 
-	private final String value;
-	private final int index;
+	private final String description;
 
-	private static final Map<String, ResolutionTag> TAG_MAP = Arrays.stream(ResolutionTag.values())
-		.collect(Collectors.toMap(tag -> tag.value, tag -> tag));
-
-	ResolutionTag(String value, int index) {
-		this.value = value;
-		this.index = index;
-	}
-
-	public static String getTagIds(List<String> tagNames) {
-		return tagNames.stream()
-			.map(tag -> String.valueOf(TAG_MAP.get(validate(tag)).index))
-			.collect(Collectors.joining(","));
-	}
-
-	public static String validate(String value) {
-		if (TAG_MAP.get(value) == null) {
-			throw new ClientBadRequestException("Unknown Tag Name");
 		}
 		return value;
 	}

--- a/src/main/java/org/sopt/makers/internal/resolution/domain/UserResolution.java
+++ b/src/main/java/org/sopt/makers/internal/resolution/domain/UserResolution.java
@@ -1,10 +1,12 @@
 package org.sopt.makers.internal.resolution.domain;
 
 import lombok.*;
+import org.sopt.makers.internal.common.GenericEnumListConverter;
 import org.sopt.makers.internal.domain.Member;
 import org.sopt.makers.internal.domain.common.AuditingTimeEntity;
 
 import javax.persistence.*;
+import java.util.List;
 
 @Entity
 @Getter
@@ -27,6 +29,13 @@ public class UserResolution extends AuditingTimeEntity {
     @Column(nullable = false)
     private Integer generation;
 
-    @Column
-    private String tagIds;
+    @Convert(converter = ResolutionTagConverter.class)
+    private List<ResolutionTag> resolutionTags;
+
+    @Converter(autoApply = true)
+    public static class ResolutionTagConverter extends GenericEnumListConverter<ResolutionTag> {
+        public ResolutionTagConverter() {
+            super(ResolutionTag.class);
+        }
+    }
 }

--- a/src/main/java/org/sopt/makers/internal/resolution/dto/request/ResolutionSaveRequest.java
+++ b/src/main/java/org/sopt/makers/internal/resolution/dto/request/ResolutionSaveRequest.java
@@ -3,9 +3,24 @@ package org.sopt.makers.internal.resolution.dto.request;
 import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import org.sopt.makers.internal.domain.Member;
+import org.sopt.makers.internal.resolution.domain.ResolutionTag;
+import org.sopt.makers.internal.resolution.domain.UserResolution;
+
+import javax.validation.constraints.NotBlank;
 
 public record ResolutionSaveRequest(
 	List<String> tags,
 	@Schema(required = true)
+	@NotBlank(message = "Content cannot be empty or blank.")
 	String content
-) {}
+) {
+	public UserResolution toDomain(Member member, Integer generation) {
+		return UserResolution.builder()
+				.member(member)
+				.resolutionTags(ResolutionTag.fromStringArray(tags))
+				.content(content)
+				.generation(generation)
+				.build();
+	}
+}

--- a/src/main/java/org/sopt/makers/internal/resolution/dto/response/ResolutionResponse.java
+++ b/src/main/java/org/sopt/makers/internal/resolution/dto/response/ResolutionResponse.java
@@ -1,12 +1,14 @@
 package org.sopt.makers.internal.resolution.dto.response;
 
+import org.sopt.makers.internal.resolution.domain.ResolutionTag;
+
 import java.util.List;
 
 public record ResolutionResponse(
 
         String memberImageUrl,
         String memberName,
-        List<String> tags,
+        List<ResolutionTag> tags,
         String content
 ) {
 }

--- a/src/main/java/org/sopt/makers/internal/resolution/mapper/UserResolutionResponseMapper.java
+++ b/src/main/java/org/sopt/makers/internal/resolution/mapper/UserResolutionResponseMapper.java
@@ -1,6 +1,7 @@
 package org.sopt.makers.internal.resolution.mapper;
 
 import org.sopt.makers.internal.domain.Member;
+import org.sopt.makers.internal.resolution.domain.ResolutionTag;
 import org.sopt.makers.internal.resolution.domain.UserResolution;
 import org.sopt.makers.internal.resolution.dto.response.ResolutionResponse;
 import org.sopt.makers.internal.resolution.dto.response.ResolutionValidResponse;
@@ -11,7 +12,7 @@ import java.util.List;
 @Component
 public class UserResolutionResponseMapper {
 
-    public ResolutionResponse toResolutionResponse(Member member, List<String> tags, String content) {
+    public ResolutionResponse toResolutionResponse(Member member, List<ResolutionTag> tags, String content) {
         return new ResolutionResponse(
             member.getProfileImage(),
             member.getName(),

--- a/src/main/java/org/sopt/makers/internal/resolution/service/UserResolutionService.java
+++ b/src/main/java/org/sopt/makers/internal/resolution/service/UserResolutionService.java
@@ -2,7 +2,6 @@ package org.sopt.makers.internal.resolution.service;
 
 import static org.sopt.makers.internal.common.Constant.*;
 
-import java.util.List;
 import java.util.Optional;
 import org.sopt.makers.internal.domain.Member;
 import org.sopt.makers.internal.exception.ClientBadRequestException;
@@ -18,7 +17,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
-import lombok.val;
 
 @Service
 @RequiredArgsConstructor
@@ -45,10 +43,8 @@ public class UserResolutionService {
 
 	@Transactional(readOnly = true)
 	public ResolutionValidResponse validation(Long memberId) {
-		val member = getMemberById(memberId);
-		val isRegistration = existsCurrentResolution(member);
-
-		return userResolutionResponseMapper.toResolutionValidResponse(isRegistration);
+		Member member = getMemberById(memberId);
+		return userResolutionResponseMapper.toResolutionValidResponse(existsCurrentResolution(member));
 	}
 
 	@Transactional

--- a/src/main/java/org/sopt/makers/internal/resolution/service/UserResolutionService.java
+++ b/src/main/java/org/sopt/makers/internal/resolution/service/UserResolutionService.java
@@ -50,6 +50,7 @@ public class UserResolutionService {
 		validateGeneration(member);
 		validateExistingResolution(member);
 
+		userResolutionRepository.save(request.toDomain(member, CURRENT_GENERATION));
 	}
 
 	private Member validateMember(Long writerId) {
@@ -70,12 +71,6 @@ public class UserResolutionService {
 		if (existsCurrentResolution(member)) {
 			throw new ClientBadRequestException("Already exist user resolution message");
 		}
-		UserResolution userResolution = UserResolution.builder()
-			.member(member)
-			.tagIds(ResolutionTag.getTagIds(request.tags()))
-			.content(request.content())
-			.generation(CURRENT_GENERATION).build();
-		userResolutionRepository.save(userResolution);
 	}
 
 	private boolean existsCurrentResolution(Member member) {

--- a/src/main/java/org/sopt/makers/internal/resolution/service/UserResolutionService.java
+++ b/src/main/java/org/sopt/makers/internal/resolution/service/UserResolutionService.java
@@ -32,8 +32,7 @@ public class UserResolutionService {
 	public ResolutionResponse getResolution(Long memberId) {
 		val member = getMemberById(memberId);
 		val resolution = UserResolutionServiceUtil.findUserResolutionByMember(member, userResolutionRepository);
-		val tags = ResolutionTag.getTagNames(resolution.getTagIds());
-		return userResolutionResponseMapper.toResolutionResponse(member, tags, resolution.getContent());
+		return userResolutionResponseMapper.toResolutionResponse(member, resolution.getResolutionTags(), resolution.getContent());
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/org/sopt/makers/internal/resolution/service/UserResolutionService.java
+++ b/src/main/java/org/sopt/makers/internal/resolution/service/UserResolutionService.java
@@ -6,8 +6,6 @@ import org.sopt.makers.internal.domain.Member;
 import org.sopt.makers.internal.exception.ClientBadRequestException;
 import org.sopt.makers.internal.exception.NotFoundDBEntityException;
 import org.sopt.makers.internal.repository.MemberRepository;
-import org.sopt.makers.internal.resolution.domain.ResolutionTag;
-import org.sopt.makers.internal.resolution.domain.UserResolution;
 import org.sopt.makers.internal.resolution.dto.request.ResolutionSaveRequest;
 import org.sopt.makers.internal.resolution.dto.response.ResolutionResponse;
 import org.sopt.makers.internal.resolution.dto.response.ResolutionValidResponse;
@@ -48,14 +46,28 @@ public class UserResolutionService {
 
 	@Transactional
 	public void createResolution(Long writerId, ResolutionSaveRequest request) {
-		val member = getMemberById(writerId);
+		Member member = validateMember(writerId);
+		validateGeneration(member);
+		validateExistingResolution(member);
+
+	}
+
+	private Member validateMember(Long writerId) {
+		Member member = getMemberById(writerId);
 		if (member.getGeneration() == null) {
 			throw new ClientBadRequestException("Not exists profile info");
 		}
-		if (!member.getGeneration().equals(CURRENT_GENERATION)) {  // 기수 갱신 시 조건 변경
+		return member;
+	}
+
+	private void validateGeneration(Member member) {
+		if (!member.getGeneration().equals(CURRENT_GENERATION)) {
 			throw new ClientBadRequestException("Only new generation can enroll resolution");
 		}
-		if (existsCurrentResolution(member)) {  // TODO 기수마다 1개씩 가능하도록 수정
+	}
+
+	private void validateExistingResolution(Member member) {
+		if (existsCurrentResolution(member)) {
 			throw new ClientBadRequestException("Already exist user resolution message");
 		}
 		UserResolution userResolution = UserResolution.builder()


### PR DESCRIPTION
## 🐬 요약
36기 새롭게 바뀐 타임캡솝 태그값들을 수정하였습니다.

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [ ] 기능 개발
- [x] 코드 스타일 수정 (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
- 태그값들 새롭게 수정된 값으로 변경
- 태그값들 인덱스가 아닌 값이 디비에 저장되도록 변경
- 타임캡솝 메시지 작성 성공 시 response 형식 수정

## ‼️ PR 참고
- UserResolutionService의 getResoution(조회하는 함수)에서 한 줄의 코드 수정이 있었습니다. 같은 함수 내에서 작업이 충돌될 것 같아 이부분 말씀드립니다!
- 두 명 모두 수정작업 완료한 이후 resolution->timecapsop으로 네이밍 변경하는 작업하면 좋을 것 같습니다!

## 🌟 관련 이슈
close: #593 
