### PR TITLE
[Feat] 카테고리에 모임글 불러오기 API 연결

### DIFF
--- a/src/main/java/org/sopt/makers/internal/community/controller/CommunityController.java
+++ b/src/main/java/org/sopt/makers/internal/community/controller/CommunityController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.sopt.makers.internal.common.util.InfiniteScrollUtil;
@@ -42,6 +43,8 @@ public class CommunityController {
     private final CommunityResponseMapper communityResponseMapper;
     private final InfiniteScrollUtil infiniteScrollUtil;
 
+    private static final Long MEETING_CATEGORY_ID = 24L;
+
     @Operation(summary = "커뮤니티 글 상세 조회")
     @GetMapping("/posts/{postId}")
     public ResponseEntity<PostDetailResponse> getOnePost(
@@ -71,8 +74,14 @@ public class CommunityController {
             @RequestParam(required = false, name = "categoryId") Long categoryId,
             @RequestParam(value = "isBlockOn", required = false, defaultValue = "true") Boolean isBlockOn,
             @RequestParam(required = false, name = "limit") Integer limit,
-            @RequestParam(required = false, name = "cursor") Long cursor
+            @RequestParam(required = false, name = "cursor") Long cursor,
+            @RequestParam(required = false, name = "page", defaultValue = "1") Integer page
     ) {
+        if(Objects.equals(categoryId, MEETING_CATEGORY_ID)){
+            PostAllResponse response = communityPostService.getMeetingPosts(userId, page, limit);
+            return ResponseEntity.status(HttpStatus.OK).body(response);
+        }
+
         List<CommunityPostMemberVo> posts = communityPostService.getAllPosts(categoryId, isBlockOn, userId,
                 infiniteScrollUtil.checkLimitForPagination(limit), cursor);
         val hasNextPosts = infiniteScrollUtil.checkHasNextElement(limit, posts);

--- a/src/main/java/org/sopt/makers/internal/community/dto/response/PostResponse.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/response/PostResponse.java
@@ -28,5 +28,6 @@ public record PostResponse(
         AnonymousProfileVo anonymousProfile,
         String createdAt,
         List<CommentResponse> comments,
-        VoteResponse vote
+        VoteResponse vote,
+        Long meetingId //크루팀 모임Id
 ) {}

--- a/src/main/java/org/sopt/makers/internal/community/mapper/CommunityResponseMapper.java
+++ b/src/main/java/org/sopt/makers/internal/community/mapper/CommunityResponseMapper.java
@@ -2,6 +2,7 @@ package org.sopt.makers.internal.community.mapper;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
@@ -18,6 +19,7 @@ import org.sopt.makers.internal.community.dto.CommunityPostMemberVo;
 import org.sopt.makers.internal.community.dto.CommunityPostVo;
 import org.sopt.makers.internal.community.dto.MemberVo;
 import org.sopt.makers.internal.community.dto.PostDetailData;
+import org.sopt.makers.internal.community.dto.SoptActivityVo;
 import org.sopt.makers.internal.community.dto.response.CommentResponse;
 import org.sopt.makers.internal.community.dto.response.PopularPostResponse;
 import org.sopt.makers.internal.community.dto.response.PostDetailResponse;
@@ -26,6 +28,7 @@ import org.sopt.makers.internal.community.dto.response.PostSaveResponse;
 import org.sopt.makers.internal.community.dto.response.PostUpdateResponse;
 import org.sopt.makers.internal.community.dto.response.RecentPostResponse;
 import org.sopt.makers.internal.community.dto.response.SopticlePostResponse;
+import org.sopt.makers.internal.external.makers.CrewPost;
 import org.sopt.makers.internal.external.platform.InternalUserDetails;
 import org.sopt.makers.internal.external.platform.SoptActivity;
 import org.sopt.makers.internal.internal.dto.InternalPopularPostResponse;
@@ -126,6 +129,47 @@ public class CommunityResponseMapper {
                 category.name(), post.title(), post.content(), post.hits(),
                 comments.size(), post.images(), post.isQuestion(), post.isBlindWriter(),
                 post.sopticleUrl(), anonymousProfile, createdAt, comments, dao.post().vote()
+        );
+    }
+
+    public PostResponse toPostResponse(CrewPost crewPost, Long viewerId) {
+        val crewUser = crewPost.user();
+
+        val soptActivityVo = new SoptActivityVo(
+                crewUser.partInfo().generation(),
+                crewUser.partInfo().part(),
+                null
+        );
+
+        val memberVo = new MemberVo(
+                crewUser.id(),
+                crewUser.name(),
+                crewUser.profileImage(),
+                soptActivityVo,
+                null
+        );
+
+        return new PostResponse(
+                crewPost.id(),
+                memberVo,
+                crewUser.id(),
+                Objects.equals(crewUser.orgId(), viewerId), // isMine
+                crewPost.isLiked(),
+                crewPost.likeCount(),
+                24L, // 모임 카테고리 ID
+                "모임", // 모임 카테고리 이름
+                crewPost.title(),
+                crewPost.contents(),
+                crewPost.viewCount(),
+                crewPost.commentCount(),
+                crewPost.images(),
+                false, // isQuestion
+                false, // isBlindWriter
+                null,  // sopticleUrl
+                null,  // anonymousProfile
+                getRelativeTime(crewPost.createdDate()),
+                Collections.emptyList(), // comments
+                null // vote
         );
     }
 

--- a/src/main/java/org/sopt/makers/internal/community/mapper/CommunityResponseMapper.java
+++ b/src/main/java/org/sopt/makers/internal/community/mapper/CommunityResponseMapper.java
@@ -128,7 +128,7 @@ public class CommunityResponseMapper {
                 post.id(), member, writerId, isMine, isLiked, likes, post.categoryId(),
                 category.name(), post.title(), post.content(), post.hits(),
                 comments.size(), post.images(), post.isQuestion(), post.isBlindWriter(),
-                post.sopticleUrl(), anonymousProfile, createdAt, comments, dao.post().vote()
+                post.sopticleUrl(), anonymousProfile, createdAt, comments, dao.post().vote(), null
         );
     }
 
@@ -169,7 +169,8 @@ public class CommunityResponseMapper {
                 null,  // anonymousProfile
                 getRelativeTime(crewPost.createdDate()),
                 Collections.emptyList(), // comments
-                null // vote
+                null, // vote
+                crewPost.meetingId()
         );
     }
 

