### PR TITLE
[Feat] 플그 이전 토큰에 대한 검증 로직 401로 에러 처리

### DIFF
--- a/src/main/java/org/sopt/makers/internal/auth/jwt/code/JwkFailure.java
+++ b/src/main/java/org/sopt/makers/internal/auth/jwt/code/JwkFailure.java
@@ -1,18 +1,19 @@
 package org.sopt.makers.internal.auth.jwt.code;
 
-import static lombok.AccessLevel.PRIVATE;
-
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.sopt.makers.internal.auth.common.code.FailureCode;
 import org.springframework.http.HttpStatus;
+
+import static lombok.AccessLevel.*;
 
 @Getter
 @RequiredArgsConstructor(access = PRIVATE)
 public enum JwkFailure implements FailureCode {
     JWK_KID_NOT_FOUND(HttpStatus.UNAUTHORIZED, "해당 kid에 대한 공개키를 찾을 수 없습니다."),
     JWK_INVALID_FORMAT(HttpStatus.BAD_REQUEST, "JWK 형식이 잘못되어 공개키를 파싱할 수 없습니다."),
-    JWK_FETCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "JWK 서버로부터 키를 가져오지 못했습니다.");
+    JWK_FETCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "JWK 서버로부터 키를 가져오지 못했습니다."),
+    JWK_KID_MISSING(HttpStatus.UNAUTHORIZED, "JWT 헤더의 kid가 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/org/sopt/makers/internal/auth/jwt/code/JwtFailure.java
+++ b/src/main/java/org/sopt/makers/internal/auth/jwt/code/JwtFailure.java
@@ -1,12 +1,11 @@
 package org.sopt.makers.internal.auth.jwt.code;
 
-import static lombok.AccessLevel.PRIVATE;
-
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.sopt.makers.internal.auth.common.code.FailureCode;
 import org.springframework.http.HttpStatus;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import static lombok.AccessLevel.*;
 
 @Getter
 @RequiredArgsConstructor(access = PRIVATE)
@@ -14,7 +13,9 @@ public enum JwtFailure implements FailureCode {
     JWT_MISSING_AUTH_HEADER(HttpStatus.UNAUTHORIZED, "인증 헤더가 존재하지 않습니다."),
     JWT_PARSE_FAILED(HttpStatus.UNAUTHORIZED, "잘못된 형식의 JWT입니다."),
     JWT_INVALID_CLAIMS(HttpStatus.UNAUTHORIZED, "JWT의 클레임이 유효하지 않습니다."),
-    JWT_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "JWT 검증에 실패했습니다.");
+    JWT_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "JWT 검증에 실패했습니다."),
+    JWT_KID_MISSING(HttpStatus.UNAUTHORIZED, "JWT 헤더의 kid가 없습니다."),
+    JWT_ALG_MISMATCH(HttpStatus.UNAUTHORIZED, "지원하지 않는 서명 알고리즘입니다. (RS256만 허용)");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/org/sopt/makers/internal/auth/jwt/service/JwtAuthenticationService.java
+++ b/src/main/java/org/sopt/makers/internal/auth/jwt/service/JwtAuthenticationService.java
@@ -70,6 +70,12 @@ public class JwtAuthenticationService {
         } catch (JwkException e) {
             log.warn("JWT 서명 검증 실패: {}", e.getMessage());
             throw new JwtException(JwtFailure.JWT_VERIFICATION_FAILED);
+        } catch (JwtException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            // jwkProvider 내부 NPE 등 예기치 못한 런타임 에러만 VERIFICATION_FAILED 로 변환
+            log.warn("Unexpected runtime during JWT auth: {}", e.getMessage(), e);
+            throw new JwtException(JwtFailure.JWT_VERIFICATION_FAILED);
         }
     }
 


### PR DESCRIPTION
## 🐬 요약
플그에서 인증중앙화 이전 세션이 남아 있는 상태에서 서버 500에러로 새 로그인 화면으로 리디렉션되지 않는 문제

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [ ] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
[Auth] 500 원인 및 조치 요약 
- 원인: JWT 헤더의 kid가 누락(null/blank)된 상태에서 jwkProvider.getPublicKey(kid)가 호출되어 Caffeine에 null 키가 들어가 NPE 발생
- 추가 발견: 토큰 alg=HS256 등 서버 정책(RS256) 과 불일치한 구조 존재
- 조치
  1. authenticate()에 alg/kid 선검증 추가
     - alg != RS256 → JWT_ALG_MISMATCH
     - kid 누락 → JWT_KID_MISSING
  2. JwkProvider.getPublicKey에서 null/blank kid 차단, 로더 null 반환 금지로 이중방어 로직 추가
  3. JWT 인증 과정 예외는 모두 401로 응답
- 결과: 잘못된 토큰은 일관된 401로 처리되고, 500 재발 방지 완료.

## 🌟 관련 이슈


- closed #761 
