### PR TITLE
[Feat] 언급 푸시 알람 연동

### DIFF
--- a/src/main/java/org/sopt/makers/internal/common/util/MentionCleaner.java
+++ b/src/main/java/org/sopt/makers/internal/common/util/MentionCleaner.java
@@ -1,0 +1,21 @@
+package org.sopt.makers.internal.common.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class MentionCleaner {
+    private static final Pattern mentionPattern = Pattern.compile("@(.*?)\\[\\d+\\]");
+
+    public static String removeMentionIds(String content) {
+        Matcher matcher = mentionPattern.matcher(content);
+        StringBuffer sb = new StringBuffer();
+
+        while (matcher.find()) {
+            String nickname = matcher.group(1);
+            matcher.appendReplacement(sb, "@" + nickname);
+        }
+        matcher.appendTail(sb);
+        return sb.toString();
+    }
+}
+

--- a/src/main/java/org/sopt/makers/internal/community/dto/request/CommentSaveRequest.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/request/CommentSaveRequest.java
@@ -1,7 +1,6 @@
 package org.sopt.makers.internal.community.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import org.sopt.makers.internal.mention.MentionRequest;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;

--- a/src/main/java/org/sopt/makers/internal/community/dto/request/CommentSaveRequest.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/request/CommentSaveRequest.java
@@ -1,6 +1,7 @@
 package org.sopt.makers.internal.community.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import org.sopt.makers.internal.mention.MentionRequest;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -19,5 +20,7 @@ public record CommentSaveRequest (
     @NotNull String webLink,
 
     @Schema(required = false)
-    Long parentCommentId
+    Long parentCommentId,
+
+    MentionRequest mention
 ) {}

