### PR TITLE
[Fix] 프로필 정보 누락 오류 수정

### DIFF
--- a/src/main/java/org/sopt/makers/internal/member/domain/enums/ActivityTeam.java
+++ b/src/main/java/org/sopt/makers/internal/member/domain/enums/ActivityTeam.java
@@ -7,7 +7,8 @@ public enum ActivityTeam {
     EMPTY(null),
     NO_TEAM("해당 없음"),
     MEDIA_TEAM("미디어팀"),
-    OPERATION_TEAM("운영팀");
+    OPERATION_TEAM("운영팀"),
+    MAKERS("메이커스팀");
 
     final String teamName;
     ActivityTeam(String teamName) {


### PR DESCRIPTION
## 🐬 요약
[Fix] 프로필 정보 누락 오류 수정

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [x] 버그 수정
- [ ] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
PR에 담긴 작업 내용을 작성해주세요!

- 프로필 수정 API 500 에러 수정
프로필 수정 시 DB의 활동 기록과 사용자가 보낸 요청의 활동 기록이 불일치할 경우 NPE가 발생하던 문제를 해결했습니다!

- 프로필 수정 시 전화번호 데이터 보호 로직 추가
사용자가 전화번호를 입력하지 않고 프로필을 저장할 경우, 플랫폼에 저장된 기존 전화번호가 null로 덮어씌워지는 문제를 방지했습니다.
요청에 유효한 전화번호 값이 있을 때만 업데이트하고, 없을 경우 기존 값을 유지하도록 방어 코드를 추가했습니다!

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #754 
