### PR TITLE
[Fix] 커피챗 중복정보 응답 수정 및 memberProfile의 activities 정보 누락 수정

### DIFF
--- a/src/main/java/org/sopt/makers/internal/member/mapper/MemberMapper.java
+++ b/src/main/java/org/sopt/makers/internal/member/mapper/MemberMapper.java
@@ -20,6 +20,7 @@ public interface MemberMapper {
     @Mapping(target = "birthday", source = "userDetails.birthday")
     @Mapping(target = "phone", source = "userDetails.phone")
     @Mapping(target = "email", source = "userDetails.email")
+    @Mapping(target = "activities", source = "userDetails.soptActivities")
     MemberProfileResponse toProfileResponse (Member member, InternalUserDetails userDetails, Boolean isCoffeeChatActivate);
 
     @Mapping(target = "projects", source = "projects")


### PR DESCRIPTION
## 🐬 요약
커피챗 검색 API의 필터링 오류를 수정하고, 
프로필 수정 API의 응답 데이터에서 활동 정보(activities)가 누락되는 문제를 해결했습니다.

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [x] 버그 수정
- [ ] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
PR에 담긴 작업 내용을 작성해주세요!

- 커피챗 검색 API 필터링 로직 수정

기존에는 검색 조건을 분리하여 처리 후 병합하는 과정에서 '파트' 필터가 우회되거나 동일 데이터가 중복으로 포함될 수 있는 문제가 있었습니다.
필터를 순차적으로 적용하도록 로직을 변경하여 문제를 해결했습니다 :)

- 프로필 수정(PUT) API 응답 데이터 누락 문제 해결

프로필 수정 후 응답 객체를 생성할 때, MemberMapper에서 활동 정보 필드(soptActivities -> activities)가 명시적으로 매핑되지 않아 null로 반환되었습니다. 응답 데이터에 활동 정보가 정상적으로 포함되도록 수정했습니다!

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #748 
