### PR TITLE
[Feat] displayOrder에 따라 전체 게시물을 정렬한 이후 응답하도록 수정

### DIFF
--- a/src/main/java/org/sopt/makers/internal/community/domain/category/Category.java
+++ b/src/main/java/org/sopt/makers/internal/community/domain/category/Category.java
@@ -37,6 +37,9 @@ public class Category {
     @OneToMany(mappedBy = "parent")
     private List<Category> children = new ArrayList<>();
 
+    @Column
+    private Integer displayOrder;
+
     @Builder
     private Category(Long id, String name, String content, Boolean hasAll, Boolean hasBlind, Boolean hasQuestion, Category parent, List<Category> children) {
         this.id = id;
@@ -47,5 +50,6 @@ public class Category {
         this.hasQuestion = hasQuestion;
         this.parent = parent;
         this.children = children;
+        this.displayOrder = null;
     }
 }

--- a/src/main/java/org/sopt/makers/internal/community/repository/CommunityQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/community/repository/CommunityQueryRepository.java
@@ -50,7 +50,7 @@ public class CommunityQueryRepository {
                 .where(ltPostId(cursor))
                 .limit(limit)
                 .distinct()
-                .orderBy(posts.createdAt.desc());
+                .orderBy(category.displayOrder.asc(), posts.createdAt.desc());
 
         if (filterBlockedUsers) {
             query.leftJoin(memberBlock).on(
@@ -81,7 +81,7 @@ public class CommunityQueryRepository {
                 .where(ltPostId(cursor), category.id.eq(categoryId).or(category.parent.id.eq(categoryId)))
                 .limit(limit)
                 .distinct()
-                .orderBy(posts.createdAt.desc());
+                .orderBy(category.displayOrder.asc(), posts.createdAt.desc());
 
         if (filterBlockedUsers) {
             query.leftJoin(memberBlock).on(


### PR DESCRIPTION
## 🐬 요약
PR의 요약을 작성해주세요!

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [x] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
1. `category_id`는 PK이자 참조키이므로:
- 의미 없는 정렬 순서를 갖고 있음 (`id` = `auto_increment` 기반)
- 순서를 바꾸려면 `ID`를 바꾸는 수밖에 없는데, 이는 곧 `post` 등 관계 테이블까지 영향이 감
- 새 카테고리(`기타`)를 추가하면 `ID`가 뒤쪽으로 밀려 정렬이 깨짐

2. 그래서 DB에서 명시적인 정렬 순서를 주는 `display_order` 필드를 추가하려고 생각해보았어요. 이렇게 했을 때 장점은 3가지가 있는데요.
- 기존 `ID` 값은 유지하고, `정렬`은 자유롭게 가능하다.
- 프론트/백엔드 정렬 기준을 통일할 수 있다.
- 새 카테고리 추가 시 `순서 지정`이 용이하다.

3. 이 방법을 도입했을 때, 프론트에서 정렬하는 경우와 서버에서 정렬해 전달해주는 경우가 있는데요.
- 방법 1 : 서버에서 정렬 없이 전달하고, 클라이언트가 `display_order`로 정렬하는 방법
- 방법 2 : 정렬 로직은 서버에서 처리하고, 단지 순서대로 보여주기만 하는 경우
- **제가 생각했을 때 가장 깔끔한 방식은, 서버가 `display_order`를 기준으로 정렬해서 응답값을 반환해주면 프론트는 정렬 로직 없이 받은 순서 그대로 렌더링하는 방식입니다.**

- 그래서 슬랙에서 팀원들과 논의 후 해당 방향으로 진행하도록 결정되었습니다.
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/85768384-c025-49d0-8871-4be16d3a9fd7" />



## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #648 