### PR TITLE
[Fix] 공홈 API 요청 시 part 값 변환 로직 삭제

### DIFF
--- a/src/main/java/org/sopt/makers/internal/community/service/SopticleService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/SopticleService.java
@@ -27,7 +27,7 @@ public class SopticleService {
     public SopticleScrapedResponse createSopticle(String sopticleUrl, Member writer) {
         MemberSoptActivity activity = getLatestActivity(writer.getId());
         SopticleVo sopticleVo = buildSopticleVo(sopticleUrl, writer, activity);
-
+        System.out.println(sopticleVo);
         ResponseEntity<SopticleScrapedResponse> response = officialHomeClient.createSopticle(authConfig.getOfficialSopticleApiSecretKey(), sopticleVo);
         validateInternalApiResponse(response);
 
@@ -44,7 +44,7 @@ public class SopticleService {
                 writer.getName(),
                 writer.getProfileImage(),
                 writer.getGeneration(),
-                Part.fromTitle(activity.getPart()).getKey()
+                activity.getPart()
         );
         return new SopticleVo(sopticleUrl, userVo);
     }

--- a/src/main/java/org/sopt/makers/internal/domain/Part.java
+++ b/src/main/java/org/sopt/makers/internal/domain/Part.java
@@ -20,13 +20,4 @@ public enum Part {
     public String getKey() {
         return name();
     }
-
-    public static Part fromTitle(String partTitle) {
-        for (Part part : Part.values()) {
-            if (part.getTitle().equals(partTitle)) {
-                return part;
-            }
-        }
-        throw new IllegalArgumentException("Unknown part title: " + partTitle);
-    }
 }


### PR DESCRIPTION
## 🐬 요약
공홈 API 요청 시 part 값 변환 로직 삭제

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [x] 버그 수정
- [ ] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
- 공홈 API 요청 시 part 값 변환 로직 삭제

## 🌟 관련 이슈

- closed #607 
