### PR TITLE
[Refactor] 홈 질문 최근글 불러오기 api 모든 카테고리 최근글 불러오기로 수정

### DIFF
--- a/src/main/java/org/sopt/makers/internal/community/controller/CommunityController.java
+++ b/src/main/java/org/sopt/makers/internal/community/controller/CommunityController.java
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.sopt.makers.internal.common.util.InfiniteScrollUtil;
-import org.sopt.makers.internal.community.domain.CommunityPost;
 import org.sopt.makers.internal.community.dto.CommunityPostMemberVo;
 import org.sopt.makers.internal.community.dto.request.CommentSaveRequest;
 import org.sopt.makers.internal.community.dto.request.CommunityHitRequest;
@@ -230,11 +229,13 @@ public class CommunityController {
         return ResponseEntity.ok().body(sopticlePosts);
     }
 
-    @Operation(summary = "커뮤니티 홈 답변 대기 질문 목록 조회 API")
-    @GetMapping("/posts/question")
-    public ResponseEntity<List<QuestionPostResponse>> getRecentQuestionPost() {
-        List<QuestionPostResponse> questionPosts = communityPostService.getRecentQuestionPosts();
-        return ResponseEntity.ok().body(questionPosts);
+    @Operation(summary = "커뮤니티 홈 모든 카테고리 최신글 조회 API")
+    @GetMapping("/posts/all/recent")
+    public ResponseEntity<List<RecentPostResponse>> getRecentPosts(
+            @Parameter(hidden = true) @AuthenticationPrincipal InternalMemberDetails memberDetails
+    ) {
+        List<RecentPostResponse> recentPosts = communityPostService.getRecentPosts(memberDetails.getId());
+        return ResponseEntity.ok().body(recentPosts);
     }
 
     @Operation(summary = "핫 게시물 조회 API")

--- a/src/main/java/org/sopt/makers/internal/community/dto/response/RecentPostResponse.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/response/RecentPostResponse.java
@@ -1,0 +1,14 @@
+package org.sopt.makers.internal.community.dto.response;
+
+public record RecentPostResponse(
+        Long id,
+        String title,
+        String content,
+        String createdAt,
+        int likeCount,
+        int commentCount,
+        String categoryName,
+        Integer totalVoteCount,
+        Boolean isAnswered
+) {
+}

--- a/src/main/java/org/sopt/makers/internal/community/dto/response/RecentPostResponse.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/response/RecentPostResponse.java
@@ -7,6 +7,7 @@ public record RecentPostResponse(
         String createdAt,
         int likeCount,
         int commentCount,
+        Long categoryId,
         String categoryName,
         Integer totalVoteCount,
         Boolean isAnswered

--- a/src/main/java/org/sopt/makers/internal/community/mapper/CommunityResponseMapper.java
+++ b/src/main/java/org/sopt/makers/internal/community/mapper/CommunityResponseMapper.java
@@ -92,7 +92,7 @@ public class CommunityResponseMapper {
         );
     }
 
-    public RecentPostResponse toRecentPostResponse(CommunityPost post, int likeCount, int commentCount, String categoryName, Integer totalVoteCount) {
+    public RecentPostResponse toRecentPostResponse(CommunityPost post, int likeCount, int commentCount, long categoryId, String categoryName, Integer totalVoteCount) {
         return new RecentPostResponse(
                 post.getId(),
                 post.getTitle(),
@@ -100,6 +100,7 @@ public class CommunityResponseMapper {
                 getRelativeTime(post.getCreatedAt()),
                 likeCount,
                 commentCount,
+                categoryId,
                 categoryName,
                 totalVoteCount,
                 commentCount > 0

--- a/src/main/java/org/sopt/makers/internal/community/mapper/CommunityResponseMapper.java
+++ b/src/main/java/org/sopt/makers/internal/community/mapper/CommunityResponseMapper.java
@@ -92,14 +92,16 @@ public class CommunityResponseMapper {
         );
     }
 
-    public QuestionPostResponse toQuestionPostResponse(CommunityPost post, int likeCount, int commentCount) {
-        return new QuestionPostResponse(
+    public RecentPostResponse toRecentPostResponse(CommunityPost post, int likeCount, int commentCount, String categoryName, Integer totalVoteCount) {
+        return new RecentPostResponse(
                 post.getId(),
                 post.getTitle(),
                 post.getContent(),
                 getRelativeTime(post.getCreatedAt()),
                 likeCount,
                 commentCount,
+                categoryName,
+                totalVoteCount,
                 commentCount > 0
         );
     }

--- a/src/main/java/org/sopt/makers/internal/community/repository/post/CommunityPostRepository.java
+++ b/src/main/java/org/sopt/makers/internal/community/repository/post/CommunityPostRepository.java
@@ -19,6 +19,8 @@ public interface CommunityPostRepository extends JpaRepository<CommunityPost, Lo
 
     List<CommunityPost> findTop5ByCategoryIdOrderByCreatedAtDesc(Long categoryId);
 
+    List<CommunityPost> findTop5ByCategoryIdNotOrderByCreatedAtDesc(Long categoryId);
+
     @Modifying
     @Query("UPDATE CommunityPost p SET p.hits = p.hits + 1 WHERE p.id = :postId")
     void increaseHitsDirect(@Param("postId") Long postId);

--- a/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostService.java
@@ -309,7 +309,7 @@ public class CommunityPostService {
                     String categoryName = categoryNameMap.get(post.getCategoryId());
 
                     return communityResponseMapper.toRecentPostResponse(
-                            post, likeCount, commentCount, categoryName, totalVoteCount
+                            post, likeCount, commentCount, post.getCategoryId(), categoryName, totalVoteCount
                     );
                 })
                 .toList();

--- a/src/test/java/org/sopt/makers/internal/community/service/post/CommunityPostServiceTest.java
+++ b/src/test/java/org/sopt/makers/internal/community/service/post/CommunityPostServiceTest.java
@@ -100,11 +100,11 @@ class CommunityPostServiceTest {
             when(voteService.getVoteByPostId(postWithoutVote.getId(), MEMBER_ID)).thenReturn(null);
 
             // 4. Mapper가 반환할 최종 DTO Mocking
-            RecentPostResponse response1 = new RecentPostResponse(101L, "투표 있는 글", "내용1", "방금 전", 10, 5, "자유", 15, true);
-            RecentPostResponse response2 = new RecentPostResponse(102L, "투표 없는 글", "내용2", "1분 전", 3, 0, "홍보", null, false);
+            RecentPostResponse response1 = new RecentPostResponse(101L, "투표 있는 글", "내용1", "방금 전", 10, 5, 1L,"자유", 15, true);
+            RecentPostResponse response2 = new RecentPostResponse(102L, "투표 없는 글", "내용2", "1분 전", 3, 0, 2L, "홍보", null, false);
 
-            when(communityResponseMapper.toRecentPostResponse(postWithVote, 10, 5, "자유", 15)).thenReturn(response1);
-            when(communityResponseMapper.toRecentPostResponse(postWithoutVote, 3, 0, "홍보", null)).thenReturn(response2);
+            when(communityResponseMapper.toRecentPostResponse(postWithVote, 10, 5, 1L, "자유", 15)).thenReturn(response1);
+            when(communityResponseMapper.toRecentPostResponse(postWithoutVote, 3, 0, 2L, "홍보", null)).thenReturn(response2);
 
             // When
             List<RecentPostResponse> result = communityPostService.getRecentPosts(MEMBER_ID);
@@ -126,8 +126,8 @@ class CommunityPostServiceTest {
             verify(communityQueryRepository, times(1)).getCategoryNamesByIds(anyList());
             verify(voteService, times(1)).getVoteByPostId(postWithVote.getId(), MEMBER_ID);
             verify(voteService, times(1)).getVoteByPostId(postWithoutVote.getId(), MEMBER_ID);
-            verify(communityResponseMapper, times(1)).toRecentPostResponse(postWithVote, 10, 5, "자유", 15);
-            verify(communityResponseMapper, times(1)).toRecentPostResponse(postWithoutVote, 3, 0, "홍보", null);
+            verify(communityResponseMapper, times(1)).toRecentPostResponse(postWithVote, 10, 5, 1L,"자유", 15);
+            verify(communityResponseMapper, times(1)).toRecentPostResponse(postWithoutVote, 3, 0, 2L, "홍보", null);
         }
 
         @Test
@@ -147,7 +147,7 @@ class CommunityPostServiceTest {
             // 게시글이 없으므로 다른 의존성은 호출되지 않아야 함
             verify(communityQueryRepository, times(1)).getCategoryNamesByIds(Collections.emptyList());
             verify(voteService, never()).getVoteByPostId(anyLong(), anyLong());
-            verify(communityResponseMapper, never()).toRecentPostResponse(any(), anyInt(), anyInt(), any(), any());
+            verify(communityResponseMapper, never()).toRecentPostResponse(any(), anyInt(), anyInt(), anyLong(), any(), any());
         }
     }
 }

--- a/src/test/java/org/sopt/makers/internal/community/service/post/CommunityPostServiceTest.java
+++ b/src/test/java/org/sopt/makers/internal/community/service/post/CommunityPostServiceTest.java
@@ -1,0 +1,153 @@
+package org.sopt.makers.internal.community.service.post;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.makers.internal.community.domain.CommunityPost;
+import org.sopt.makers.internal.community.dto.response.RecentPostResponse;
+import org.sopt.makers.internal.community.mapper.CommunityResponseMapper;
+import org.sopt.makers.internal.community.repository.CommunityQueryRepository;
+import org.sopt.makers.internal.community.repository.comment.CommunityCommentRepository;
+import org.sopt.makers.internal.community.repository.post.CommunityPostLikeRepository;
+import org.sopt.makers.internal.community.repository.post.CommunityPostRepository;
+import org.sopt.makers.internal.vote.dto.response.VoteResponse;
+import org.sopt.makers.internal.vote.service.VoteService;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CommunityPostService 단위 테스트")
+class CommunityPostServiceTest {
+
+    @InjectMocks
+    private CommunityPostService communityPostService;
+
+    @Mock
+    private CommunityPostRepository communityPostRepository;
+    @Mock
+    private CommunityQueryRepository communityQueryRepository;
+    @Mock
+    private CommunityPostLikeRepository communityPostLikeRepository;
+    @Mock
+    private CommunityCommentRepository communityCommentRepository;
+    @Mock
+    private VoteService voteService;
+    @Mock
+    private CommunityResponseMapper communityResponseMapper;
+
+    private static final long SOPTICLE_CATEGORY_ID = 21L;
+
+    @Nested
+    @DisplayName("홈 최신 게시글 목록 조회 (getRecentPosts)")
+    class GetRecentPosts {
+
+        private final Long MEMBER_ID = 1L;
+
+        @Test
+        @DisplayName("성공 - 게시글(투표 포함/미포함)이 존재할 경우, DTO 리스트를 올바르게 반환한다")
+        void getRecentPosts_Success_WhenPostsExist() {
+            // Given
+            // 1. Mock 게시글 데이터 생성
+            CommunityPost postWithVote = CommunityPost.builder()
+                    .id(101L)
+                    .categoryId(1L)
+                    .title("투표 있는 글")
+                    .content("내용1")
+                    .build();
+            CommunityPost postWithoutVote = CommunityPost.builder()
+                    .id(102L)
+                    .categoryId(2L)
+                    .title("투표 없는 글")
+                    .content("내용2")
+                    .build();
+
+            // 1-2. Reflection을 사용하여 상속된 createdAt 필드 값 설정
+            ReflectionTestUtils.setField(postWithVote, "createdAt", LocalDateTime.now());
+            ReflectionTestUtils.setField(postWithoutVote, "createdAt", LocalDateTime.now().minusMinutes(5));
+
+            List<CommunityPost> mockPosts = List.of(postWithVote, postWithoutVote);
+
+            when(communityPostRepository.findTop5ByCategoryIdNotOrderByCreatedAtDesc(SOPTICLE_CATEGORY_ID))
+                    .thenReturn(mockPosts);
+
+            // 2. Mock 카테고리 이름 데이터
+            Map<Long, String> categoryNameMap = Map.of(1L, "자유", 2L, "홍보");
+            when(communityQueryRepository.getCategoryNamesByIds(anyList())).thenReturn(categoryNameMap);
+
+            // 3. 각 게시글의 Count 및 Vote 데이터 Mocking
+            // 3-1. 투표가 있는 게시글 (댓글 5개)
+            when(communityPostLikeRepository.countAllByPostId(postWithVote.getId())).thenReturn(10);
+            when(communityCommentRepository.countAllByPostId(postWithVote.getId())).thenReturn(5);
+            VoteResponse voteResponse = new VoteResponse(1L, false, true, 15, Collections.emptyList());
+            when(voteService.getVoteByPostId(postWithVote.getId(), MEMBER_ID)).thenReturn(voteResponse);
+
+            // 3-2. 투표가 없는 게시글 (댓글 0개)
+            when(communityPostLikeRepository.countAllByPostId(postWithoutVote.getId())).thenReturn(3);
+            when(communityCommentRepository.countAllByPostId(postWithoutVote.getId())).thenReturn(0);
+            when(voteService.getVoteByPostId(postWithoutVote.getId(), MEMBER_ID)).thenReturn(null);
+
+            // 4. Mapper가 반환할 최종 DTO Mocking
+            RecentPostResponse response1 = new RecentPostResponse(101L, "투표 있는 글", "내용1", "방금 전", 10, 5, "자유", 15, true);
+            RecentPostResponse response2 = new RecentPostResponse(102L, "투표 없는 글", "내용2", "1분 전", 3, 0, "홍보", null, false);
+
+            when(communityResponseMapper.toRecentPostResponse(postWithVote, 10, 5, "자유", 15)).thenReturn(response1);
+            when(communityResponseMapper.toRecentPostResponse(postWithoutVote, 3, 0, "홍보", null)).thenReturn(response2);
+
+            // When
+            List<RecentPostResponse> result = communityPostService.getRecentPosts(MEMBER_ID);
+
+            // Then
+            // 1. 결과 검증
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0)).isEqualTo(response1);
+            assertThat(result.get(1)).isEqualTo(response2);
+
+            assertThat(result.get(0).totalVoteCount()).isEqualTo(15);
+            assertThat(result.get(0).isAnswered()).isTrue();
+
+            assertThat(result.get(1).totalVoteCount()).isNull();
+            assertThat(result.get(1).isAnswered()).isFalse();
+
+            // 2. Mock 객체 상호작용 검증
+            verify(communityPostRepository, times(1)).findTop5ByCategoryIdNotOrderByCreatedAtDesc(SOPTICLE_CATEGORY_ID);
+            verify(communityQueryRepository, times(1)).getCategoryNamesByIds(anyList());
+            verify(voteService, times(1)).getVoteByPostId(postWithVote.getId(), MEMBER_ID);
+            verify(voteService, times(1)).getVoteByPostId(postWithoutVote.getId(), MEMBER_ID);
+            verify(communityResponseMapper, times(1)).toRecentPostResponse(postWithVote, 10, 5, "자유", 15);
+            verify(communityResponseMapper, times(1)).toRecentPostResponse(postWithoutVote, 3, 0, "홍보", null);
+        }
+
+        @Test
+        @DisplayName("성공 - 조회된 게시글이 없을 경우, 빈 리스트를 반환한다")
+        void getRecentPosts_Success_WhenPostsDoNotExist() {
+            // Given
+            when(communityPostRepository.findTop5ByCategoryIdNotOrderByCreatedAtDesc(SOPTICLE_CATEGORY_ID))
+                    .thenReturn(Collections.emptyList());
+
+            // When
+            List<RecentPostResponse> result = communityPostService.getRecentPosts(MEMBER_ID);
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result).isEmpty();
+
+            // 게시글이 없으므로 다른 의존성은 호출되지 않아야 함
+            verify(communityQueryRepository, times(1)).getCategoryNamesByIds(Collections.emptyList());
+            verify(voteService, never()).getVoteByPostId(anyLong(), anyLong());
+            verify(communityResponseMapper, never()).toRecentPostResponse(any(), anyInt(), anyInt(), any(), any());
+        }
+    }
+}


### PR DESCRIPTION
## 🐬 요약

[Refactor] 홈 질문 최근글 불러오기 api 모든 카테고리 최근글 불러오기로 수정

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [x] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
PR에 담긴 작업 내용을 작성해주세요!

- 홈 질문 최근글 불러오기 api를 솝티클 카테고리를 제외한 모든 카테고리의 최근글을 불러올 수 있도록 변경했습니다 :)
- 최신글을 조회하기 전, 해당하는 카테고리를 미리 조회하여 N+1 문제를 방지하고자 했습니다!
- 테스트 코드를 통해 해당 기능 검증을 완료했습니다.
<img width="874" alt="image" src="https://github.com/user-attachments/assets/e1a08d5a-23a3-43a5-acb2-1734358d7263" />


## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #681 
