### PR TITLE
[Fix] 상위 카테고리 조회 문제 해결

### DIFF
--- a/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostService.java
@@ -398,7 +398,7 @@ public class CommunityPostService {
                         .max(Comparator.comparing(MemberSoptActivity::getGeneration))
                         .orElse(null);
 
-                String categoryName = categoryNameMap.getOrDefault(post.getCategoryId(), "");
+                String categoryName = categoryNameMap.getOrDefault(categoryId, "");
 
                 Optional<AnonymousPostProfile> anonymousProfile = Optional.empty();
                 if (post.getIsBlindWriter()) {


### PR DESCRIPTION
## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [x] 버그 수정
- [ ] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
- 자식 카테고리를 가진 '홍보'(ID: 4L)와 '파트Talk'(ID: 2L) 카테고리에서 최신 게시글을 조회할 때, 해당 게시글이 자식 카테고리에 속해 있을 경우 categoryName이 정상적으로 반환되지 않는 문제가 있었습니다.
- 원인은 getInternalLatestPosts 메서드 에서 게시글(post)에 직접 저장된 categoryId를 사용하여 categoryNameMap에서 카테고리 이름을 조회했지만 categoryNameMap에는 최상위 카테고리 정보만 담겨 있어, 게시글이 하위 카테고리에 속한 경우 해당 ID를 찾지 못해 빈 문자열("")이 반환되었습니다!
- 이 문제를 해결하기 위해, 게시글 자체의 categoryId가 아닌, 반복문에서 사용 중인 **최상위 카테고리 ID (categoryId)**를 사용해 categoryNameMap에서 이름을 조회하도록 수정했습니다!

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #700 
