### PR TITLE
[Refac] 인기글 조회 API 요구사항 변경 및 조회 속도 향상

### DIFF
--- a/src/main/java/org/sopt/makers/internal/community/controller/CommunityController.java
+++ b/src/main/java/org/sopt/makers/internal/community/controller/CommunityController.java
@@ -209,8 +209,10 @@ public class CommunityController {
 
     @Operation(summary = "커뮤니티 홈 인기글 조회 API")
     @GetMapping("/posts/popular")
-    public ResponseEntity<List<PopularPostResponse>> getPopularPost() {
-        return ResponseEntity.ok(communityPostService.getPopularPosts());
+    public ResponseEntity<List<PopularPostResponse>> getPopularPost(
+            @Parameter(description = "조회할 인기글 개수 (기본값: 3)")
+            @RequestParam(defaultValue = "3") int limit) {
+        return ResponseEntity.ok(communityPostService.getPopularPosts(limit));
     }
 
     @Operation(summary = "커뮤니티 홈 최근 솝티클 목록 조회 API")

--- a/src/main/java/org/sopt/makers/internal/community/dto/MemberVo.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/MemberVo.java
@@ -1,6 +1,5 @@
 package org.sopt.makers.internal.community.dto;
 
-import lombok.val;
 import org.sopt.makers.internal.member.domain.Member;
 import org.sopt.makers.internal.member.domain.MemberCareer;
 import org.sopt.makers.internal.member.domain.MemberSoptActivity;

--- a/src/main/java/org/sopt/makers/internal/community/dto/response/PopularPostResponse.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/response/PopularPostResponse.java
@@ -11,6 +11,7 @@ public record PopularPostResponse(
         Integer hits
 ) {
     public static PopularPostResponse of(CommunityPost post, String categoryName) {
+        String title = post.getTitle().isEmpty() ? post.getContent() : post.getTitle();
 
         return new PopularPostResponse(
                 post.getId(),

--- a/src/main/java/org/sopt/makers/internal/community/dto/response/PopularPostResponse.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/response/PopularPostResponse.java
@@ -11,12 +11,10 @@ public record PopularPostResponse(
         Integer hits
 ) {
     public static PopularPostResponse of(CommunityPost post, String categoryName) {
-        String title = post.getTitle().isEmpty() ? post.getContent() : post.getTitle();
-
         return new PopularPostResponse(
                 post.getId(),
                 categoryName,
-                title,
+                post.getTitle(),
                 MemberNameAndProfileImageResponse.from(post.getMember()),
                 post.getHits()
         );

--- a/src/main/java/org/sopt/makers/internal/community/dto/response/PopularPostResponse.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/response/PopularPostResponse.java
@@ -1,21 +1,22 @@
 package org.sopt.makers.internal.community.dto.response;
 
 import org.sopt.makers.internal.community.domain.CommunityPost;
-import org.sopt.makers.internal.community.dto.MemberVo;
+import org.sopt.makers.internal.member.dto.response.MemberNameAndProfileImageResponse;
 
 public record PopularPostResponse(
         Long id,
         String category,
         String title,
-        MemberVo member,
+        MemberNameAndProfileImageResponse member,
         Integer hits
 ) {
     public static PopularPostResponse of(CommunityPost post, String categoryName) {
+
         return new PopularPostResponse(
                 post.getId(),
                 categoryName,
-                post.getTitle(),
-                MemberVo.of(post.getMember()),
+                title,
+                MemberNameAndProfileImageResponse.from(post.getMember()),
                 post.getHits()
         );
     }

--- a/src/main/java/org/sopt/makers/internal/community/repository/CommunityQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/community/repository/CommunityQueryRepository.java
@@ -194,7 +194,7 @@ public class CommunityQueryRepository {
             .execute();
     }
 
-    public List<CommunityPost> findPopularPosts() {
+    public List<CommunityPost> findPopularPosts(int limitCount) {
         QCommunityPost communityPost = QCommunityPost.communityPost;
         QMember member = QMember.member;
 
@@ -205,7 +205,7 @@ public class CommunityQueryRepository {
                 .leftJoin(communityPost.member, member).fetchJoin()
                 .where(communityPost.createdAt.after(oneMonthAgo))
                 .orderBy(communityPost.hits.desc())
-                .limit(3)
+                .limit(limitCount)
                 .fetch();
     }
     

--- a/src/main/java/org/sopt/makers/internal/community/repository/CommunityQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/community/repository/CommunityQueryRepository.java
@@ -20,7 +20,10 @@ import org.sopt.makers.internal.member.domain.QMemberSoptActivity;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
@@ -104,6 +107,25 @@ public class CommunityQueryRepository {
                 .leftJoin(member.careers, careers)
                 .innerJoin(category).on(posts.categoryId.eq(category.id))
                 .where(posts.id.eq(postId)).distinct().fetchOne();
+    }
+
+    public Map<Long, String> getCategoryNamesByIds(List<Long> categoryIds) {
+        if (categoryIds == null || categoryIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        QCategory category = QCategory.category;
+
+        return queryFactory
+                .select(category.id, category.name)
+                .from(category)
+                .where(category.id.in(categoryIds))
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        tuple -> tuple.get(category.id),
+                        tuple -> tuple.get(category.name) // category.name은 NOT NULL 보장
+                ));
     }
 
     public String getCategoryNameById(Long categoryId) {

--- a/src/main/java/org/sopt/makers/internal/community/repository/CommunityQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/community/repository/CommunityQueryRepository.java
@@ -19,6 +19,7 @@ import org.sopt.makers.internal.member.domain.QMemberCareer;
 import org.sopt.makers.internal.member.domain.QMemberSoptActivity;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -171,6 +172,21 @@ public class CommunityQueryRepository {
             .execute();
     }
 
+    public List<CommunityPost> findPopularPosts() {
+        QCommunityPost communityPost = QCommunityPost.communityPost;
+        QMember member = QMember.member;
+
+        LocalDateTime oneMonthAgo = LocalDateTime.now().minusMonths(1);
+
+        return queryFactory
+                .selectFrom(communityPost)
+                .leftJoin(communityPost.member, member).fetchJoin()
+                .where(communityPost.createdAt.after(oneMonthAgo))
+                .orderBy(communityPost.hits.desc())
+                .limit(3)
+                .fetch();
+    }
+    
     private BooleanExpression ltPostId(Long cursor) {
         val posts = QCommunityPost.communityPost;
         if(cursor == null || cursor == 0) return null;

--- a/src/main/java/org/sopt/makers/internal/community/repository/post/CommunityPostRepository.java
+++ b/src/main/java/org/sopt/makers/internal/community/repository/post/CommunityPostRepository.java
@@ -17,8 +17,6 @@ public interface CommunityPostRepository extends JpaRepository<CommunityPost, Lo
 
     Integer countAllByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime start, LocalDateTime end);
 
-    List<CommunityPost> findTop3ByCreatedAtAfterOrderByHitsDesc(LocalDateTime oneMonthAgo);
-
     List<CommunityPost> findTop5ByCategoryIdOrderByCreatedAtDesc(Long categoryId);
 
     @Modifying

--- a/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostService.java
@@ -242,8 +242,8 @@ public class CommunityPostService {
         return communityPostRepository.findRecentPostByCategory(category);
     }
 
-    public List<PopularPostResponse> getPopularPosts() {
-        List<CommunityPost> posts = communityQueryRepository.findPopularPosts();
+    public List<PopularPostResponse> getPopularPosts(int limitCount) {
+        List<CommunityPost> posts = communityQueryRepository.findPopularPosts(limitCount);
 
         if (posts.isEmpty()) {
             throw new BusinessLogicException("최근 한 달 내에 작성된 게시물이 없습니다.");

--- a/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostService.java
@@ -242,9 +242,7 @@ public class CommunityPostService {
     }
 
     public List<PopularPostResponse> getPopularPosts() {
-        LocalDateTime oneMonthAgo = LocalDateTime.now().minusMonths(1);
-        List<CommunityPost> posts = communityPostRepository
-                .findTop3ByCreatedAtAfterOrderByHitsDesc(oneMonthAgo);
+        List<CommunityPost> posts = communityQueryRepository.findPopularPosts();
 
         if (posts.isEmpty()) {
             throw new BusinessLogicException("최근 한 달 내에 작성된 게시물이 없습니다.");

--- a/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostService.java
@@ -47,6 +47,7 @@ import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -248,8 +249,14 @@ public class CommunityPostService {
             throw new BusinessLogicException("최근 한 달 내에 작성된 게시물이 없습니다.");
         }
 
+        List<Long> categoryIds = posts.stream()
+                .map(CommunityPost::getCategoryId)
+                .distinct()
+                .toList();
+        Map<Long, String> categoryNames = communityQueryRepository.getCategoryNamesByIds(categoryIds);
+
         return posts.stream()
-                .map(post -> PopularPostResponse.of(post, communityQueryRepository.getCategoryNameById(post.getCategoryId())))
+                .map(post -> PopularPostResponse.of(post, categoryNames.get(post.getCategoryId())))
                 .toList();
     }
 

--- a/src/main/java/org/sopt/makers/internal/member/domain/Member.java
+++ b/src/main/java/org/sopt/makers/internal/member/domain/Member.java
@@ -60,9 +60,9 @@ public class Member {
 
     @Builder.Default
     @OneToMany(
-        cascade = CascadeType.ALL,
-        orphanRemoval = true,
-        fetch = FetchType.EAGER
+            cascade = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch = FetchType.LAZY
     )
     @JoinColumn(name = "user_id")
     private List<MemberSoptActivity> activities = new ArrayList<>();

--- a/src/main/java/org/sopt/makers/internal/member/dto/response/MemberNameAndProfileImageResponse.java
+++ b/src/main/java/org/sopt/makers/internal/member/dto/response/MemberNameAndProfileImageResponse.java
@@ -1,0 +1,17 @@
+package org.sopt.makers.internal.member.dto.response;
+
+import org.sopt.makers.internal.member.domain.Member;
+
+public record MemberNameAndProfileImageResponse(
+        Long id,
+        String name,
+        String profileImage
+) {
+    public static MemberNameAndProfileImageResponse from(Member member) {
+        return new MemberNameAndProfileImageResponse(
+                member.getId(),
+                member.getName(),
+                member.getProfileImage()
+        );
+    }
+}


### PR DESCRIPTION
## 🐬 요약
인기글 조회 API 요구사항 변경 및 조회 속도 향상

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [ ] 기능 개발
- [x] 코드 스타일 수정 (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
- Response 필드 중 Member에 대해 필요한 id, name, image만 보내주는 reponse 파일을 새로 만들었습니다. 기존 구현 방식 이유는 MemberVo를 재사용하고자 했으나, 필요없는 정보를 조회하는 쿼리문이 너무 길어 필요한 정보만 조회해 보내주는 것이 맞다고 생각해 새로 `MemberNameAndProfileImageResponse` 파일을 추가하였습니다. (해당 변경사항 내용 FE에게 전달 완료)
- 인기글 조회 시 기존 구현은 jpa 메소드를 사용했으나, SQL 쿼리 실행문을 보며 최적화하던 중 성능 향상을 위해 fetch join을 사용하도록 `communityQueryRepository에 메소드를 추가`하고 적용하였습니다.
- Member Entity의 oneToMany 관계인 activities 필드에 fetchtype을 lazy로 수정하여 조회가 필요한 경우에만 외래키를 사용해 조회되도록 수정하였습니다. (플그 api 중 멤버 id, name 등 적은 정보만 가져오는 api가 많은 것에 비해 항상 다른 테이블과 join하여 activities정보까지 가져오는 경우가 불필요하다고 생각했습니다)
- 슬랙 내 FE, PM 요구사항에 맞춰 title이 빈 값이 올 경우 content를 보내주는 것으로 수정했습니다!

## 🌟 관련 이슈


- closed #634 
