### PR TITLE
[Refactor] 카테고리 반환해 주는 API 정렬 순서 변경

### DIFF
--- a/src/main/java/org/sopt/makers/internal/community/controller/CommunityCategoryController.java
+++ b/src/main/java/org/sopt/makers/internal/community/controller/CommunityCategoryController.java
@@ -25,6 +25,7 @@ public class CommunityCategoryController {
     @GetMapping("")
     public ResponseEntity<List<CommunityCategoryResponse>> getAllCategories() {
 
-        return ResponseEntity.status(HttpStatus.OK).body(categoryService.getAllCategoriesWithChildren());
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(categoryService.getAllCategoriesWithChildren());
     }
 }

--- a/src/main/java/org/sopt/makers/internal/community/domain/category/Category.java
+++ b/src/main/java/org/sopt/makers/internal/community/domain/category/Category.java
@@ -41,7 +41,8 @@ public class Category {
     private Integer displayOrder;
 
     @Builder
-    private Category(Long id, String name, String content, Boolean hasAll, Boolean hasBlind, Boolean hasQuestion, Category parent, List<Category> children) {
+    private Category(Long id, String name, String content, Boolean hasAll, Boolean hasBlind,
+                     Boolean hasQuestion, Category parent, List<Category> children, Integer displayOrder) {
         this.id = id;
         this.name = name;
         this.content = content;
@@ -50,6 +51,6 @@ public class Category {
         this.hasQuestion = hasQuestion;
         this.parent = parent;
         this.children = children;
-        this.displayOrder = null;
+        this.displayOrder = displayOrder;
     }
 }

--- a/src/main/java/org/sopt/makers/internal/community/dto/response/CommunityCategoryResponse.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/response/CommunityCategoryResponse.java
@@ -1,5 +1,6 @@
 package org.sopt.makers.internal.community.dto.response;
 
+import java.util.Comparator;
 import org.sopt.makers.internal.community.domain.category.Category;
 
 import java.util.List;
@@ -35,6 +36,7 @@ public record CommunityCategoryResponse(
 
     public static CommunityCategoryResponse from(Category category) {
         List<CommunityCategoryResponse> children = category.getChildren().stream()
+                .sorted(Comparator.comparing(Category::getDisplayOrder))
                 .map(CommunityCategoryResponse::from)
                 .toList();
 

--- a/src/main/java/org/sopt/makers/internal/community/service/category/CategoryService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/category/CategoryService.java
@@ -20,8 +20,8 @@ public class CategoryService {
 
         return categories.stream()
                 .filter(category -> category.getParent() == null)
+                .sorted(Comparator.comparing(Category::getDisplayOrder))
                 .map(CommunityCategoryResponse::from)
-                .sorted(Comparator.comparing((CommunityCategoryResponse c) -> c.id() != 21))
                 .toList();
     }
 }

--- a/src/test/java/org/sopt/makers/internal/service/community/category/CategoryServiceUnitTest.java
+++ b/src/test/java/org/sopt/makers/internal/service/community/category/CategoryServiceUnitTest.java
@@ -41,6 +41,7 @@ public class CategoryServiceUnitTest {
                 .hasQuestion(true)
                 .parent(null)
                 .children(new ArrayList<>())
+                .displayOrder(1)
                 .build();
 
         Category parentTwoCategory = Category.builder()
@@ -52,6 +53,7 @@ public class CategoryServiceUnitTest {
                 .hasQuestion(true)
                 .parent(null)
                 .children(new ArrayList<>())
+                .displayOrder(2)
                 .build();
 
         Category childrenCategory = Category.builder()
@@ -63,6 +65,7 @@ public class CategoryServiceUnitTest {
                 .hasQuestion(true)
                 .parent(parentOneCategory)
                 .children(new ArrayList<>())
+                .displayOrder(3)
                 .build();
 
         parentOneCategory.getChildren().add(childrenCategory);


### PR DESCRIPTION
## 🐬 요약
PR의 요약을 작성해주세요!
[Refactor] 카테고리 반환해 주는 API 정렬 순서 변경

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [x] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
PR에 담긴 작업 내용을 작성해주세요!

- 전체 카테고리 조회 API의 코드에도 displayOrder에 따른 정렬 이후 데이터를 응답하도록 수정했습니다!
<img width="1677" alt="image" src="https://github.com/user-attachments/assets/a6f1a873-16f1-49fb-9b1d-24df9bfb581e" />


## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #650 