--- a/src/main/java/org/sopt/makers/internal/community/dto/request/MentionRequest.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/request/MentionRequest.java
@@ -1,4 +1,4 @@
-package org.sopt.makers.internal.mention;
+package org.sopt.makers.internal.community.dto.request;
 
 public record MentionRequest(
         Long[] userIds,

--- a/src/main/java/org/sopt/makers/internal/community/dto/request/PostSaveRequest.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/request/PostSaveRequest.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
-import org.sopt.makers.internal.mention.MentionRequest;
 import org.sopt.makers.internal.vote.dto.request.VoteRequest;
 
 @Builder

--- a/src/main/java/org/sopt/makers/internal/community/dto/request/PostSaveRequest.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/request/PostSaveRequest.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+
+import org.sopt.makers.internal.mention.MentionRequest;
 import org.sopt.makers.internal.vote.dto.request.VoteRequest;
 
 @Builder
@@ -33,6 +35,8 @@ public record PostSaveRequest(
 
         String link,
 
-        VoteRequest vote
+        VoteRequest vote,
+
+        MentionRequest mention
 ) {
 }

--- a/src/main/java/org/sopt/makers/internal/community/service/CommunityCommentService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/CommunityCommentService.java
@@ -32,8 +32,7 @@ import org.sopt.makers.internal.community.repository.comment.DeletedCommunityCom
 import org.sopt.makers.internal.community.repository.comment.ReportCommentRepository;
 import org.sopt.makers.internal.external.pushNotification.PushNotificationService;
 import org.sopt.makers.internal.member.service.MemberRetriever;
-import org.sopt.makers.internal.mention.MentionCleaner;
-import org.sopt.makers.internal.mention.MentionRequest;
+import org.sopt.makers.internal.common.util.MentionCleaner;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/org/sopt/makers/internal/community/service/CommunityCommentService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/CommunityCommentService.java
@@ -2,7 +2,10 @@ package org.sopt.makers.internal.community.service;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 import org.sopt.makers.internal.community.domain.CommunityPost;

--- a/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostService.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
-import org.apache.commons.lang3.StringUtils;
 import org.sopt.makers.internal.community.dto.response.PopularPostResponse;
 import org.sopt.makers.internal.community.dto.response.QuestionPostResponse;
 import org.sopt.makers.internal.community.dto.response.SopticlePostResponse;
@@ -14,7 +13,6 @@ import org.sopt.makers.internal.community.repository.post.DeletedCommunityPostRe
 import org.sopt.makers.internal.community.service.SopticleScrapedService;
 import org.sopt.makers.internal.exception.BusinessLogicException;
 import org.sopt.makers.internal.external.pushNotification.PushNotificationService;
-import org.sopt.makers.internal.external.pushNotification.dto.PushNotificationRequest;
 import org.sopt.makers.internal.member.domain.MakersMemberId;
 import org.sopt.makers.internal.external.slack.SlackMessageUtil;
 import org.sopt.makers.internal.community.dto.request.PostSaveRequest;
@@ -40,9 +38,6 @@ import org.sopt.makers.internal.community.mapper.CommunityMapper;
 import org.sopt.makers.internal.community.mapper.CommunityResponseMapper;
 import org.sopt.makers.internal.member.service.MemberRetriever;
 import org.sopt.makers.internal.member.repository.MemberBlockRepository;
-import org.sopt.makers.internal.mention.MentionCleaner;
-import org.sopt.makers.internal.mention.MentionRequest;
-import org.sopt.makers.internal.vote.domain.Vote;
 import org.sopt.makers.internal.vote.dto.response.VoteResponse;
 import org.sopt.makers.internal.vote.service.VoteService;
 import org.springframework.beans.factory.annotation.Value;
@@ -54,7 +49,6 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.*;
-import java.util.stream.Collectors;
 
 @Slf4j
 @RequiredArgsConstructor

--- a/src/main/java/org/sopt/makers/internal/external/pushNotification/PushNotificationService.java
+++ b/src/main/java/org/sopt/makers/internal/external/pushNotification/PushNotificationService.java
@@ -3,7 +3,6 @@ package org.sopt.makers.internal.external.pushNotification;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.makers.internal.external.pushNotification.dto.PushNotificationRequest;
-import org.sopt.makers.internal.external.pushNotification.dto.PushNotificationResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/org/sopt/makers/internal/external/pushNotification/PushNotificationService.java
+++ b/src/main/java/org/sopt/makers/internal/external/pushNotification/PushNotificationService.java
@@ -1,13 +1,16 @@
 package org.sopt.makers.internal.external.pushNotification;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.sopt.makers.internal.external.pushNotification.dto.PushNotificationRequest;
 import org.sopt.makers.internal.external.pushNotification.dto.PushNotificationResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.util.Arrays;
 import java.util.UUID;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PushNotificationService {
@@ -23,27 +26,38 @@ public class PushNotificationService {
 
     private final PushServerClient pushServerClient;
 
-    public void sendPushNotification(PushNotificationRequest request) {
-        PushNotificationResponse response = pushServerClient.sendPushNotification(
-                pushNotificationApiKey,
-                action,
-                UUID.randomUUID().toString(),
-                service,
-                request
-        );
+    public void sendPushNotification(String title, String content, Long[] userIds, String webLink) {
+        try {
+            String[] stringUserIds = Arrays.stream(userIds)
+                    .map(String::valueOf)
+                    .toArray(String[]::new);
 
-        // TODO: 푸시알림 에러에 따른 플로우 처리
+            PushNotificationRequest pushNotificationRequest = PushNotificationRequest.builder()
+                    .title(title)
+                    .content(content)
+                    .userIds(stringUserIds)
+                    .webLink(webLink)
+                    .category("NEWS").build();
+
+            pushServerClient.sendPushNotification(
+                    pushNotificationApiKey,
+                    action,
+                    UUID.randomUUID().toString(),
+                    service,
+                    pushNotificationRequest
+            );
+        } catch (Exception error) {
+            log.error("Push 알림 실패: {}", error.getMessage());
+        }
     }
 
     public void sendAllPushNotification(PushNotificationRequest request) {
-        PushNotificationResponse response = pushServerClient.sendPushNotification(
+        pushServerClient.sendPushNotification(
                 pushNotificationApiKey,
                 "sendAll",
                 UUID.randomUUID().toString(),
                 service,
                 request
         );
-
-        // TODO: 푸시알림 에러에 따른 플로우 처리
     }
 }

--- a/src/main/java/org/sopt/makers/internal/mention/MentionRequest.java
+++ b/src/main/java/org/sopt/makers/internal/mention/MentionRequest.java
@@ -1,0 +1,8 @@
+package org.sopt.makers.internal.mention;
+
+public record MentionRequest(
+        Long[] userIds,
+        String writerName,
+        String webLink
+) {
+}

--- a/src/main/java/org/sopt/makers/internal/scheduler/PushNotificationScheduler.java
+++ b/src/main/java/org/sopt/makers/internal/scheduler/PushNotificationScheduler.java
@@ -34,7 +34,7 @@ public class PushNotificationScheduler {
     @PersistenceContext
     private EntityManager em;
 
-    @Scheduled(cron = "0 40 11 * * ?")
+//    @Scheduled(cron = "0 40 11 * * ?")
     public void sendHotPostPushNotification() {
         List<CommunityPost> todayCommunityPosts = communityPostService.getTodayPosts();
         CommunityPost hotPost = communityPostService.findTodayHotPost(todayCommunityPosts);


### PR DESCRIPTION
## 🐬 요약
게시물 및 댓글에서 언급 푸시 알람 연동

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [x] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용

- Sp3 관련: 
   - 커뮤니티 글, 댓글 생성 시 mentionRequest 필드를 추가하였습니다.
   - 커뮤니티 글, 댓글에서 언급 시 푸시 알람 전송 되도록 연결하였습니다.
   - 언급 알람 전송 시 메시지에는 @임주민[221] 형태가 보이지 않도록 [221]을 제거해주는 MentionCleaner 유틸리티 클래스를 추가하였습니다. 
- 기존에 존재하던 알람로직인 '자신의 게시물에 새로운 댓글 달렸을 때' 알람 전송 되는 메시지 형태를 새로운 요구사항에 따라 변경하였습니다.

## 🌟 관련 이슈

- closed #682 
