### PR TITLE
[Fix] 멤버 필터링 조회 및 페이지네이션 처리 로직 수정

### DIFF
--- a/src/main/java/org/sopt/makers/internal/external/platform/GetPlatformUserBatchRequest.java
+++ b/src/main/java/org/sopt/makers/internal/external/platform/GetPlatformUserBatchRequest.java
@@ -1,0 +1,7 @@
+package org.sopt.makers.internal.external.platform;
+
+import java.util.List;
+
+public record GetPlatformUserBatchRequest(
+        List<Long> userIds
+) {}

--- a/src/main/java/org/sopt/makers/internal/external/platform/PlatformClient.java
+++ b/src/main/java/org/sopt/makers/internal/external/platform/PlatformClient.java
@@ -6,6 +6,7 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -19,6 +20,13 @@ public interface PlatformClient{
             @RequestHeader(name = "X-Api-Key") String apiKey,
             @RequestHeader(name = "X-Service-Name") String serviceName,
             @RequestParam(name = "userIds") List<Long> userIds
+    );
+
+    @PostMapping(value = "/api/v1/users")
+    ResponseEntity<BaseResponse<List<InternalUserDetails>>> getBatchInternalUserDetails(
+            @RequestHeader(name = "X-Api-Key") String apiKey,
+            @RequestHeader(name = "X-Service-Name") String serviceName,
+            @RequestBody GetPlatformUserBatchRequest body
     );
 
     @PutMapping(value = "/api/v1/users/{userId}")

--- a/src/main/java/org/sopt/makers/internal/external/platform/PlatformService.java
+++ b/src/main/java/org/sopt/makers/internal/external/platform/PlatformService.java
@@ -5,12 +5,14 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.sopt.makers.internal.auth.AuthConfig;
 import org.sopt.makers.internal.exception.NotFoundDBEntityException;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