--- a/src/main/java/org/sopt/makers/internal/external/makers/CrewMeeting.java
+++ b/src/main/java/org/sopt/makers/internal/external/makers/CrewMeeting.java
@@ -1,0 +1,9 @@
+package org.sopt.makers.internal.external.makers;
+
+public record CrewMeeting(
+        String title,
+        String category,
+        String imageUrl,
+        String description
+) {
+}

--- a/src/main/java/org/sopt/makers/internal/external/makers/CrewMeetingListResponse.java
+++ b/src/main/java/org/sopt/makers/internal/external/makers/CrewMeetingListResponse.java
@@ -1,0 +1,8 @@
+package org.sopt.makers.internal.external.makers;
+
+import java.util.List;
+
+public record CrewMeetingListResponse(
+        List<CrewMeeting> meetings
+) {
+}

--- a/src/main/java/org/sopt/makers/internal/external/makers/CrewPost.java
+++ b/src/main/java/org/sopt/makers/internal/external/makers/CrewPost.java
@@ -1,0 +1,29 @@
+package org.sopt.makers.internal.external.makers;
+
+import java.time.LocalDateTime;
+
+public record CrewPost(
+        long id,
+        String title,
+        String contents,
+        LocalDateTime createdDate,
+        String[] images,
+        CrewUser user,
+        int likeCount,
+        boolean isLiked,
+        int viewCount,
+        int commentCount
+) {
+    public record CrewUser(
+            long id,
+            long orgId,
+            String name,
+            String profileImage,
+            PartInfo partInfo
+    ) {}
+
+    public record PartInfo(
+            String part,
+            int generation
+    ) {}
+}

--- a/src/main/java/org/sopt/makers/internal/external/makers/CrewPost.java
+++ b/src/main/java/org/sopt/makers/internal/external/makers/CrewPost.java
@@ -12,7 +12,8 @@ public record CrewPost(
         int likeCount,
         boolean isLiked,
         int viewCount,
-        int commentCount
+        int commentCount,
+        Long meetingId
 ) {
     public record CrewUser(
             long id,

--- a/src/main/java/org/sopt/makers/internal/external/makers/CrewPostListResponse.java
+++ b/src/main/java/org/sopt/makers/internal/external/makers/CrewPostListResponse.java
@@ -1,0 +1,9 @@
+package org.sopt.makers.internal.external.makers;
+
+import java.util.List;
+
+public record CrewPostListResponse(
+        List<CrewPost> posts,
+        PaginationMeta pageMeta
+) {
+}

--- a/src/main/java/org/sopt/makers/internal/external/makers/MakersCrewClient.java
+++ b/src/main/java/org/sopt/makers/internal/external/makers/MakersCrewClient.java
@@ -10,6 +10,13 @@ import org.springframework.web.bind.annotation.RequestParam;
 @FeignClient(value = "makersCrewClient", url = "${internal.crew.url}")
 public interface MakersCrewClient {
 
+    @GetMapping("/internal/post/{orgId}")
+    CrewPostListResponse getPosts(
+            @PathVariable("orgId") Long orgId,
+            @RequestParam("page") Integer page,
+            @RequestParam("take") Integer take
+    );
+
     @GetMapping("/meeting/v2/org-user")
     MemberCrewResponse getUserAllCrew(
             @RequestParam("page") Integer page,

--- a/src/main/java/org/sopt/makers/internal/external/makers/MakersCrewClient.java
+++ b/src/main/java/org/sopt/makers/internal/external/makers/MakersCrewClient.java
@@ -10,6 +10,12 @@ import org.springframework.web.bind.annotation.RequestParam;
 @FeignClient(value = "makersCrewClient", url = "${internal.crew.url}")
 public interface MakersCrewClient {
 
+    @GetMapping("/internal/meetings/post")
+    CrewMeetingListResponse getMeetings(
+            @RequestParam("page") Integer page,
+            @RequestParam("take") Integer take
+    );
+
     @GetMapping("/internal/post/{orgId}")
     CrewPostListResponse getPosts(
             @PathVariable("orgId") Long orgId,


### PR DESCRIPTION
## 🐬 요약
[Feat] 카테고리에 모임글 불러오기 API 연결

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [x] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
PR에 담긴 작업 내용을 작성해주세요!

- 크루팀의 API를 연결해 모임 카테고리 클릭 시, 크루 팀 모임 피드 전체 조회 API 를 호출하여 피드를 불러오도록 구현했습니다..!

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #719 
