### PR TITLE
[Fix] isBlinder 여부와 상관없이 isMine이 true면 phoneNumber를 보여주도록 수정

### DIFF
--- a/src/main/java/org/sopt/makers/internal/member/dto/response/MemberProfileSpecificResponse.java
+++ b/src/main/java/org/sopt/makers/internal/member/dto/response/MemberProfileSpecificResponse.java
@@ -96,7 +96,7 @@ public record MemberProfileSpecificResponse(
             response.profileImage(),
             response.birthday(),
             response.isPhoneBlind(),
-            response.isPhoneBlind() ? null : response.phone(),
+            isMine || !response.isPhoneBlind() ? response.phone() : null,
             response.email(),
             response.address(),
             response.university(),


### PR DESCRIPTION
## 🐬 요약

[Fix] isBlinder 여부와 상관없이 isMine이 true면 phoneNumber를 보여주도록 수정했어요!

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [x] 버그 수정
- [ ] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
PR에 담긴 작업 내용을 작성해주세요!

- 기존에는 isPhoneBlind가 true라면 phone정보도 null로 보내주는 오류가 있었습니다!
- 이번 작업에서는 isMine이 true인 경우 isPhoneBlind여부와 상관없이 phoneNumber를 정상적으로 보내주도록 수정했습니다!

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #756 
