### PR TITLE
[Fix] 인기글 글 조회 시 익명글은 익명 프로필 처리하도록 수정

### DIFF
--- a/src/main/java/org/sopt/makers/internal/community/controller/CommunityController.java
+++ b/src/main/java/org/sopt/makers/internal/community/controller/CommunityController.java
@@ -49,7 +49,7 @@ public class CommunityController {
         val post = communityPostService.getPostById(memberDetails.getId(), postId, isBlockOn);
         val isLiked = communityPostService.isLiked(memberDetails.getId(), post.post().id());
         val likes = communityPostService.getLikes(post.post().id());
-        val anonymousProfile = communityPostService.getAnonymousPostProfile(post.member().id(), post.post().id());
+        val anonymousProfile = communityPostService.getAnonymousPostProfile(post.post().id());
         val response = communityResponseMapper.toPostDetailReponse(post, memberDetails.getId(), isLiked, likes, anonymousProfile);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
@@ -75,7 +75,7 @@ public class CommunityController {
         val hasNextPosts = infiniteScrollUtil.checkHasNextElement(limit, posts);
         val postResponse = posts.stream().map(post -> {
             val comments = communityCommentService.getPostCommentList(post.post().id(), memberDetails.getId(), isBlockOn);
-            val anonymousPostProfile = communityPostService.getAnonymousPostProfile(post.member().id(), post.post().id());
+            val anonymousPostProfile = communityPostService.getAnonymousPostProfile(post.post().id());
             val isLiked = communityPostService.isLiked(memberDetails.getId(), post.post().id());
             val likes = communityPostService.getLikes(post.post().id());
             return communityResponseMapper.toPostResponse(post, comments, memberDetails.getId(), anonymousPostProfile, isLiked, likes);

--- a/src/main/java/org/sopt/makers/internal/community/dto/response/PopularPostResponse.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/response/PopularPostResponse.java
@@ -1,6 +1,7 @@
 package org.sopt.makers.internal.community.dto.response;
 
 import org.sopt.makers.internal.community.domain.CommunityPost;
+import org.sopt.makers.internal.community.domain.anonymous.AnonymousPostProfile;
 import org.sopt.makers.internal.member.dto.response.MemberNameAndProfileImageResponse;
 
 public record PopularPostResponse(
@@ -10,13 +11,4 @@ public record PopularPostResponse(
         MemberNameAndProfileImageResponse member,
         Integer hits
 ) {
-    public static PopularPostResponse of(CommunityPost post, String categoryName) {
-        return new PopularPostResponse(
-                post.getId(),
-                categoryName,
-                post.getTitle(),
-                MemberNameAndProfileImageResponse.from(post.getMember()),
-                post.getHits()
-        );
-    }
 }

--- a/src/main/java/org/sopt/makers/internal/community/mapper/CommunityResponseMapper.java
+++ b/src/main/java/org/sopt/makers/internal/community/mapper/CommunityResponseMapper.java
@@ -9,6 +9,7 @@ import org.sopt.makers.internal.community.domain.anonymous.AnonymousCommentProfi
 import org.sopt.makers.internal.community.domain.anonymous.AnonymousPostProfile;
 import org.sopt.makers.internal.community.domain.category.Category;
 import org.sopt.makers.internal.community.domain.CommunityPost;
+import org.sopt.makers.internal.member.dto.response.MemberNameAndProfileImageResponse;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -110,6 +111,28 @@ public class CommunityResponseMapper {
 
     public InternalCommunityPost toInternalCommunityPostResponse(PostCategoryDao dao) {
         return new InternalCommunityPost(dao.post().getId(), dao.post().getTitle(), dao.category().getName(), dao.post().getImages(), dao.post().getIsHot(), dao.post().getContent());
+    }
+
+    public PopularPostResponse toPopularPostResponse(CommunityPost post, AnonymousPostProfile anonymousPostProfile, String categoryName) {
+        MemberNameAndProfileImageResponse memberResponse;
+
+        if (Boolean.TRUE.equals(post.getIsBlindWriter()) && anonymousPostProfile != null) {
+            memberResponse = new MemberNameAndProfileImageResponse(
+                    anonymousPostProfile.getId(),
+                    anonymousPostProfile.getNickname().getNickname(),
+                    anonymousPostProfile.getProfileImg().getImageUrl()
+            );
+        } else {
+            memberResponse = MemberNameAndProfileImageResponse.from(post.getMember());
+        }
+
+        return new PopularPostResponse(
+                post.getId(),
+                categoryName,
+                post.getTitle(),
+                memberResponse,
+                post.getHits()
+        );
     }
 
     private String getRelativeTime(LocalDateTime createdAt) {

--- a/src/main/java/org/sopt/makers/internal/community/repository/CommunityQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/community/repository/CommunityQueryRepository.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.sopt.makers.internal.community.domain.CommunityPost;
 import org.sopt.makers.internal.community.domain.QCommunityPost;
+import org.sopt.makers.internal.community.domain.anonymous.AnonymousPostProfile;
+import org.sopt.makers.internal.community.domain.anonymous.QAnonymousPostProfile;
 import org.sopt.makers.internal.community.domain.category.QCategory;
 import org.sopt.makers.internal.community.domain.comment.QCommunityComment;
 import org.sopt.makers.internal.community.dto.CategoryPostMemberDao;
@@ -126,8 +128,22 @@ public class CommunityQueryRepository {
                 ));
     }
 
+    public Map<Long, AnonymousPostProfile> getAnonymousPostProfilesByPostId(List<Long> postIds) {
+        if (postIds == null || postIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        QAnonymousPostProfile anonymousPostProfile = QAnonymousPostProfile.anonymousPostProfile;
 
         return queryFactory
+                .selectFrom(anonymousPostProfile)
+                .where(anonymousPostProfile.communityPost.id.in(postIds))
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        profile -> profile.getCommunityPost().getId(),
+                        profile -> profile
+                ));
     }
 
     public List<CommentDao> findCommentByPostId(Long postId, Long memberId, boolean isBlockedOn) {

--- a/src/main/java/org/sopt/makers/internal/community/repository/CommunityQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/community/repository/CommunityQueryRepository.java
@@ -94,7 +94,6 @@ public class CommunityQueryRepository {
     }
 
     public CategoryPostMemberDao getPostById(Long postId) {
-        val careers = QMemberCareer.memberCareer;
         val activities = QMemberSoptActivity.memberSoptActivity;
         val posts = QCommunityPost.communityPost;
         val category = QCategory.category;
@@ -104,7 +103,6 @@ public class CommunityQueryRepository {
                 .from(posts)
                 .innerJoin(posts.member, member)
                 .leftJoin(member.activities, activities)
-                .leftJoin(member.careers, careers)
                 .innerJoin(category).on(posts.categoryId.eq(category.id))
                 .where(posts.id.eq(postId)).distinct().fetchOne();
     }
@@ -128,14 +126,8 @@ public class CommunityQueryRepository {
                 ));
     }
 
-    public String getCategoryNameById(Long categoryId) {
-        QCategory category = QCategory.category;
 
         return queryFactory
-                .select(category.name)
-                .from(category)
-                .where(category.id.eq(categoryId))
-                .fetchOne();
     }
 
     public List<CommentDao> findCommentByPostId(Long postId, Long memberId, boolean isBlockedOn) {
@@ -174,15 +166,6 @@ public class CommunityQueryRepository {
             .where(post.isHot.eq(true))
             .orderBy(post.createdAt.desc())
             .fetchFirst();
-    }
-
-    public void updateHitsByPostId(List<Long> postIdList) {
-        val post = QCommunityPost.communityPost;
-
-        queryFactory.update(post)
-                .set(post.hits, post.hits.add(1))
-                .where(post.id.in(postIdList))
-                .execute();
     }
 
     public void updateIsHotByPostId(Long postId) {

--- a/src/main/java/org/sopt/makers/internal/community/repository/anonymous/AnonymousPostProfileRepository.java
+++ b/src/main/java/org/sopt/makers/internal/community/repository/anonymous/AnonymousPostProfileRepository.java
@@ -12,7 +12,7 @@ public interface AnonymousPostProfileRepository extends JpaRepository<AnonymousP
 	// CREATE
 
 	// READ
-	Optional<AnonymousPostProfile> findAnonymousPostProfileByMemberIdAndCommunityPostId(Long memberId, Long communityPostId);
+	Optional<AnonymousPostProfile> findAnonymousPostProfileByCommunityPostId(Long communityPostId);
 	Optional<AnonymousPostProfile> findByMemberAndCommunityPost(Member member, CommunityPost post);
 
 	// UPDATE

--- a/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostService.java
@@ -220,8 +220,8 @@ public class CommunityPostService {
     }
 
     @Transactional(readOnly = true)
-    public AnonymousPostProfile getAnonymousPostProfile(Long memberId, Long postId) {
-        return anonymousPostProfileRepository.findAnonymousPostProfileByMemberIdAndCommunityPostId(memberId, postId).orElse(null);
+    public AnonymousPostProfile getAnonymousPostProfile(Long postId) {
+        return anonymousPostProfileRepository.findAnonymousPostProfileByCommunityPostId(postId).orElse(null);
     }
 
     @Transactional(readOnly = true)
@@ -250,17 +250,8 @@ public class CommunityPostService {
             throw new BusinessLogicException("최근 한 달 내에 작성된 게시물이 없습니다.");
         }
 
-        List<Long> categoryIds = posts.stream()
-                .map(CommunityPost::getCategoryId)
-                .distinct()
-                .toList();
-        Map<Long, String> categoryNameMap = communityQueryRepository.getCategoryNamesByIds(categoryIds);
-
-        List<Long> postIds = posts.stream()
-                .map(CommunityPost::getId)
-                .distinct()
-                .toList();
-        Map<Long, AnonymousPostProfile> anonymousProfileMap = communityQueryRepository.getAnonymousPostProfilesByPostId(postIds);
+        Map<Long, String> categoryNameMap = getCategoryNameMap(posts);
+        Map<Long, AnonymousPostProfile> anonymousProfileMap = getAnonymousProfileMap(posts);
 
         return posts.stream()
                 .map(post -> communityResponseMapper.toPopularPostResponse(
@@ -399,5 +390,21 @@ public class CommunityPostService {
         if (!Objects.equals(memberId, postWriterId)) {
             throw new ClientBadRequestException("수정/삭제 권한이 없는 유저입니다.");
         }
+    }
+
+    private Map<Long, String> getCategoryNameMap(List<CommunityPost> posts) {
+        List<Long> categoryIds = posts.stream()
+                .map(CommunityPost::getCategoryId)
+                .distinct()
+                .toList();
+        return communityQueryRepository.getCategoryNamesByIds(categoryIds);
+    }
+
+    private Map<Long, AnonymousPostProfile> getAnonymousProfileMap(List<CommunityPost> posts) {
+        List<Long> postIds = posts.stream()
+                .map(CommunityPost::getId)
+                .distinct()
+                .toList();
+        return communityQueryRepository.getAnonymousPostProfilesByPostId(postIds);
     }
 }


### PR DESCRIPTION
## 🐬 요약
인기글 글 조회 시 익명글은 익명 프로필 처리하도록 수정

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [x] 버그 수정
- [ ] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
- 인기글 글 조회 시 익명글은 익명 프로필 조회해서 적용되도록 쿼리문 추가하였습니다.
- 기존 커뮤니티 글 상세/전체 조회 시 익명글의 익명 프로필 조회하던 로직이 memberId와 communityPostId를 함께 조건으로 조회했지만, DB 구조상 communityPostId는 고유한 값이므로 단독 조회로 충분하다고 판단하여 불필요한 조건을 제거하였습니다.
- 인기글 Response 변환 로직 Mapper로 이동하였습니다.
- 사용하지 않는 메서드 2개를 제거하였습니다.

## 🌟 관련 이슈
- closed #640 
