### PR TITLE
[Feat] 앱팀에서 사용할 인기글 internal api 로직 구현

### DIFF
--- a/src/main/java/org/sopt/makers/internal/community/controller/CommunityController.java
+++ b/src/main/java/org/sopt/makers/internal/community/controller/CommunityController.java
@@ -238,6 +238,7 @@ public class CommunityController {
         return ResponseEntity.ok().body(recentPosts);
     }
 
+    @Deprecated
     @Operation(summary = "핫 게시물 조회 API")
     @GetMapping("/posts/hot")
     public ResponseEntity<Object> getTodayHotPost() {

--- a/src/main/java/org/sopt/makers/internal/community/dto/response/PopularPostResponse.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/response/PopularPostResponse.java
@@ -1,7 +1,5 @@
 package org.sopt.makers.internal.community.dto.response;
 
-import org.sopt.makers.internal.community.domain.CommunityPost;
-import org.sopt.makers.internal.community.domain.anonymous.AnonymousPostProfile;
 import org.sopt.makers.internal.member.dto.response.MemberNameAndProfileImageResponse;
 
 public record PopularPostResponse(

--- a/src/main/java/org/sopt/makers/internal/community/mapper/CommunityResponseMapper.java
+++ b/src/main/java/org/sopt/makers/internal/community/mapper/CommunityResponseMapper.java
@@ -3,19 +3,24 @@ package org.sopt.makers.internal.community.mapper;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import lombok.val;
+import org.sopt.makers.internal.common.util.MentionCleaner;
 import org.sopt.makers.internal.community.dto.*;
 import org.sopt.makers.internal.community.dto.response.*;
 import org.sopt.makers.internal.community.domain.anonymous.AnonymousCommentProfile;
 import org.sopt.makers.internal.community.domain.anonymous.AnonymousPostProfile;
 import org.sopt.makers.internal.community.domain.category.Category;
 import org.sopt.makers.internal.community.domain.CommunityPost;
+import org.sopt.makers.internal.internal.dto.InternalPopularPostResponse;
+import org.sopt.makers.internal.member.domain.MemberSoptActivity;
 import org.sopt.makers.internal.member.dto.response.MemberNameAndProfileImageResponse;
 import org.sopt.makers.internal.vote.dto.response.VoteResponse;
 import org.springframework.stereotype.Component;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toList;
 
 @Component
 public class CommunityResponseMapper {
@@ -73,7 +78,7 @@ public class CommunityResponseMapper {
         val member = dao.post().isBlindWriter() ? null : dao.member();
         val writerId = dao.post().isBlindWriter() ? null : dao.member().id();
         val isMine = Objects.equals(dao.member().id(), memberId);
-        val comments = commentDaos.stream().map(comment -> toCommentResponse(comment, memberId, null)).collect(Collectors.toList());
+        val comments = commentDaos.stream().map(comment -> toCommentResponse(comment, memberId, null)).collect(toList());
         val anonymousProfile = dao.post().isBlindWriter() && anonymousPostProfile != null ? toAnonymousPostProfileVo(anonymousPostProfile) : null;
         val createdAt = getRelativeTime(dao.post().createdAt());
         return new PostResponse(post.id(), member, writerId, isMine, isLiked, likes, post.categoryId(), category.name(), post.title(), post.content(), post.hits(),

--- a/src/main/java/org/sopt/makers/internal/community/mapper/CommunityResponseMapper.java
+++ b/src/main/java/org/sopt/makers/internal/community/mapper/CommunityResponseMapper.java
@@ -119,6 +119,41 @@ public class CommunityResponseMapper {
         return new InternalCommunityPost(dao.post().getId(), dao.post().getTitle(), dao.category().getName(), dao.post().getImages(), dao.post().getIsHot(), dao.post().getContent());
     }
 
+    public InternalPopularPostResponse toInternalPopularPostResponse(CommunityPost post, AnonymousPostProfile anonymousPostProfile, String categoryName, int rank) {
+        if (Boolean.TRUE.equals(post.getIsBlindWriter()) && anonymousPostProfile != null) {
+            // 익명일 경우
+            return InternalPopularPostResponse.builder()
+                    .id(post.getId())
+                    .profileImage(anonymousPostProfile.getProfileImg().getImageUrl())
+                    .name(anonymousPostProfile.getNickname().getNickname())
+                    .generationAndPart("")
+                    .rank(rank)
+                    .category(categoryName)
+                    .title(post.getTitle())
+                    .content(MentionCleaner.removeMentionIds(post.getContent()))
+                    .webLink("https://playground.sopt.org/?feed=" + post.getId())
+                    .build();
+        } else {
+            MemberSoptActivity latestActivity = post.getMember().getActivities().stream()
+                    .max(Comparator.comparing(MemberSoptActivity::getGeneration))
+                    .orElse(null);
+            String generationAndPart = (latestActivity != null)
+                    ? latestActivity.getGeneration() + "기 " + latestActivity.getPart()
+                    : "정보 없음";
+            return InternalPopularPostResponse.builder()
+                    .id(post.getId())
+                    .profileImage(post.getMember().getProfileImage())
+                    .name(post.getMember().getName())
+                    .generationAndPart(generationAndPart)
+                    .rank(rank)
+                    .category(categoryName)
+                    .title(post.getTitle())
+                    .content(MentionCleaner.removeMentionIds(post.getContent()))
+                    .webLink("https://playground.sopt.org/?feed=" + post.getId())
+                    .build();
+        }
+    }
+
     public PopularPostResponse toPopularPostResponse(CommunityPost post, AnonymousPostProfile anonymousPostProfile, String categoryName) {
         MemberNameAndProfileImageResponse memberResponse;
 

--- a/src/main/java/org/sopt/makers/internal/community/repository/CommunityQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/community/repository/CommunityQueryRepository.java
@@ -182,12 +182,14 @@ public class CommunityQueryRepository {
     public List<CommunityPost> findPopularPosts(int limitCount) {
         QCommunityPost communityPost = QCommunityPost.communityPost;
         QMember member = QMember.member;
+        QMemberSoptActivity activities = QMemberSoptActivity.memberSoptActivity;
 
         LocalDateTime oneMonthAgo = LocalDateTime.now().minusMonths(1);
 
         return queryFactory
                 .selectFrom(communityPost)
                 .leftJoin(communityPost.member, member).fetchJoin()
+                .leftJoin(member.activities, activities).fetchJoin()
                 .where(communityPost.createdAt.after(oneMonthAgo))
                 .orderBy(communityPost.hits.desc())
                 .limit(limitCount)

--- a/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostService.java
@@ -276,11 +276,7 @@ public class CommunityPostService {
 
     @Transactional(readOnly = true)
     public List<PopularPostResponse> getPopularPosts(int limitCount) {
-        List<CommunityPost> posts = communityQueryRepository.findPopularPosts(limitCount);
-
-        if (posts.isEmpty()) {
-            throw new BusinessLogicException("최근 한 달 내에 작성된 게시물이 없습니다.");
-        }
+        List<CommunityPost> posts = getPopularPostsBase(limitCount);
 
         Map<Long, String> categoryNameMap = getCategoryNameMap(posts);
         Map<Long, AnonymousPostProfile> anonymousProfileMap = getAnonymousProfileMap(posts);
@@ -292,6 +288,16 @@ public class CommunityPostService {
                         categoryNameMap.get(post.getCategoryId())
                 ))
                 .toList();
+    }
+
+
+    private List<CommunityPost> getPopularPostsBase(int limitCount) {
+        List<CommunityPost> posts = communityQueryRepository.findPopularPosts(limitCount);
+
+        if (posts.isEmpty()) {
+            throw new BusinessLogicException("최근 한 달 내에 작성된 게시물이 없습니다.");
+        }
+        return posts;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/makers/internal/internal/InternalOpenApiController.java
+++ b/src/main/java/org/sopt/makers/internal/internal/InternalOpenApiController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.sopt.makers.internal.community.dto.response.PopularPostResponse;
 import org.sopt.makers.internal.community.service.post.CommunityPostService;
 import org.sopt.makers.internal.common.auth.AuthConfig;
 import org.sopt.makers.internal.community.dto.InternalCommunityPost;
@@ -331,6 +332,14 @@ public class InternalOpenApiController {
     public ResponseEntity<List<InternalCoffeeChatMemberResponse>> getCoffeeChatActivateMembers() {
         List<InternalCoffeeChatMemberDto> members = memberService.getAllMemberByCoffeeChatActivate();
         List<InternalCoffeeChatMemberResponse> response = coffeeChatResponseMapper.toInternalCoffeeChatMemberResponse(members);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @Operation(summary = "솝트앱 내 보여지는 인기글 리스트 조회 API")
+    @GetMapping("/community/posts/popular")
+    public ResponseEntity<List<InternalPopularPostResponse>> getPopularPosts() {
+        int limit = 3;
+        List<InternalPopularPostResponse> response = communityPostService.getPopularPostsForInternal(limit);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/src/main/java/org/sopt/makers/internal/internal/dto/InternalPopularPostResponse.java
+++ b/src/main/java/org/sopt/makers/internal/internal/dto/InternalPopularPostResponse.java
@@ -1,0 +1,17 @@
+package org.sopt.makers.internal.internal.dto;
+
+import lombok.Builder;
+
+@Builder
+public record InternalPopularPostResponse(
+        Long id,
+        String profileImage,
+        String name,
+        String generationAndPart,
+        int rank,
+        String category,
+        String title,
+        String content,
+        String webLink
+) {
+}


### PR DESCRIPTION
## 🐬 요약
앱팀에서 사용할 인기글 internal api 로직 구현

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [ ] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
- InternalPopularPostResponse 레코드 생성
- 기존 플그에서 사용하던 인기글 로직에서 공통된 메서드 분리
- 파트 정보와 기수 정보도 가져올 수 있도록 join문 추가
- 익명글 여부에 따라 유저 정보 반환 분기 처리
- 반환되는 글 내용에 멘션 관련 내용 없도록 MentionCleaner 유틸리티 사용

## 🌟 관련 이슈
- closed: #686 
