### PR TITLE
[Feat] 인기글 3개 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/makers/internal/community/controller/CommunityController.java
+++ b/src/main/java/org/sopt/makers/internal/community/controller/CommunityController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.sopt.makers.internal.common.util.InfiniteScrollUtil;
+import org.sopt.makers.internal.community.domain.CommunityPost;
 import org.sopt.makers.internal.community.dto.request.CommentSaveRequest;
 import org.sopt.makers.internal.community.dto.request.CommunityHitRequest;
 import org.sopt.makers.internal.community.dto.request.PostSaveRequest;
@@ -204,6 +205,12 @@ public class CommunityController {
 
         communityPostService.unlikePost(memberDetails.getId(), postId);
         return ResponseEntity.status(HttpStatus.OK).body(Map.of("커뮤니티 게시글 좋아요 취소 성공", true));
+    }
+
+    @Operation(summary = "커뮤니티 홈 인기글 조회 API")
+    @GetMapping("/posts/popular")
+    public ResponseEntity<List<PopularPostResponse>> getPopularPost() {
+        return ResponseEntity.ok(communityPostService.getPopularPosts());
     }
 
     @Operation(summary = "핫 게시물 조회 API")

--- a/src/main/java/org/sopt/makers/internal/community/dto/MemberVo.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/MemberVo.java
@@ -1,7 +1,11 @@
 package org.sopt.makers.internal.community.dto;
 
+import lombok.val;
+import org.sopt.makers.internal.member.domain.Member;
 import org.sopt.makers.internal.member.domain.MemberCareer;
 import org.sopt.makers.internal.member.domain.MemberSoptActivity;
+
+import java.util.Comparator;
 
 public record MemberVo(
         Long id,
@@ -9,4 +13,20 @@ public record MemberVo(
         String profileImage,
         MemberSoptActivity activity,
         MemberCareer careers
-) {}
+) {
+    public static MemberVo of(Member member) {
+        MemberCareer career = (member.getCareers() == null || member.getCareers().stream().noneMatch(MemberCareer::getIsCurrent)) ?
+                null : member.getCareers().stream().filter(MemberCareer::getIsCurrent).toList().get(0);
+        MemberSoptActivity activity = member.getActivities().stream()
+                .max(Comparator.comparingInt(MemberSoptActivity::getGeneration))
+                .orElse(null);
+
+        return new MemberVo(
+                member.getId(),
+                member.getName(),
+                member.getProfileImage(),
+                activity,
+                career
+        );
+    }
+}

--- a/src/main/java/org/sopt/makers/internal/community/dto/response/PopularPostResponse.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/response/PopularPostResponse.java
@@ -1,0 +1,22 @@
+package org.sopt.makers.internal.community.dto.response;
+
+import org.sopt.makers.internal.community.domain.CommunityPost;
+import org.sopt.makers.internal.community.dto.MemberVo;
+
+public record PopularPostResponse(
+        Long id,
+        String category,
+        String title,
+        MemberVo member,
+        Integer hits
+) {
+    public static PopularPostResponse of(CommunityPost post, String categoryName) {
+        return new PopularPostResponse(
+                post.getId(),
+                categoryName,
+                post.getTitle(),
+                MemberVo.of(post.getMember()),
+                post.getHits()
+        );
+    }
+}

--- a/src/main/java/org/sopt/makers/internal/community/mapper/CommunityResponseMapper.java
+++ b/src/main/java/org/sopt/makers/internal/community/mapper/CommunityResponseMapper.java
@@ -3,6 +3,7 @@ package org.sopt.makers.internal.community.mapper;
 import lombok.val;
 import org.sopt.makers.internal.community.dto.*;
 import org.sopt.makers.internal.community.dto.response.*;
+import org.sopt.makers.internal.community.repository.CommunityQueryRepository;
 import org.sopt.makers.internal.member.domain.Member;
 import org.sopt.makers.internal.member.domain.MemberCareer;
 import org.sopt.makers.internal.community.domain.anonymous.AnonymousCommentProfile;
