### PR TITLE
[Chore] 타임캡솝 조회 및 삭제 기능 수정 및 추가

### DIFF
--- a/src/main/java/org/sopt/makers/internal/resolution/controller/UserResolutionController.java
+++ b/src/main/java/org/sopt/makers/internal/resolution/controller/UserResolutionController.java
@@ -53,4 +53,13 @@ public class UserResolutionController {
 		return ResponseEntity.status(HttpStatus.OK).body(userResolutionService.validation(memberDetails.getId()));
 	}
 
+	@Operation(summary = "다짐 메세지 삭제")
+	@DeleteMapping
+	public ResponseEntity<Void> deleteResolution(
+			@Parameter(hidden = true) @AuthenticationPrincipal InternalMemberDetails memberDetails
+	){
+		userResolutionService.deleteResolution(memberDetails.getId());
+		return ResponseEntity.status(HttpStatus.OK).build();
+	}
+
 }

--- a/src/main/java/org/sopt/makers/internal/resolution/controller/UserResolutionController.java
+++ b/src/main/java/org/sopt/makers/internal/resolution/controller/UserResolutionController.java
@@ -59,7 +59,7 @@ public class UserResolutionController {
 			@Parameter(hidden = true) @AuthenticationPrincipal InternalMemberDetails memberDetails
 	){
 		userResolutionService.deleteResolution(memberDetails.getId());
-		return ResponseEntity.status(HttpStatus.OK).build();
+		return ResponseEntity.noContent().build();
 	}
 
 }

--- a/src/main/java/org/sopt/makers/internal/resolution/service/UserResolutionService.java
+++ b/src/main/java/org/sopt/makers/internal/resolution/service/UserResolutionService.java
@@ -30,8 +30,6 @@ public class UserResolutionService {
 
 	private final UserResolutionResponseMapper userResolutionResponseMapper;
 
-	private final static String DEFAULT_PROFILE_IMAGE = "";
-
 	@Transactional(readOnly = true)
 	public ResolutionResponse getResolution(Long memberId) {
 		Member member = getMemberById(memberId);

--- a/src/main/java/org/sopt/makers/internal/resolution/service/UserResolutionService.java
+++ b/src/main/java/org/sopt/makers/internal/resolution/service/UserResolutionService.java
@@ -66,6 +66,37 @@ public class UserResolutionService {
 		userResolutionRepository.save(userResolution);
 	}
 
+	@Transactional
+	public void deleteResolution(Long memberId){
+		Member member = validateMember(memberId);
+		validateGeneration(member);
+		validateNoExistingResolution(member);
+
+		UserResolution resolution = UserResolutionServiceUtil.findUserResolutionByMember(member, userResolutionRepository);
+
+		userResolutionRepository.delete(resolution);
+	}
+
+	private Member validateMember(Long memberId){
+		Member member = getMemberById(memberId);
+		if (member.getGeneration() == null) {
+			throw new ClientBadRequestException("Not exists profile info");
+		}
+		return member;
+	}
+
+	private void validateGeneration(Member member){
+		if(!member.getGeneration().equals(CURRENT_GENERATION)){
+			throw new ClientBadRequestException("Only new generation can enroll resolution");
+		}
+	}
+
+	private void validateNoExistingResolution(Member member){
+		if(!existsCurrentResolution(member)){
+			throw new ClientBadRequestException("No exist user resolution message");
+		}
+	}
+
 	private boolean existsCurrentResolution(Member member) {
 		return userResolutionRepository.existsByMemberAndGeneration(member, CURRENT_GENERATION);
 	}

--- a/src/main/java/org/sopt/makers/internal/resolution/service/UserResolutionService.java
+++ b/src/main/java/org/sopt/makers/internal/resolution/service/UserResolutionService.java
@@ -74,32 +74,24 @@ public class UserResolutionService {
 	}
 
 	@Transactional
-	public void deleteResolution(Long memberId){
-		Member member = validateMember(memberId);
-		validateGeneration(member);
-		validateNoExistingResolution(member);
+	public void deleteResolution(Long memberId) {
+		Member member = getMemberById(memberId);
+		validateResolutionDeletion(member);
 
-		UserResolution resolution = UserResolutionServiceUtil.findUserResolutionByMember(member, userResolutionRepository);
+		UserResolution resolution = userResolutionRepository.findUserResolutionByMemberAndGeneration(member, CURRENT_GENERATION)
+				.orElseThrow(() -> new NotFoundDBEntityException("Not exists resolution message"));
 
 		userResolutionRepository.delete(resolution);
 	}
 
-	private Member validateMember(Long memberId){
-		Member member = getMemberById(memberId);
+	private void validateResolutionDeletion(Member member) {
 		if (member.getGeneration() == null) {
 			throw new ClientBadRequestException("Not exists profile info");
 		}
-		return member;
-	}
-
-	private void validateGeneration(Member member){
-		if(!member.getGeneration().equals(CURRENT_GENERATION)){
+		if (!member.getGeneration().equals(CURRENT_GENERATION)) {
 			throw new ClientBadRequestException("Only new generation can enroll resolution");
 		}
-	}
-
-	private void validateNoExistingResolution(Member member){
-		if(!existsCurrentResolution(member)){
+		if (!userResolutionRepository.existsByMemberAndGeneration(member, CURRENT_GENERATION)) {
 			throw new ClientBadRequestException("No exist user resolution message");
 		}
 	}


### PR DESCRIPTION
## 🐬 요약
PR의 요약을 작성해주세요!

- 36기 타임캡솝의 조회 관련 로직을 수정하고, 삭제하는 로직을 추가했습니다.

## 👻 유형

- [ ] 버그 수정
- [x] 기능 개발
- [x] 코드 스타일 수정 (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
- [x]  `메시지 조회 API` 수정
    - [x]  다짐메세지를 작성안한 사람 -> 조회 시 태그와 내용이 null로 보내짐
    - [x]  다짐메시지를 작성한 사람 -> 태그와 내용을 이전과 같은 형태로 전달

<img width="1407" alt="image" src="https://github.com/user-attachments/assets/a124f887-fd9d-4c66-b468-34421f54cdb8" />

<img width="1406" alt="image" src="https://github.com/user-attachments/assets/109f3fc3-260f-420b-8e9b-98042ddf3fad" />

- [x]  `메시지 삭제 API` 구현

<img width="1414" alt="image" src="https://github.com/user-attachments/assets/48b44850-dc17-4294-9763-7b7996d8e9ae" />

## 🌟 관련 이슈

close: #593 
