### PR TITLE
[Refac] 불필요한 Column 어노테이션 삭제

### DIFF
--- a/src/main/java/org/sopt/makers/internal/community/domain/CommunityPost.java
+++ b/src/main/java/org/sopt/makers/internal/community/domain/CommunityPost.java
@@ -57,10 +57,6 @@ public class CommunityPost extends AuditingTimeEntity {
     @Column(nullable = false)
     private Boolean isHot = false;
 
-    @Builder.Default
-    @Column(nullable = false)
-    private Boolean isSopticle = false;
-
     private String sopticleUrl;
 
     @Builder.Default

--- a/src/main/java/org/sopt/makers/internal/dto/community/CommunityPostVo.java
+++ b/src/main/java/org/sopt/makers/internal/dto/community/CommunityPostVo.java
@@ -12,7 +12,6 @@ public record CommunityPostVo(
         Boolean isQuestion,
         Boolean isBlindWriter,
         String sopticleUrl,
-        Boolean isSopticle,
         Boolean isReported,
         LocalDateTime createdAt,
         LocalDateTime updatedAt

--- a/src/main/java/org/sopt/makers/internal/dto/community/PostResponse.java
+++ b/src/main/java/org/sopt/makers/internal/dto/community/PostResponse.java
@@ -22,7 +22,6 @@ public record PostResponse(
         String[] images,
         Boolean isQuestion,
         Boolean isBlindWriter,
-        Boolean isSopticle,
         String sopticleUrl,
         AnonymousProfileVo anonymousProfile,
         LocalDateTime createdAt,

--- a/src/main/java/org/sopt/makers/internal/mapper/CommunityResponseMapper.java
+++ b/src/main/java/org/sopt/makers/internal/mapper/CommunityResponseMapper.java
@@ -68,7 +68,7 @@ public class CommunityResponseMapper {
 
     public CommunityPostVo toPostVo(CommunityPost post) {
         return new CommunityPostVo(post.getId(), post.getCategoryId(), post.getTitle(), post.getContent(), post.getHits(),
-                post.getImages(), post.getIsQuestion(), post.getIsBlindWriter(), post.getSopticleUrl(), post.getIsSopticle(), post.getIsReported(), post.getCreatedAt(), post.getUpdatedAt());
+                post.getImages(), post.getIsQuestion(), post.getIsBlindWriter(), post.getSopticleUrl(), post.getIsReported(), post.getCreatedAt(), post.getUpdatedAt());
     }
 
     public PostResponse toPostResponse (CommunityPostMemberVo dao, List<CommentDao> commentDaos, Long memberId, AnonymousPostProfile anonymousPostProfile, Boolean isLiked, Integer likes) {
@@ -80,7 +80,7 @@ public class CommunityResponseMapper {
         val comments = commentDaos.stream().map(comment -> toCommentResponse(comment, memberId, null)).collect(Collectors.toList());
         val anonymousProfile = dao.post().isBlindWriter() && anonymousPostProfile != null ? toAnonymousPostProfileVo(anonymousPostProfile) : null;
         return new PostResponse(post.id(), member, writerId, isMine, isLiked, likes, post.categoryId(), category.name(), post.title(), post.content(), post.hits(),
-                comments.size(), post.images(), post.isQuestion(), post.isBlindWriter(), post.isSopticle(), post.sopticleUrl(), anonymousProfile, post.createdAt(), comments);
+                comments.size(), post.images(), post.isQuestion(), post.isBlindWriter(), post.sopticleUrl(), anonymousProfile, post.createdAt(), comments);
     }
 
     private AnonymousProfileVo toAnonymousPostProfileVo(AnonymousPostProfile anonymousPostProfile) {


### PR DESCRIPTION
## 🐬 요약
클라측 요청 사항에 따라
/api/v1/community/posts 에서  isSopticle 필드를 사용하지 않고도 categoryId로 솝티클 여부 판단이 가능해서 해당 값을 지우도록 수정했습니다!

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [ ] 기능 개발
- [x] 코드 스타일 수정 (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
PR에 담긴 작업 내용을 작성해주세요!

- VO 수정
- PostReponse 수정
- Mapper 수정
- CommunityPost 수정
- DB 반영

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #603 
