### PR TITLE
[Fix]: Subject 필드를 리스트 형태로 받아오도록 수정

### DIFF
--- a/src/main/java/org/sopt/makers/internal/community/dto/response/ReviewCountResponse.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/response/ReviewCountResponse.java
@@ -14,7 +14,7 @@ public record ReviewCountResponse(
             int generation,
             String description,
             String part,
-            String subject,
+            List<String> subject,
             String thumbnailUrl,
             String platform,
             String url


### PR DESCRIPTION
## 🐬 요약
알림서버의 /api/v1/members/property API에서 외부 API 응답 파싱 오류가 발생했습니다.

ReviewCountResponse.ReviewDto.subject 필드 타입이 String으로 선언되어 있으나, 
실제 응답은 Array 형태(List)로 반환되고 있어 이로 인해 400 Bad Request 발생 중인 상황입니다.

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [x] 버그 수정
- [ ] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
PR에 담긴 작업 내용을 작성해주세요!

- 필드 형식 변경

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #623 