+@Slf4j
 @Service
 public class PlatformService {
 
@@ -78,7 +80,8 @@ public class PlatformService {
                 .toList();
 
         if (!missingIds.isEmpty()) {
-            throw new NotFoundDBEntityException( "[INTERNAL-404-PARTIAL] 플랫폼에 일부 유저 정보가 없습니다.\n요청 ID: " + userIds + "\n누락 ID: " + missingIds);
+            // Log 만 남기도록 수정
+            log.warn("[INTERNAL-PLATFORM] 일부 유저 정보 누락. 요청 ID: {}, 누락 ID: {}", userIds, missingIds);
         }
 
         return users;

--- a/src/main/java/org/sopt/makers/internal/member/repository/MemberProfileQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/member/repository/MemberProfileQueryRepository.java
@@ -6,7 +6,6 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import lombok.val;
 import org.sopt.makers.internal.coffeechat.domain.QCoffeeChat;
 import org.sopt.makers.internal.member.domain.Member;
 import org.sopt.makers.internal.member.domain.QMember;
@@ -25,18 +24,22 @@ public class MemberProfileQueryRepository {
 
     private final JPAQueryFactory queryFactory;
 
+    private final QMember member = QMember.member;
+    private final QMemberCareer memberCareer = QMemberCareer.memberCareer;
+    private final QProject project = QProject.project;
+    private final QMemberProjectRelation relation = QMemberProjectRelation.memberProjectRelation;
+    private final QCoffeeChat coffeeChat = QCoffeeChat.coffeeChat;
+
     private BooleanExpression checkMemberHasProfile() {
-        return QMember.member.hasProfile.eq(true);
+        return member.hasProfile.eq(true);
     }
 
     private BooleanExpression checkMemberMbti(String mbti) {
-        val isMbtiEmpty = !StringUtils.hasText(mbti);
-        return isMbtiEmpty ? null : QMember.member.mbti.eq(mbti);
+        Boolean isMbtiEmpty = !StringUtils.hasText(mbti);
+        return isMbtiEmpty ? null : member.mbti.eq(mbti);
     }
 
     public List<MemberProfileProjectDao> findMemberProfileProjectsByMemberId (Long memberId) {
-        val project = QProject.project;
-        val relation = QMemberProjectRelation.memberProjectRelation;
         return queryFactory.select(
                         new QMemberProfileProjectDao(
                                 project.id, project.writerId, project.name, project.summary, project.generation,
@@ -48,9 +51,6 @@ public class MemberProfileQueryRepository {
     }
 
     public List<Member> findAllMembersByCoffeeChatActivate() {
-        QMember member = QMember.member;
-        QCoffeeChat coffeeChat = QCoffeeChat.coffeeChat;
-
         return queryFactory
                 .selectFrom(member)
                 .innerJoin(coffeeChat).on(coffeeChat.member.eq(member))
@@ -59,8 +59,6 @@ public class MemberProfileQueryRepository {
     }
 
     public List<Long> findAllMemberIdsByRecommendFilter(String university, String mbti) {
-        val member = QMember.member;
-
         return queryFactory.select(member.id)
             .from(member)
             .where(checkMemberHasProfile(),
@@ -71,19 +69,16 @@ public class MemberProfileQueryRepository {
     }
 
     private BooleanExpression checkMemberUniversity(String university) {
-        val isUniversityEmpty = !StringUtils.hasText(university);
-        return isUniversityEmpty ? null : QMember.member.university.contains(university);
+        Boolean isUniversityEmpty = !StringUtils.hasText(university);
+        return isUniversityEmpty ? null : member.university.contains(university);
     }
 
     // 서버 측 전체 ID 조회: limit/cursor 없이 DB 필터만 적용하여 모든 userId 반환
     public List<Long> findAllMemberIdsByDbFilters(String mbti, Integer employed, String search) {
-        val member = QMember.member;
-        val career = QMemberCareer.memberCareer;
-
         return queryFactory
                 .selectDistinct(member.id)
                 .from(member)
-                .leftJoin(member.careers, career)
+                .leftJoin(member.careers, memberCareer)
                 .where(
                         checkMemberHasProfile(),
                         checkMemberMbti(mbti),
@@ -95,29 +90,26 @@ public class MemberProfileQueryRepository {
     }
 
     private BooleanExpression checkSearchUniversityOrCompany(String search) {
-        val isEmpty = !StringUtils.hasText(search);
+        Boolean isEmpty = !StringUtils.hasText(search);
         if (isEmpty) return null;
-        val member = QMember.member;
-        val career = QMemberCareer.memberCareer;
         return member.university.contains(search)
-                .or(career.companyName.contains(search));
+                .or(memberCareer.companyName.contains(search));
     }
 
     private BooleanExpression checkEmployed(Integer employed) {
         if (employed == null) return null;
-        val member = QMember.member;
         if (employed == 1) {
             return JPAExpressions.selectOne()
-                    .from(QMemberCareer.memberCareer)
-                    .where(QMemberCareer.memberCareer.memberId.eq(member.id)
-                            .and(QMemberCareer.memberCareer.isCurrent.isTrue()))
+                    .from(memberCareer)
+                    .where(memberCareer.memberId.eq(member.id)
+                            .and(memberCareer.isCurrent.isTrue()))
                     .exists();
         }
         if (employed == 0) {
             return JPAExpressions.selectOne()
-                    .from(QMemberCareer.memberCareer)
-                    .where(QMemberCareer.memberCareer.memberId.eq(member.id)
-                            .and(QMemberCareer.memberCareer.isCurrent.isTrue()))
+                    .from(memberCareer)
+                    .where(memberCareer.memberId.eq(member.id)
+                            .and(memberCareer.isCurrent.isTrue()))
                     .notExists();
         }
         return null;

--- a/src/main/java/org/sopt/makers/internal/member/repository/MemberProfileQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/member/repository/MemberProfileQueryRepository.java
@@ -85,7 +85,6 @@ public class MemberProfileQueryRepository {
                         checkEmployed(employed),
                         checkSearchUniversityOrCompany(search)
                 )
-                .orderBy(member.id.desc())
                 .fetch();
     }
 

--- a/src/main/java/org/sopt/makers/internal/member/service/MemberService.java
+++ b/src/main/java/org/sopt/makers/internal/member/service/MemberService.java
@@ -359,13 +359,7 @@ public class MemberService {
 	}
 
 	private String checkActivityTeamConditions(String team) {
-		Predicate<String> teamIsEmpty = Objects::isNull;
-		Predicate<String> teamIsNullString = s -> s.equals("해당 없음");
-		val isNullResult = teamIsEmpty.or(teamIsNullString).test(team);
-		if (isNullResult)
-			return null;
-		else
-			return team;
+		return (team == null || team.equals("해당 없음")) ? null : team;
 	}
 
 	public Member saveDefaultMemberProfile(Long userId) {


### PR DESCRIPTION
## 🐬 요약
멤버 필터링 조회 로직 수정

## 👻 유형
- [x] 버그 수정
- [x] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용

### 멤버 필터링 조회 로직 수정
1. 플그 서버에서 필터링이 가능한 조건에 해당하는 모든 userIds 조회
2. 모든 userIds 기반으로 인증서버 유저 정보 요청
3. 인증서버에서 받아온 멤버 목록에서 기수 및 팀 필터링 진행
4. 최종적으로 조건에 해당하는 모든 멤버 반환
5. 서버 내에서 임의의 Pagination 적용 (Cursor 기반)
⇒ 정상적인 방법의 Pagination 처리는 아니지만, 현재 구조에서는 최선의 방안

### 멤버 정렬기준 추가
1. 최신 기수
2. 프로필 정보량
3. 이름 ㄱㄴㄷ 순

### 기타
* 인증 서버에서 정보가 없는 ID 조회 시도 시, 에러 반환 대신 warning log 만 남기도록 처리


## 🌟 관련 이슈
- #769 
