### PR TITLE
[Feat] 앱팀 Internal 각 최상위 카테고리 별 최신글 5개 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/makers/internal/community/repository/post/CommunityPostRepository.java
+++ b/src/main/java/org/sopt/makers/internal/community/repository/post/CommunityPostRepository.java
@@ -21,6 +21,8 @@ public interface CommunityPostRepository extends JpaRepository<CommunityPost, Lo
 
     List<CommunityPost> findTop5ByCategoryIdNotOrderByCreatedAtDesc(Long categoryId);
 
+    Optional<CommunityPost> findFirstByCategoryIdOrderByCreatedAtDesc(Long categoryId);
+
     @Modifying
     @Query("UPDATE CommunityPost p SET p.hits = p.hits + 1 WHERE p.id = :postId")
     void increaseHitsDirect(@Param("postId") Long postId);

--- a/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostService.java
@@ -1,7 +1,9 @@
 package org.sopt.makers.internal.community.service.post;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +19,7 @@ import org.sopt.makers.internal.community.repository.post.DeletedCommunityPostRe
 import org.sopt.makers.internal.community.service.SopticleScrapedService;
 import org.sopt.makers.internal.exception.BusinessLogicException;
 import org.sopt.makers.internal.external.pushNotification.PushNotificationService;
+import org.sopt.makers.internal.internal.dto.InternalLatestPostResponse;
 import org.sopt.makers.internal.member.domain.MakersMemberId;
 import org.sopt.makers.internal.external.slack.SlackMessageUtil;
 import org.sopt.makers.internal.community.dto.request.PostSaveRequest;
@@ -40,6 +43,7 @@ import org.sopt.makers.internal.exception.ClientBadRequestException;
 import org.sopt.makers.internal.external.slack.SlackClient;
 import org.sopt.makers.internal.community.mapper.CommunityMapper;
 import org.sopt.makers.internal.community.mapper.CommunityResponseMapper;
+import org.sopt.makers.internal.member.domain.MemberSoptActivity;
 import org.sopt.makers.internal.member.service.MemberRetriever;
 import org.sopt.makers.internal.member.repository.MemberBlockRepository;
 import org.sopt.makers.internal.vote.dto.response.VoteResponse;
@@ -345,6 +349,32 @@ public class CommunityPostService {
                     );
                 })
                 .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<InternalLatestPostResponse> getInternalLatestPosts() {
+        final List<Long> topLevelCategoryIds = List.of(1L, 22L, 4L, 2L, 21L);
+
+        Map<Long, String> categoryNameMap = categoryRetriever.findAllByIds(topLevelCategoryIds).stream()
+                .collect(Collectors.toMap(Category::getId, Category::getName));
+
+        List<InternalLatestPostResponse> responses = new ArrayList<>();
+
+        for (Long categoryId : topLevelCategoryIds) {
+            Optional<CommunityPost> postOptional = communityPostRepository.findFirstByCategoryIdOrderByCreatedAtDesc(categoryId);
+
+            postOptional.ifPresent(post -> {
+                Member member = post.getMember();
+                MemberSoptActivity latestActivity = member.getActivities().stream()
+                        .max(Comparator.comparing(MemberSoptActivity::getGeneration))
+                        .orElse(null);
+
+                String categoryName = categoryNameMap.getOrDefault(post.getCategoryId(), "");
+
+                responses.add(InternalLatestPostResponse.of(post, latestActivity, categoryName));
+            });
+        }
+        return responses;
     }
 
     private PostWithPoints createPostWithPoints(CommunityPost post) {

--- a/src/main/java/org/sopt/makers/internal/internal/InternalOpenApiController.java
+++ b/src/main/java/org/sopt/makers/internal/internal/InternalOpenApiController.java
@@ -326,6 +326,15 @@ public class InternalOpenApiController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
+    @Operation(
+            summary = "앱팀 Internal API 최신글 5개 조회",
+            description = "최상위 카테고리별(자유, 질문, 홍보, 파트Talk, 솝티클)로 최신글 1개씩 총 5개를 조회하는 API입니다.")
+    @GetMapping("/community/posts/latest")
+    public ResponseEntity<List<InternalLatestPostResponse>> getLatestPostsForApp() {
+        List<InternalLatestPostResponse> response = communityPostService.getInternalLatestPosts();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
     @Operation(summary = "커피챗 오픈 유저 리스트 조회 API")
     @GetMapping("/members/coffeechat")
     public ResponseEntity<List<InternalCoffeeChatMemberResponse>> getCoffeeChatActivateMembers() {

--- a/src/main/java/org/sopt/makers/internal/internal/dto/InternalLatestPostResponse.java
+++ b/src/main/java/org/sopt/makers/internal/internal/dto/InternalLatestPostResponse.java
@@ -1,0 +1,38 @@
+package org.sopt.makers.internal.internal.dto;
+
+import java.time.format.DateTimeFormatter;
+import lombok.Builder;
+import org.sopt.makers.internal.community.domain.CommunityPost;
+import org.sopt.makers.internal.member.domain.MemberSoptActivity;
+
+@Builder
+public record InternalLatestPostResponse(
+        Long id,
+        String profileImage,
+        String name,
+        String generationAndPart,
+        String category,
+        String title,
+        String content,
+        String webLink,
+        String createdAt
+) {
+    public static InternalLatestPostResponse of(CommunityPost post, MemberSoptActivity latestActivity, String categoryName) {
+        String generationAndPart = "";
+        if (latestActivity != null) {
+            generationAndPart = String.format("%d기 %s", latestActivity.getGeneration(), latestActivity.getPart());
+        }
+
+        return new InternalLatestPostResponse(
+                post.getId(),
+                post.getMember().getProfileImage(),
+                post.getMember().getName(),
+                generationAndPart,
+                categoryName,
+                post.getTitle(),
+                post.getContent(),
+                "https://playground.sopt.org/?feed=" + post.getId(),
+                post.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS"))
+        );
+    }
+}


### PR DESCRIPTION
## 🐬 요약
PR의 요약을 작성해주세요!

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [x] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
PR에 담긴 작업 내용을 작성해주세요!

- 기존 DTO와 달리 새로운 응답 InternalLatestPostResponse DTO를 정의하여 요구사항에 맞췄습니다.
- 지정된 최상위 카테고리(자유, 질문, 홍보, 파트Talk, 솝티클) 목록을 기반으로 각 카테고리의 최신 게시물을 조회하고, 응답 DTO로 가공하는 비즈니스 로직을 구현했습니다..!
- 기존 최신글 API와 별도로 구현하였습니다. `/community/posts/latest`.
- `findFirstByCategoryIdOrderByCreatedAtDesc` JPA 메소드를 추가하여 특정 카테고리의 최신 게시물을 효율적으로 조회하도록 했습니다 :) 

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #687 
