### PR TITLE
[Refactor] 기존 멤버 검색 api 리팩토링(개수 리밋, 보여주는 순서, 코드 최적화)

### DIFF
--- a/src/main/java/org/sopt/makers/internal/community/mapper/CommunityResponseMapper.java
+++ b/src/main/java/org/sopt/makers/internal/community/mapper/CommunityResponseMapper.java
@@ -92,7 +92,7 @@ public class CommunityResponseMapper {
         );
     }
 
-    public RecentPostResponse toRecentPostResponse(CommunityPost post, int likeCount, int commentCount, long categoryId, String categoryName, Integer totalVoteCount) {
+    public RecentPostResponse toRecentPostResponse(CommunityPost post, int likeCount, int commentCount, Long categoryId, String categoryName, Integer totalVoteCount) {
         return new RecentPostResponse(
                 post.getId(),
                 post.getTitle(),

--- a/src/main/java/org/sopt/makers/internal/community/service/category/CategoryRetriever.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/category/CategoryRetriever.java
@@ -24,4 +24,8 @@ public class CategoryRetriever {
             throw new NotFoundDBEntityException("존재하지 않는 category id 값입니다.");
         }
     }
+
+    public List<Category> findAllByIds(List<Long> ids) {
+        return categoryRepository.findAllById(ids);
+    }
 }

--- a/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostService.java
@@ -330,7 +330,7 @@ public class CommunityPostService {
                     String categoryName = "";
 
                     if (Objects.nonNull(category)) {
-                        categoryName = category.getName();
+                        categoryName = (category.getParent() != null) ? category.getParent().getName() : category.getName();
                         categoryId = (category.getParent() != null) ? category.getParent().getId() : category.getId();
                     }
 

--- a/src/main/java/org/sopt/makers/internal/member/controller/MemberController.java
+++ b/src/main/java/org/sopt/makers/internal/member/controller/MemberController.java
@@ -99,12 +99,8 @@ public class MemberController {
     ) {
         boolean isFirstSearch = (name == null || name.isBlank() || name.equals("@"));
 
-        List<Member> members;
-        if (isFirstSearch) {
-            members = memberService.getRandomMembers(MEMBER_SEARCH_RANDOM_SIZE);
-        } else {
-            members = memberService.getMembersByNameSorted(name);
-        }
+
+        List<Member> members = isFirstSearch ? memberService.getRandomMembers(MEMBER_SEARCH_RANDOM_SIZE) : memberService.getMembersByNameSorted(name);
 
         List<MemberResponse> responses = members.stream()
                 .map(memberMapper::toResponse)

--- a/src/main/java/org/sopt/makers/internal/member/repository/MemberProfileQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/member/repository/MemberProfileQueryRepository.java
@@ -1,5 +1,7 @@
 package org.sopt.makers.internal.member.repository;
 
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
@@ -367,6 +369,32 @@ public class MemberProfileQueryRepository {
                 .selectFrom(member)
                 .innerJoin(coffeeChat).on(coffeeChat.member.eq(member))
                 .where(coffeeChat.isCoffeeChatActivate.isTrue())
+                .fetch();
+    }
+
+    public List<Member> findRandomMembers(int limit) {
+        QMember member = QMember.member;
+
+        NumberExpression<Double> rand = Expressions.numberTemplate(Double.class, "function('RAND')");
+
+        return queryFactory
+                .selectFrom(member)
+                .where(member.hasProfile.isTrue())
+                .orderBy(rand.asc())
+                .limit(limit)
+                .fetch();
+    }
+
+    public List<Member> findByNameContainingOrderByLatestActivity(String name) {
+        QMember member = QMember.member;
+        QMemberSoptActivity activity = QMemberSoptActivity.memberSoptActivity;
+
+        return queryFactory
+                .selectFrom(member)
+                .leftJoin(member.activities, activity)
+                .where(member.name.contains(name))
+                .groupBy(member.id)
+                .orderBy(activity.generation.max().desc(), member.id.desc())
                 .fetch();
     }
 }

--- a/src/main/java/org/sopt/makers/internal/member/service/MemberService.java
+++ b/src/main/java/org/sopt/makers/internal/member/service/MemberService.java
@@ -418,13 +418,13 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
-    public List<Member> getMemberByName(String name) {
-        return memberRepository.findAllByNameContaining(name);
+    public List<Member> getRandomMembers(int limit) {
+        return memberProfileQueryRepository.findRandomMembers(limit);
     }
 
     @Transactional(readOnly = true)
-    public List<Member> getMemberBySearchCond(String search) {
-        return memberProfileQueryRepository.findAllMemberProfilesBySearchCond(search);
+    public List<Member> getMembersByNameSorted(String name) {
+        return memberProfileQueryRepository.findByNameContainingOrderByLatestActivity(name);
     }
 
     @Transactional

--- a/src/test/java/org/sopt/makers/internal/community/service/post/CommunityPostServiceTest.java
+++ b/src/test/java/org/sopt/makers/internal/community/service/post/CommunityPostServiceTest.java
@@ -11,7 +11,6 @@ import org.sopt.makers.internal.community.domain.CommunityPost;
 import org.sopt.makers.internal.community.domain.category.Category;
 import org.sopt.makers.internal.community.dto.response.RecentPostResponse;
 import org.sopt.makers.internal.community.mapper.CommunityResponseMapper;
-import org.sopt.makers.internal.community.repository.CommunityQueryRepository;
 import org.sopt.makers.internal.community.repository.comment.CommunityCommentRepository;
 import org.sopt.makers.internal.community.repository.post.CommunityPostLikeRepository;
 import org.sopt.makers.internal.community.repository.post.CommunityPostRepository;
@@ -83,10 +82,10 @@ class CommunityPostServiceTest {
 
             // 4. Mapper가 반환할 최종 DTO Mocking
             RecentPostResponse response1 = new RecentPostResponse(101L, "부모 카테고리 글", "부모글 내용", "방금 전", 10, 5, 1L, "메인", null, true);
-            RecentPostResponse response2 = new RecentPostResponse(102L, "자식 카테고리 글", "자식글 내용", "5분 전", 10, 5, 1L, "자유", null, true); // categoryId는 부모 ID(1L)
+            RecentPostResponse response2 = new RecentPostResponse(102L, "자식 카테고리 글", "자식글 내용", "5분 전", 10, 5, 1L, "메인", null, true); // categoryId는 부모 ID(1L)
 
             when(communityResponseMapper.toRecentPostResponse(postInParent, 10, 5, 1L, "메인", null)).thenReturn(response1);
-            when(communityResponseMapper.toRecentPostResponse(postInChild, 10, 5, 1L, "자유", null)).thenReturn(response2);
+            when(communityResponseMapper.toRecentPostResponse(postInChild, 10, 5, 1L, "메인", null)).thenReturn(response2);
 
             // When
             List<RecentPostResponse> result = communityPostService.getRecentPosts(MEMBER_ID);
@@ -94,12 +93,14 @@ class CommunityPostServiceTest {
             // Then
             assertThat(result).hasSize(2);
             assertThat(result.get(0).categoryId()).isEqualTo(1L);
+            assertThat(result.get(0).categoryName()).isEqualTo("메인");
             assertThat(result.get(1).categoryId()).isEqualTo(1L);
+            assertThat(result.get(1).categoryName()).isEqualTo("메인");
 
             // Verify
             verify(categoryRetriever, times(1)).findAllByIds(anyList());
             verify(communityResponseMapper, times(1)).toRecentPostResponse(postInParent, 10, 5, 1L, "메인", null);
-            verify(communityResponseMapper, times(1)).toRecentPostResponse(postInChild, 10, 5, 1L, "자유", null);
+            verify(communityResponseMapper, times(1)).toRecentPostResponse(postInChild, 10, 5, 1L, "메인", null);
         }
 
         @Test

--- a/src/test/java/org/sopt/makers/internal/community/service/post/CommunityPostServiceTest.java
+++ b/src/test/java/org/sopt/makers/internal/community/service/post/CommunityPostServiceTest.java
@@ -8,19 +8,19 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.sopt.makers.internal.community.domain.CommunityPost;
+import org.sopt.makers.internal.community.domain.category.Category;
 import org.sopt.makers.internal.community.dto.response.RecentPostResponse;
 import org.sopt.makers.internal.community.mapper.CommunityResponseMapper;
 import org.sopt.makers.internal.community.repository.CommunityQueryRepository;
 import org.sopt.makers.internal.community.repository.comment.CommunityCommentRepository;
 import org.sopt.makers.internal.community.repository.post.CommunityPostLikeRepository;
 import org.sopt.makers.internal.community.repository.post.CommunityPostRepository;
-import org.sopt.makers.internal.vote.dto.response.VoteResponse;
+import org.sopt.makers.internal.community.service.category.CategoryRetriever;
 import org.sopt.makers.internal.vote.service.VoteService;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,9 +36,9 @@ class CommunityPostServiceTest {
     private CommunityPostService communityPostService;
 
     @Mock
-    private CommunityPostRepository communityPostRepository;
+    private CategoryRetriever categoryRetriever;
     @Mock
-    private CommunityQueryRepository communityQueryRepository;
+    private CommunityPostRepository communityPostRepository;
     @Mock
     private CommunityPostLikeRepository communityPostLikeRepository;
     @Mock
@@ -57,85 +57,56 @@ class CommunityPostServiceTest {
         private final Long MEMBER_ID = 1L;
 
         @Test
-        @DisplayName("성공 - 게시글(투표 포함/미포함)이 존재할 경우, DTO 리스트를 올바르게 반환한다")
+        @DisplayName("성공 - 게시글(부모/자식 카테고리)이 존재할 경우, DTO 리스트를 올바르게 반환한다")
         void getRecentPosts_Success_WhenPostsExist() {
             // Given
-            // 1. Mock 게시글 데이터 생성
-            CommunityPost postWithVote = CommunityPost.builder()
-                    .id(101L)
-                    .categoryId(1L)
-                    .title("투표 있는 글")
-                    .content("내용1")
-                    .build();
-            CommunityPost postWithoutVote = CommunityPost.builder()
-                    .id(102L)
-                    .categoryId(2L)
-                    .title("투표 없는 글")
-                    .content("내용2")
-                    .build();
+            // 1. Mock 카테고리 데이터 (부모-자식 관계)
+            Category parentCategory = Category.builder().id(1L).name("메인").build();
+            Category childCategory = Category.builder().id(2L).name("자유").parent(parentCategory).build();
+            List<Category> mockCategories = List.of(parentCategory, childCategory);
 
-            // 1-2. Reflection을 사용하여 상속된 createdAt 필드 값 설정
-            ReflectionTestUtils.setField(postWithVote, "createdAt", LocalDateTime.now());
-            ReflectionTestUtils.setField(postWithoutVote, "createdAt", LocalDateTime.now().minusMinutes(5));
+            // 2. Mock 게시글 데이터
+            CommunityPost postInParent = CommunityPost.builder().id(101L).categoryId(1L).title("부모 카테고리 글").content("부모글 내용").build();
+            CommunityPost postInChild = CommunityPost.builder().id(102L).categoryId(2L).title("자식 카테고리 글").content("자식글 내용").build();
+            List<CommunityPost> mockPosts = List.of(postInParent, postInChild);
 
-            List<CommunityPost> mockPosts = List.of(postWithVote, postWithoutVote);
+            ReflectionTestUtils.setField(postInParent, "createdAt", LocalDateTime.now());
+            ReflectionTestUtils.setField(postInChild, "createdAt", LocalDateTime.now().minusMinutes(5));
 
-            when(communityPostRepository.findTop5ByCategoryIdNotOrderByCreatedAtDesc(SOPTICLE_CATEGORY_ID))
-                    .thenReturn(mockPosts);
+            when(communityPostRepository.findTop5ByCategoryIdNotOrderByCreatedAtDesc(SOPTICLE_CATEGORY_ID)).thenReturn(mockPosts);
+            when(categoryRetriever.findAllByIds(anyList())).thenReturn(mockCategories);
 
-            // 2. Mock 카테고리 이름 데이터
-            Map<Long, String> categoryNameMap = Map.of(1L, "자유", 2L, "홍보");
-            when(communityQueryRepository.getCategoryNamesByIds(anyList())).thenReturn(categoryNameMap);
-
-            // 3. 각 게시글의 Count 및 Vote 데이터 Mocking
-            // 3-1. 투표가 있는 게시글 (댓글 5개)
-            when(communityPostLikeRepository.countAllByPostId(postWithVote.getId())).thenReturn(10);
-            when(communityCommentRepository.countAllByPostId(postWithVote.getId())).thenReturn(5);
-            VoteResponse voteResponse = new VoteResponse(1L, false, true, 15, Collections.emptyList());
-            when(voteService.getVoteByPostId(postWithVote.getId(), MEMBER_ID)).thenReturn(voteResponse);
-
-            // 3-2. 투표가 없는 게시글 (댓글 0개)
-            when(communityPostLikeRepository.countAllByPostId(postWithoutVote.getId())).thenReturn(3);
-            when(communityCommentRepository.countAllByPostId(postWithoutVote.getId())).thenReturn(0);
-            when(voteService.getVoteByPostId(postWithoutVote.getId(), MEMBER_ID)).thenReturn(null);
+            // 3. Count 및 Vote 데이터 Mocking
+            when(communityPostLikeRepository.countAllByPostId(anyLong())).thenReturn(10);
+            when(communityCommentRepository.countAllByPostId(anyLong())).thenReturn(5);
+            when(voteService.getVoteByPostId(anyLong(), anyLong())).thenReturn(null);
 
             // 4. Mapper가 반환할 최종 DTO Mocking
-            RecentPostResponse response1 = new RecentPostResponse(101L, "투표 있는 글", "내용1", "방금 전", 10, 5, 1L,"자유", 15, true);
-            RecentPostResponse response2 = new RecentPostResponse(102L, "투표 없는 글", "내용2", "1분 전", 3, 0, 2L, "홍보", null, false);
+            RecentPostResponse response1 = new RecentPostResponse(101L, "부모 카테고리 글", "부모글 내용", "방금 전", 10, 5, 1L, "메인", null, true);
+            RecentPostResponse response2 = new RecentPostResponse(102L, "자식 카테고리 글", "자식글 내용", "5분 전", 10, 5, 1L, "자유", null, true); // categoryId는 부모 ID(1L)
 
-            when(communityResponseMapper.toRecentPostResponse(postWithVote, 10, 5, 1L, "자유", 15)).thenReturn(response1);
-            when(communityResponseMapper.toRecentPostResponse(postWithoutVote, 3, 0, 2L, "홍보", null)).thenReturn(response2);
+            when(communityResponseMapper.toRecentPostResponse(postInParent, 10, 5, 1L, "메인", null)).thenReturn(response1);
+            when(communityResponseMapper.toRecentPostResponse(postInChild, 10, 5, 1L, "자유", null)).thenReturn(response2);
 
             // When
             List<RecentPostResponse> result = communityPostService.getRecentPosts(MEMBER_ID);
 
             // Then
-            // 1. 결과 검증
             assertThat(result).hasSize(2);
-            assertThat(result.get(0)).isEqualTo(response1);
-            assertThat(result.get(1)).isEqualTo(response2);
+            assertThat(result.get(0).categoryId()).isEqualTo(1L);
+            assertThat(result.get(1).categoryId()).isEqualTo(1L);
 
-            assertThat(result.get(0).totalVoteCount()).isEqualTo(15);
-            assertThat(result.get(0).isAnswered()).isTrue();
-
-            assertThat(result.get(1).totalVoteCount()).isNull();
-            assertThat(result.get(1).isAnswered()).isFalse();
-
-            // 2. Mock 객체 상호작용 검증
-            verify(communityPostRepository, times(1)).findTop5ByCategoryIdNotOrderByCreatedAtDesc(SOPTICLE_CATEGORY_ID);
-            verify(communityQueryRepository, times(1)).getCategoryNamesByIds(anyList());
-            verify(voteService, times(1)).getVoteByPostId(postWithVote.getId(), MEMBER_ID);
-            verify(voteService, times(1)).getVoteByPostId(postWithoutVote.getId(), MEMBER_ID);
-            verify(communityResponseMapper, times(1)).toRecentPostResponse(postWithVote, 10, 5, 1L,"자유", 15);
-            verify(communityResponseMapper, times(1)).toRecentPostResponse(postWithoutVote, 3, 0, 2L, "홍보", null);
+            // Verify
+            verify(categoryRetriever, times(1)).findAllByIds(anyList());
+            verify(communityResponseMapper, times(1)).toRecentPostResponse(postInParent, 10, 5, 1L, "메인", null);
+            verify(communityResponseMapper, times(1)).toRecentPostResponse(postInChild, 10, 5, 1L, "자유", null);
         }
 
         @Test
         @DisplayName("성공 - 조회된 게시글이 없을 경우, 빈 리스트를 반환한다")
         void getRecentPosts_Success_WhenPostsDoNotExist() {
             // Given
-            when(communityPostRepository.findTop5ByCategoryIdNotOrderByCreatedAtDesc(SOPTICLE_CATEGORY_ID))
-                    .thenReturn(Collections.emptyList());
+            when(communityPostRepository.findTop5ByCategoryIdNotOrderByCreatedAtDesc(SOPTICLE_CATEGORY_ID)).thenReturn(Collections.emptyList());
 
             // When
             List<RecentPostResponse> result = communityPostService.getRecentPosts(MEMBER_ID);
@@ -144,8 +115,8 @@ class CommunityPostServiceTest {
             assertThat(result).isNotNull();
             assertThat(result).isEmpty();
 
-            // 게시글이 없으므로 다른 의존성은 호출되지 않아야 함
-            verify(communityQueryRepository, times(1)).getCategoryNamesByIds(Collections.emptyList());
+            // Verify
+            verify(categoryRetriever, never()).findAllByIds(Collections.emptyList());
             verify(voteService, never()).getVoteByPostId(anyLong(), anyLong());
             verify(communityResponseMapper, never()).toRecentPostResponse(any(), anyInt(), anyInt(), anyLong(), any(), any());
         }

--- a/src/test/java/org/sopt/makers/internal/service/community/category/CategoryServiceUnitTest.java
+++ b/src/test/java/org/sopt/makers/internal/service/community/category/CategoryServiceUnitTest.java
@@ -8,12 +8,32 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.sopt.makers.internal.community.dto.response.CommunityCategoryResponse;
 import org.sopt.makers.internal.community.domain.category.Category;
+import org.sopt.makers.internal.community.mapper.CommunityMapper;
+import org.sopt.makers.internal.community.mapper.CommunityResponseMapper;
+import org.sopt.makers.internal.community.repository.CommunityQueryRepository;
+import org.sopt.makers.internal.community.repository.ReportPostRepository;
+import org.sopt.makers.internal.community.repository.anonymous.AnonymousPostProfileRepository;
+import org.sopt.makers.internal.community.repository.comment.CommunityCommentRepository;
+import org.sopt.makers.internal.community.repository.comment.DeletedCommunityCommentRepository;
+import org.sopt.makers.internal.community.repository.post.CommunityPostLikeRepository;
+import org.sopt.makers.internal.community.repository.post.CommunityPostRepository;
+import org.sopt.makers.internal.community.repository.post.DeletedCommunityPostRepository;
+import org.sopt.makers.internal.community.service.SopticleScrapedService;
+import org.sopt.makers.internal.community.service.anonymous.AnonymousPostProfileService;
 import org.sopt.makers.internal.community.service.category.CategoryRetriever;
 import org.sopt.makers.internal.community.service.category.CategoryService;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.sopt.makers.internal.community.service.post.CommunityPostModifier;
+import org.sopt.makers.internal.community.service.post.CommunityPostRetriever;
+import org.sopt.makers.internal.external.pushNotification.PushNotificationService;
+import org.sopt.makers.internal.external.slack.SlackClient;
+import org.sopt.makers.internal.external.slack.SlackMessageUtil;
+import org.sopt.makers.internal.member.repository.MemberBlockRepository;
+import org.sopt.makers.internal.member.service.MemberRetriever;
+import org.sopt.makers.internal.vote.service.VoteService;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
@@ -24,8 +44,7 @@ public class CategoryServiceUnitTest {
     @InjectMocks
     private CategoryService categoryService;
 
-    @Mock
-    private CategoryRetriever categoryRetriever;
+    @Mock private CategoryRetriever categoryRetriever;
 
     @Test
     @DisplayName("커뮤니티 카테고리 조회")


### PR DESCRIPTION
## 🐬 요약
PR의 요약을 작성해주세요!

기존 멤버 검색 api 리팩토링(개수 리밋, 보여주는 순서, 코드 최적화)

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [x] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
PR에 담긴 작업 내용을 작성해주세요!

- 기존 멤버 검색 api 리팩토링(개수 리밋, 보여주는 순서, 코드 최적화)
기존 코드는 이름(name)을 기준으로 포함되는 모든 멤버를 조회하는 단순한 로직이었습니다. 이번에는 하나의 API 엔드포인트에서 초기 랜덤 유저 조회와 이름 기반 검색을 모두 처리하고, 정렬 순서와 개수 제한까지 적용하는 방식으로 리팩토링하였습니다.
- 시나리오는 아래와 같습니다.
시나리오 1 (초기 진입): 검색어(name)가 없거나 @일 경우, 랜덤 유저 30명을 반환합니다.
시나리오 2 (검색 시): 검색어가 있을 경우, 해당 검색어가 이름에 포함된 유저를 최신 활동 기수 순서로 정렬하여 반환합니다.
- Respository는 QueryDSL을 활용하여 복잡한 동적쿼리에 대한 안정성을 고려했습니다.



## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #685 