@@ -18,7 +19,7 @@ import java.util.stream.Collectors;
 @Component
 public class CommunityResponseMapper {
     public CommentResponse toCommentResponse(CommentDao dao, Long memberId, AnonymousCommentProfile profile) {
-        val member = dao.comment().getIsBlindWriter() ? null : toMemberResponse(dao.member());
+        val member = dao.comment().getIsBlindWriter() ? null : MemberVo.of(dao.member());
         val comment = dao.comment();
         val anonymousProfile = dao.comment().getIsBlindWriter() && profile != null? toAnonymousCommentProfileVo(profile) : null;
         val isMine = Objects.equals(dao.member().getId(), memberId);
@@ -27,7 +28,7 @@ public class CommunityResponseMapper {
     }
 
     public CommunityPostMemberVo toCommunityVo(CategoryPostMemberDao dao) {
-        val member = toMemberResponse(dao.member());
+        val member = MemberVo.of(dao.member());
         val category = toCategoryResponse(dao.category());
         val post = toPostVo(dao.posts());
         return new CommunityPostMemberVo(member, post, category);
@@ -50,15 +51,6 @@ public class CommunityResponseMapper {
         val isMine = Objects.equals(post.member().id(), memberId);
         val anonymousProfile = post.post().isBlindWriter() && anonymousPostProfile != null ? toAnonymousPostProfileVo(anonymousPostProfile) : null;
         return new PostDetailResponse(member, post.post(), post.category(), isMine, isLiked, likes, anonymousProfile);
-    }
-
-    public MemberVo toMemberResponse(Member member) {
-        if(member == null) return null;
-        val career = (member.getCareers() == null || member.getCareers().stream().noneMatch(MemberCareer::getIsCurrent)) ?
-                null : member.getCareers().stream().filter(MemberCareer::getIsCurrent).toList().get(0);
-        member.getActivities().sort((act1, act2) -> (act2.getGeneration() - act1.getGeneration()));
-        return new MemberVo(member.getId(),member.getName(), member.getProfileImage(),
-                member.getActivities().get(0), career);
     }
 
     public CategoryVo toCategoryResponse(Category category) {

--- a/src/main/java/org/sopt/makers/internal/community/repository/CommunityQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/community/repository/CommunityQueryRepository.java
@@ -105,6 +105,16 @@ public class CommunityQueryRepository {
                 .where(posts.id.eq(postId)).distinct().fetchOne();
     }
 
+    public String getCategoryNameById(Long categoryId) {
+        QCategory category = QCategory.category;
+
+        return queryFactory
+                .select(category.name)
+                .from(category)
+                .where(category.id.eq(categoryId))
+                .fetchOne();
+    }
+
     public List<CommentDao> findCommentByPostId(Long postId, Long memberId, boolean isBlockedOn) {
         val comment = QCommunityComment.communityComment;
         val member = QMember.member;

--- a/src/main/java/org/sopt/makers/internal/community/repository/post/CommunityPostRepository.java
+++ b/src/main/java/org/sopt/makers/internal/community/repository/post/CommunityPostRepository.java
@@ -17,6 +17,8 @@ public interface CommunityPostRepository extends JpaRepository<CommunityPost, Lo
 
     Integer countAllByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime start, LocalDateTime end);
 
+    List<CommunityPost> findTop3ByCreatedAtAfterOrderByHitsDesc(LocalDateTime oneMonthAgo);
+
     @Modifying
     @Query("UPDATE CommunityPost p SET p.hits = p.hits + 1 WHERE p.id = :postId")
     void increaseHitsDirect(@Param("postId") Long postId);


### PR DESCRIPTION
## 🐬 요약
인기글 3개 조회 API 구현

## 👻 유형
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [x] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용

- 인기글 3개 조회 API 구현
- CommunityMapper 내 Member -> MemberVo 변환 메소드를 MemberVo DTO 안으로 위치 변경 및 기존 정렬 로직 올바르게 수정
  - 이유1: controller에서 reponse로 변환하는 메소드로 사용하는게 아닌 상황입니다
  - 이유2: controller가 아닌 타 파일 내에서 사용 시 Mapper 클래스 선언 없이 사용하고 싶었습니다
  - 이유3: MemberVo DTO 변환 책임을 DTO 파일에게 주고 싶습니다
 - 카테고리 id를 name으로 변경하는 로직을 다른 메소드에 있던 query문 활용해서 queryRepository에 빼두기
   - 이유1: Enum으로 카테고리가 선언되어 있지 않아 선언하고 변환할까 하다가, enum으로 관리할 시 parent 카테고리 포함 너무 많아지게 될 것 같아 복잡할 것 같았습니다
   - 이유2: 이후 커뮤니티 카테고리 수정 작업 시 많은 카테고리를 코드로 유지보수하기 까다로울 것 같아, db에서만 관리하자 싶어 query문 활용했습니다!

## 🌟 관련 이슈

- closed #627 
