### PR TITLE
[Feat] 멤버 검색 관련 플랫폼팀 API 연결 & MemberSoptActivity 관련 의존성 제거

### DIFF
--- a/src/main/java/org/sopt/makers/internal/community/repository/CommunityQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/community/repository/CommunityQueryRepository.java
@@ -18,7 +18,6 @@ import org.sopt.makers.internal.community.dto.QCommentDao;
 import org.sopt.makers.internal.member.domain.QMember;
 import org.sopt.makers.internal.member.domain.QMemberBlock;
 import org.sopt.makers.internal.member.domain.QMemberCareer;
-import org.sopt.makers.internal.member.domain.QMemberSoptActivity;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -40,7 +39,6 @@ public class CommunityQueryRepository {
         val posts = QCommunityPost.communityPost;
         val member = QMember.member;
         val category = QCategory.category;
-        val activities = QMemberSoptActivity.memberSoptActivity;
         val careers = QMemberCareer.memberCareer;
         val memberBlock = QMemberBlock.memberBlock;
 
@@ -49,7 +47,6 @@ public class CommunityQueryRepository {
             query = queryFactory.select(new QCategoryPostMemberDao(posts, member, category))
                     .from(posts)
                     .innerJoin(posts.member, member)
-                    .innerJoin(member.activities, activities)
                     .leftJoin(member.careers, careers).on(member.id.eq(careers.memberId))
                     .innerJoin(category).on(posts.categoryId.eq(category.id))
                     .where(ltPostId(cursor), category.id.eq(categoryId).or(category.parent.id.eq(categoryId)))
@@ -60,7 +57,6 @@ public class CommunityQueryRepository {
             query = queryFactory.select(new QCategoryPostMemberDao(posts, member, category))
                     .from(posts)
                     .innerJoin(posts.member, member)
-                    .innerJoin(member.activities, activities)
                     .leftJoin(member.careers, careers).on(member.id.eq(careers.memberId))
                     .innerJoin(category).on(posts.categoryId.eq(category.id))
                     .where(ltPostId(cursor), category.id.eq(categoryId).or(category.parent.id.eq(categoryId)))
@@ -82,7 +78,6 @@ public class CommunityQueryRepository {
     }
 
     public CategoryPostMemberDao getPostById(Long postId) {
-        val activities = QMemberSoptActivity.memberSoptActivity;
         val posts = QCommunityPost.communityPost;
         val category = QCategory.category;
         val member = QMember.member;
@@ -90,7 +85,6 @@ public class CommunityQueryRepository {
         return queryFactory.select(new QCategoryPostMemberDao(posts, member, category))
                 .from(posts)
                 .innerJoin(posts.member, member)
-                .leftJoin(member.activities, activities)
                 .innerJoin(category).on(posts.categoryId.eq(category.id))
                 .where(posts.id.eq(postId)).distinct().fetchOne();
     }
@@ -135,14 +129,12 @@ public class CommunityQueryRepository {
     public List<CommentDao> findCommentByPostId(Long postId, Long memberId, boolean isBlockedOn) {
         val comment = QCommunityComment.communityComment;
         val member = QMember.member;
-        val activities = QMemberSoptActivity.memberSoptActivity;
         val careers = QMemberCareer.memberCareer;
         val memberBlock = QMemberBlock.memberBlock;
 
         JPAQuery<CommentDao> query = queryFactory.select(new QCommentDao(member, comment))
                 .from(comment)
                 .innerJoin(member).on(member.id.eq(comment.writerId))
-                .innerJoin(member.activities, activities)
                 .leftJoin(member.careers, careers)
                 .where(comment.postId.eq(postId))
                 .distinct()
@@ -182,14 +174,12 @@ public class CommunityQueryRepository {
     public List<CommunityPost> findPopularPosts(int limitCount) {
         QCommunityPost communityPost = QCommunityPost.communityPost;
         QMember member = QMember.member;
-        QMemberSoptActivity activities = QMemberSoptActivity.memberSoptActivity;
 
         LocalDateTime oneMonthAgo = LocalDateTime.now().minusMonths(1);
 
         return queryFactory
                 .selectFrom(communityPost)
                 .leftJoin(communityPost.member, member).fetchJoin()
-                .leftJoin(member.activities, activities).fetchJoin()
                 .where(communityPost.createdAt.after(oneMonthAgo))
                 .orderBy(communityPost.hits.desc())
                 .limit(limitCount)

--- a/src/main/java/org/sopt/makers/internal/external/platform/PlatformClient.java
+++ b/src/main/java/org/sopt/makers/internal/external/platform/PlatformClient.java
@@ -29,4 +29,16 @@ public interface PlatformClient{
             @RequestBody PlatformUserUpdateRequest body
     );
 
+    @GetMapping(value = "/api/v1/users/search")
+    ResponseEntity<BaseResponse<UserSearchResponse>> searchUsers(
+        @RequestHeader(name = "X-Api-Key") String apiKey,
+        @RequestHeader(name = "X-Service-Name") String serviceName,
+        @RequestParam(name = "generation", required = false) Integer generation,
+        @RequestParam(name = "part", required = false) String part,
+        @RequestParam(name = "team", required = false) String team,
+        @RequestParam(name = "name", required = false) String name,
+        @RequestParam(name = "limit", required = false) Integer limit,
+        @RequestParam(name = "offset", required = false) Integer offset,
+        @RequestParam(name = "orderBy", required = false) String orderBy
+    );
 }

--- a/src/main/java/org/sopt/makers/internal/external/platform/PlatformService.java
+++ b/src/main/java/org/sopt/makers/internal/external/platform/PlatformService.java
@@ -119,4 +119,24 @@ public class PlatformService {
             throw new RuntimeException("플랫폼 API 호출 실패 또는 인증 오류. id: " + userId);
         }
     }
+
+    /**
+     * 유저 검색 관련 메서드
+     */
+    public UserSearchResponse searchInternalUsers(
+        Integer generation, String part, String team, String name,
+        Integer limit, Integer offset, String orderBy
+    ) {
+        val result = platformClient.searchUsers(
+            authConfig.getPlatformApiKey(),
+            authConfig.getPlatformServiceName(),
+            generation, part, team, name, limit, offset, orderBy
+        );
+
+        val body = result.getBody();
+        if (body == null || !Boolean.TRUE.equals(body.isSuccess()) || body.getData() == null) {
+            throw new RuntimeException("플랫폼 검색 API 호출 실패 또는 인증 오류.");
+        }
+        return body.getData();
+    }
 }

--- a/src/main/java/org/sopt/makers/internal/external/platform/UserSearchResponse.java
+++ b/src/main/java/org/sopt/makers/internal/external/platform/UserSearchResponse.java
@@ -1,0 +1,10 @@
+package org.sopt.makers.internal.external.platform;
+
+import java.util.List;
+
+public record UserSearchResponse(
+	List<InternalUserDetails> profiles,
+	boolean hasNext,
+	int totalCount
+) {
+}

--- a/src/main/java/org/sopt/makers/internal/member/controller/MemberController.java
+++ b/src/main/java/org/sopt/makers/internal/member/controller/MemberController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
@@ -75,15 +76,15 @@ public class MemberController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-//    @Operation(summary = "멤버 검색 API", description = """
-//            - name 파라미터가 없거나 '@'인 경우: 랜덤 유저 30명을 반환합니다.
-//            - name 파라미터에 검색어가 있는 경우: 해당 이름이 포함된 유저를 최신 활동기수 순으로 정렬하여 반환합니다.
-//            """)
-//    @GetMapping("/search")
-//    public ResponseEntity<List<MemberResponse>> getMemberByName (@RequestParam String name) {
-//        List<MemberResponse> responses = memberService.getMemberByName(name);
-//        return ResponseEntity.status(HttpStatus.OK).body(responses);
-//    }
+   @Operation(summary = "멤버 검색 API", description = """
+           - name 파라미터가 없거나 '@'인 경우: 랜덤 유저 30명을 반환합니다.
+           - name 파라미터에 검색어가 있는 경우: 해당 이름이 포함된 유저를 최신 활동기수 순으로 정렬하여 반환합니다.
+           """)
+   @GetMapping("/search")
+   public ResponseEntity<List<MemberResponse>> getMemberByName (@RequestParam String name) {
+       List<MemberResponse> responses = memberService.getMemberByName(name);
+       return ResponseEntity.status(HttpStatus.OK).body(responses);
+   }
 
 
     @Operation(summary = "유저 프로필 생성 API",
@@ -229,16 +230,16 @@ public class MemberController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    @Operation(summary = "멤버 프로필 활동 삭제 API")
-    @DeleteMapping("/profile/activity/{activityId}")
-    public ResponseEntity<CommonResponse> deleteUserProfileActivity (
-            @PathVariable(name = "activityId") Long activityId,
-            @Parameter(hidden = true) @AuthenticationPrincipal Long userId
-    ) {
-        memberService.deleteUserProfileActivity(activityId, userId);
-        CommonResponse response = new CommonResponse(true, "성공적으로 activity를 삭제했습니다.");
-        return ResponseEntity.status(HttpStatus.OK).body(response);
-    }
+    // @Operation(summary = "멤버 프로필 활동 삭제 API")
+    // @DeleteMapping("/profile/activity/{activityId}")
+    // public ResponseEntity<CommonResponse> deleteUserProfileActivity (
+    //         @PathVariable(name = "activityId") Long activityId,
+    //         @Parameter(hidden = true) @AuthenticationPrincipal Long userId
+    // ) {
+    //     memberService.deleteUserProfileActivity(activityId, userId);
+    //     CommonResponse response = new CommonResponse(true, "성공적으로 activity를 삭제했습니다.");
+    //     return ResponseEntity.status(HttpStatus.OK).body(response);
+    // }
 
     @Operation(summary = "유저 차단 활성하기 API")
     @PatchMapping("/block/activate")

--- a/src/main/java/org/sopt/makers/internal/member/domain/Member.java
+++ b/src/main/java/org/sopt/makers/internal/member/domain/Member.java
@@ -110,55 +110,12 @@ public class Member {
     @ColumnDefault("true")
     private Boolean isPhoneBlind = true;
 
-    // ==================================
-    // 해당 컬럼들은 QA 이상없으면 완전히 삭제하기
-    // ==================================
-
-    // TODO: - activities 삭제 부탁
-    @Builder.Default
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private List<MemberSoptActivity> activities = new ArrayList<>();
-
-//    @Column(name = "auth_user_id")
-//    private String authUserId;
-//
-//    @Column(name = "idp_type")
-//    private String idpType;
-//
-//    @Column(name = "name")
-//    private String name;
-//
-//    @Column(name = "email")
-//    private String email;
-//
-//    @Column(name = "generation")
-//    private Integer generation;
-//
-//    @Column(name = "profile_image")
-//    private String profileImage;
-//
-//    @Column
-//    private LocalDate birthday;
-//
-//    @Column
-//    private String phone;
-
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<VoteSelection> voteSelections = new ArrayList<>();
 
     public void editActivityChange(Boolean isCheck) {
         this.editActivitiesAble = isCheck;
     }
-
-//    public void updateMemberAuth(String authUserId, String idpType) {
-//        this.authUserId = authUserId;
-//        this.idpType = idpType;
-//    }
-
-//    public void changeEmail(String email) {
-//        this.email = email;
-//    }
 
     public void saveMemberProfile(
             String address,
@@ -174,10 +131,6 @@ public class Member {
             String idealType,
             String selfIntroduction,
             Boolean allowOfficial,
-
-            // TODO: - activities 삭제 부탁
-            List<MemberSoptActivity> activities,
-
             List<MemberLink> links,
             List<MemberCareer> careers,
             Boolean isPhoneBlind
@@ -195,11 +148,6 @@ public class Member {
         this.idealType = idealType;
         this.selfIntroduction = selfIntroduction;
         this.allowOfficial = allowOfficial;
-
-        // TODO: - activities 삭제 부탁
-        this.activities.clear();
-        this.activities.addAll(activities);
-
         this.links.clear();
         this.links.addAll(links);
         this.careers.clear();

--- a/src/main/java/org/sopt/makers/internal/member/mapper/MemberMapper.java
+++ b/src/main/java/org/sopt/makers/internal/member/mapper/MemberMapper.java
@@ -4,8 +4,8 @@ import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.sopt.makers.internal.external.platform.InternalUserDetails;
+import org.sopt.makers.internal.external.platform.SoptActivity;
 import org.sopt.makers.internal.member.domain.Member;
-import org.sopt.makers.internal.member.domain.MemberSoptActivity;
 import org.sopt.makers.internal.member.dto.ActivityVo;
 import org.sopt.makers.internal.member.dto.MemberProfileProjectDao;
 import org.sopt.makers.internal.member.dto.MemberProfileProjectVo;
@@ -23,7 +23,7 @@ public interface MemberMapper {
     MemberProfileResponse toProfileResponse (Member member, InternalUserDetails userDetails, Boolean isCoffeeChatActivate);
 
     @Mapping(target = "projects", source = "projects")
-    MemberProfileProjectVo toSoptMemberProfileProjectVo(MemberSoptActivity member, List<MemberProjectVo> projects);
+    MemberProfileProjectVo toSoptMemberProfileProjectVo(SoptActivity member, List<MemberProjectVo> projects);
 
     @Mapping(target = "name", source = "userDetails.name")
     @Mapping(target = "profileImage", source = "userDetails.profileImage")
@@ -41,14 +41,12 @@ public interface MemberMapper {
             Boolean isCoffeeChatActivate
     );
 
-    ActivityVo toActivityInfoVo (MemberSoptActivity activity, boolean isProject);
+    @Mapping(target="id", source="activity.activityId")
+    ActivityVo toActivityInfoVo (SoptActivity activity, boolean isProject);
 
     @Mapping(source = "project.name", target = "team")
     ActivityVo toActivityInfoVo (MemberProfileProjectDao project, boolean isProject, String part);
 
     MemberProjectVo toActivityInfoVo (MemberProfileProjectDao project);
 
-    default String mapPhoneIfBlind(Boolean isPhoneBlind, String phone) {
-        return isPhoneBlind ? null : phone;
-    }
 }

--- a/src/main/java/org/sopt/makers/internal/member/repository/MemberProfileQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/member/repository/MemberProfileQueryRepository.java
@@ -1,22 +1,14 @@
 package org.sopt.makers.internal.member.repository;
 
-import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.List;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.sopt.makers.internal.coffeechat.domain.QCoffeeChat;
-import org.sopt.makers.internal.member.domain.MakersMemberId;
 import org.sopt.makers.internal.member.domain.Member;
 import org.sopt.makers.internal.member.domain.QMember;
-import org.sopt.makers.internal.member.domain.QMemberCareer;
-import org.sopt.makers.internal.member.domain.QMemberSoptActivity;
-import org.sopt.makers.internal.member.domain.enums.OrderByCondition;
 import org.sopt.makers.internal.member.dto.MemberProfileProjectDao;
 import org.sopt.makers.internal.member.dto.QMemberProfileProjectDao;
 import org.sopt.makers.internal.project.domain.QMemberProjectRelation;
@@ -31,66 +23,6 @@ public class MemberProfileQueryRepository {
 
     private final JPAQueryFactory queryFactory;
 
-    private static final List<Long> WHITE_LIST = List.of(894L);
-
-    private BooleanExpression checkActivityContainsPart(String part) {
-        if(part == null) return null;
-        return QMemberSoptActivity.memberSoptActivity.part.contains(part);
-    }
-
-    private BooleanExpression checkUserContainsPart(String part) {
-        if(part == null) return null;
-        return QMember.member.id.in(queryFactory.select(QMember.member.id)
-                .innerJoin(QMember.member.activities, QMemberSoptActivity.memberSoptActivity)
-                .where(checkActivityContainsPart(part)));
-    }
-
-    private BooleanExpression checkActivityContainsGenerationAndTeam(Integer generation, String team) {
-        if(generation == null && team == null) return null;
-        return QMember.member.id.in(
-                queryFactory.select(QMember.member.id)
-                        .innerJoin(QMember.member.activities, QMemberSoptActivity.memberSoptActivity)
-                        .where(QMemberSoptActivity.memberSoptActivity.generation.eq(generation)
-                                        .and(checkActivityContainsTeam(team)))
-        );
-    }
-
-    private BooleanExpression checkActivityContainsGenerationAndPart(Integer generation, String part) {
-        if(generation == null && part == null) return null;
-        return QMember.member.id.in(
-                queryFactory.select(QMember.member.id)
-                        .innerJoin(QMember.member.activities, QMemberSoptActivity.memberSoptActivity)
-                        .where(QMemberSoptActivity.memberSoptActivity.generation.eq(generation)
-                                .and(checkActivityContainsPart(part)))
-        );
-    }
-
-    private BooleanExpression checkActivityContainsPartAndTeam(String part, String team) {
-        if(part == null && team == null) return null;
-        else if(part == null) return checkActivityContainsTeam(team);
-        else if(team == null) return checkActivityContainsPart(part);
-        else {
-            return QMember.member.id.in(
-                    queryFactory.select(QMember.member.id)
-                            .innerJoin(QMember.member.activities, QMemberSoptActivity.memberSoptActivity)
-                            .where(checkActivityContainsTeam(team).and(checkUserContainsPart(part)))
-            );
-        }
-    }
-
-    private BooleanExpression checkActivityContainsGenerationAndTeamAndPart(Integer generation, String team, String part) {
-        if(generation == null && team == null && part == null) return null;
-        else if(generation == null) return checkActivityContainsPartAndTeam(part,team);
-        else if(part == null) return checkActivityContainsGenerationAndTeam(generation,team);
-        else if(team == null) return checkActivityContainsGenerationAndPart(generation,part);
-        return QMember.member.id.in(
-                queryFactory.select(QMember.member.id)
-                        .innerJoin(QMember.member.activities, QMemberSoptActivity.memberSoptActivity)
-                        .where(checkActivityContainsGenerationAndTeam(generation,team)
-                                .and(checkActivityContainsGenerationAndPart(generation,part)))
-        );
-    }
-
     private BooleanExpression checkMemberHasProfile() {
         return QMember.member.hasProfile.eq(true);
     }
@@ -100,70 +32,9 @@ public class MemberProfileQueryRepository {
         return isMbtiEmpty ? null : QMember.member.mbti.eq(mbti);
     }
 
-    private BooleanExpression checkActivityContainsTeam(String team) {
-        val isTeamEmpty = Objects.isNull(team);
-        if (isTeamEmpty) return null;
-        switch (team) {
-            case "임원진" -> {
-                return QMemberSoptActivity.memberSoptActivity.part.eq("메이커스 리드")
-                        .or(QMemberSoptActivity.memberSoptActivity.part.eq("총무")
-                                .or(QMemberSoptActivity.memberSoptActivity.part.contains("장")));
-            }
-            case "운영팀" -> {
-                return QMemberSoptActivity.memberSoptActivity.part.eq("운영 팀장")
-                        .or(QMemberSoptActivity.memberSoptActivity.team.eq("운영팀"));
-            }
-            case "미디어팀" -> {
-                return QMemberSoptActivity.memberSoptActivity.part.eq("미디어 팀장")
-                        .or(QMemberSoptActivity.memberSoptActivity.team.eq("미디어팀"));
-            }
-            case "메이커스" -> {
-                return QMember.member.id.in(MakersMemberId.getMakersMember());
-            }
-            default -> {
-                return null;
-            }
-        }
-    }
-
-    private BooleanExpression checkNotInWhiteList(QMember member) {
-        return member.id.notIn(WHITE_LIST);
-    }
-
-    private BooleanExpression checkContainsSearchCond(QMember member, QMemberCareer memberCareer, String search) {
-        if (search == null || memberCareer == null) return null;
-        return memberCareer.companyName.contains(search)
-                // TODO : - name contain 해결하기
-//            .or(member.name.contains(search))
-            .or(member.university.contains(search));
-    }
-
-    private BooleanExpression checkMemberCurrentlyEmployed(QMemberCareer memberCareer, Integer employed) {
-        if (employed == null || employed != 1 || memberCareer == null) return null;
-
-        val dateFormat = new SimpleDateFormat("yyyy-MM");
-        val today = dateFormat.format(new Date());
-        return memberCareer.isNotNull()
-            .and(memberCareer.isCurrent.isTrue()
-                .and(memberCareer.endDate.isNull().or(memberCareer.endDate.goe(today.toString()))));
-
-    }
-
-    private OrderSpecifier getOrderByCondition(OrderByCondition orderByNum) {
-        val orderByNumIsEmpty = Objects.isNull(orderByNum);
-        if (orderByNumIsEmpty) return QMember.member.id.desc();
-        return switch (orderByNum) {
-            case OLDEST_REGISTERED -> QMember.member.id.asc();
-            case LATEST_GENERATION -> QMemberSoptActivity.memberSoptActivity.generation.max().desc();
-            case OLDEST_GENERATION -> QMemberSoptActivity.memberSoptActivity.generation.min().asc();
-            default -> QMember.member.id.desc();
-        };
-    }
-
     public List<MemberProfileProjectDao> findMemberProfileProjectsByMemberId (Long memberId) {
         val project = QProject.project;
         val relation = QMemberProjectRelation.memberProjectRelation;
-        val member = QMember.member;
         return queryFactory.select(
                         new QMemberProfileProjectDao(
                                 project.id, project.writerId, project.name, project.summary, project.generation,
@@ -172,57 +43,6 @@ public class MemberProfileQueryRepository {
                 .innerJoin(relation).on(project.id.eq(relation.projectId))
                 .where(relation.isTeamMember.isTrue().and(relation.userId.eq(memberId)))
                 .fetch();
-    }
-
-    public List<Member> findAllLimitedMemberProfile(
-            String part, Integer limit, Integer cursor, String search,
-            Integer generation, Integer employed, Integer orderBy, String mbti, String team
-    ) {
-        val member = QMember.member;
-        val activities = QMemberSoptActivity.memberSoptActivity;
-        val career = QMemberCareer.memberCareer;
-
-        return queryFactory.selectFrom(member)
-                .innerJoin(member.activities, activities)
-                .leftJoin(member.careers, career)
-                .where(checkMemberHasProfile(),
-                        checkContainsSearchCond(member, career, search),
-                        checkMemberCurrentlyEmployed(career, employed),
-                        checkMemberMbti(mbti), checkActivityContainsGenerationAndTeamAndPart(generation, team, part),
-                        checkNotInWhiteList(member))
-                .offset(cursor)
-                .limit(limit)
-                .groupBy(member.id)
-                .orderBy(getOrderByCondition(OrderByCondition.valueOf(orderBy))).fetch();
-    }
-
-//    public List<Member> findAllMemberProfilesBySearchCond(String search) {
-//        val member = QMember.member;
-//        val career = QMemberCareer.memberCareer;
-//        return queryFactory.selectFrom(member)
-//            .innerJoin(member.careers, career)
-//            .where(checkContainsSearchCond(member, career, search))
-//            .groupBy(member.id)
-//            .fetch();
-//    }
-
-    public int countAllMemberProfile(String part, String search, Integer generation, Integer employed, String mbti, String team) {
-        val member = QMember.member;
-        val career = QMemberCareer.memberCareer;
-        val activities = QMemberSoptActivity.memberSoptActivity;
-        return queryFactory.select(member.id)
-                .from(member)
-                .innerJoin(member.activities, activities)
-                .leftJoin(member.careers, career)
-                .where(checkMemberHasProfile(),
-                    checkContainsSearchCond(member, career, search),
-                    checkMemberCurrentlyEmployed(career, employed),
-                    checkActivityContainsPart(part),checkMemberMbti(mbti),
-                    checkActivityContainsGenerationAndTeamAndPart(generation, team, part),
-                    checkNotInWhiteList(member))
-                .groupBy(member.id)
-                .fetch()
-                .size();
     }
 
     public List<Member> findAllMembersByCoffeeChatActivate() {
@@ -253,131 +73,4 @@ public class MemberProfileQueryRepository {
         return isUniversityEmpty ? null : QMember.member.university.contains(university);
     }
 
-//    public List<Member> findAllLimitedMemberProfile(String part, Integer limit, Integer cursor, String name, Integer generation) {
-//        val member = QMember.member;
-//        val activities = QMemberSoptActivity.memberSoptActivity;
-//        return queryFactory.selectFrom(member)
-//                .innerJoin(member.activities, activities)
-//                .where(checkMemberHasProfile(), checkActivityContainsPart(part), checkUserActivityContainsGeneration(generation), checkMemberContainsName(name))
-//                .offset(cursor)
-//                .limit(limit)
-//                .groupBy(member.id)
-//                .orderBy(member.id.asc())
-//                .fetch();
-//    }
-//    public List<Member> findAllMemberProfile(String part, Integer cursor, String name, Integer generation) {
-//        val member = QMember.member;
-//        val activities = QMemberSoptActivity.memberSoptActivity;
-//        return queryFactory.selectFrom(member)
-//                .innerJoin(member.activities, activities)
-//                .where(checkMemberHasProfile(), checkActivityContainsPart(part), checkUserActivityContainsGeneration(generation), checkMemberContainsName(name))
-//                .groupBy(member.id)
-//                .orderBy(member.id.asc())
-//                .fetch();
-//    }
-//
-//    public List<Member> findAllMemberProfile(String part, String search, Integer generation,
-//        Integer employed, Integer orderBy, String mbti, String team) {
-//        val member = QMember.member;
-//        val activities = QMemberSoptActivity.memberSoptActivity;
-//        val career = QMemberCareer.memberCareer;
-//        return queryFactory.selectFrom(member)
-//                .innerJoin(member.activities, activities)
-//                .leftJoin(member.careers, career)
-//                .where(checkMemberHasProfile(),
-//                        checkContainsSearchCond(member, career, search),
-//                        checkMemberCurrentlyEmployed(career, employed),
-//                        checkActivityContainsPart(part), checkMemberMbti(mbti), checkNotInWhiteList(member),
-//                        checkActivityContainsGenerationAndTeamAndPart(generation, team, part))
-//                .groupBy(member.id)
-//                .orderBy(getOrderByCondition(OrderByCondition.valueOf(orderBy)))
-//                .fetch();
-//    }
-//
-//    public List<Long> findAllMemberIdsByGeneration(Integer generation) {
-//        val member = QMember.member;
-//        val activities = QMemberSoptActivity.memberSoptActivity;
-//        return queryFactory.select(member.id)
-//                .from(member)
-//                .innerJoin(member.activities, activities)
-//                .where(checkMemberHasProfile(), checkUserActivityContainsGeneration(generation)
-//                ).groupBy(member.id)
-//                .fetch();
-//    }
-//
-//
-//    public List<Long> findAllInactivityMemberIdsByGenerationAndPart(Integer generation, Part part) {
-//        val member = QMember.member;
-//        val activities = QMemberSoptActivity.memberSoptActivity;
-//        if (part != null) {
-//            return queryFactory.select(member.id)
-//                    .from(member)
-//                    .innerJoin(member.activities, activities)
-//                    .where(activities.generation.ne(generation))
-//                    .where(activities.part.eq(part.getTitle()))
-//                    .groupBy(member.id)
-//                    .orderBy(member.id.asc())
-//                    .fetch();
-//        } else {
-//            return queryFactory.select(member.id)
-//                    .from(member)
-//                    .innerJoin(member.activities, activities)
-//                    .where(activities.generation.ne(generation))
-//                    .groupBy(member.id)
-//                    .orderBy(member.id.asc())
-//                    .fetch();
-//        }
-//    }
-//
-//    public int countMembersByGeneration(Integer generation) {
-//        val member = QMember.member;
-//        val activities = QMemberSoptActivity.memberSoptActivity;
-//        return queryFactory.select(member.id)
-//                .from(member)
-//                .innerJoin(member.activities, activities).on(activities.memberId.eq(member.id))
-//                .where(checkMemberHasProfile(), checkUserActivityContainsGeneration(generation))
-//                .groupBy(member.id)
-//                .fetch()
-//                .size();
-//    }
-//
-//    private BooleanExpression checkMemberContainsName(String name) {
-//        if(name == null) return null;
-//        return QMember.member.name.contains(name);
-//    }
-//
-//    private BooleanExpression checkUserActivityContainsGeneration(Integer generation) {
-//        if(generation == null) return null;
-//        return QMember.member.id.in(
-//                queryFactory.select(QMember.member.id)
-//                        .innerJoin(QMember.member.activities, QMemberSoptActivity.memberSoptActivity)
-//                        .where(QMemberSoptActivity.memberSoptActivity.generation.eq(generation))
-//        );
-//    }
-//
-//    public List<Member> findRandomMembers(int limit) {
-//        QMember member = QMember.member;
-//
-//        NumberExpression<Double> rand = Expressions.numberTemplate(Double.class, "function('RAND')");
-//
-//        return queryFactory
-//                .selectFrom(member)
-//                .where(member.hasProfile.isTrue())
-//                .orderBy(rand.asc())
-//                .limit(limit)
-//                .fetch();
-//    }
-//
-//    public List<Member> findByNameContainingOrderByLatestActivity(String name) {
-//        QMember member = QMember.member;
-//        QMemberSoptActivity activity = QMemberSoptActivity.memberSoptActivity;
-//
-//        return queryFactory
-//                .selectFrom(member)
-//                .leftJoin(member.activities, activity)
-//                .where(member.name.contains(name))
-//                .groupBy(member.id)
-//                .orderBy(activity.generation.max().desc(), member.id.desc())
-//                .fetch();
-//    }
 }


### PR DESCRIPTION
## 🐬 요약
[Feat] 멤버 검색 관련 플랫폼팀 API 연결 & MemberSoptActivity 관련 의존성 제거

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [x] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
PR에 담긴 작업 내용을 작성해주세요!

- 플랫폼팀의 멤버 검색 API를 사용하여 유저정보를 불러오도록 수정했습니다. (프로필 수정, 멤버검색, 프로필 생성)
- 기존 MemberSoptActivity와 연관된 코드들은 모두 삭제했습니다!
- 프로필 삭제 API의 경우 플랫폼팀의 프로필 삭제 API가 존재하지 않아, 개발된 이후 추가하는 것이 좋을 것 같아 우선 주석처리해 두었습니다!

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #732 
