### PR TITLE
[Fix] 내 정보 조회 - 일반 프로필 조회 조건 정상화

### DIFF
--- a/src/main/java/org/sopt/makers/internal/member/controller/MemberController.java
+++ b/src/main/java/org/sopt/makers/internal/member/controller/MemberController.java
@@ -149,7 +149,7 @@ public class MemberController {
             @PathVariable Long id,
             @Parameter(hidden = true) @AuthenticationPrincipal Long userId
     ) {
-        MemberProfileSpecificResponse response = memberService.getMemberProfile(id, userId);
+        MemberProfileSpecificResponse response = memberService.getMemberProfile(id, false);
         sortProfileCareer(response);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
@@ -159,7 +159,7 @@ public class MemberController {
     public ResponseEntity<MemberProfileSpecificResponse> getMyProfile (
             @Parameter(hidden = true) @AuthenticationPrincipal Long userId
     ) {
-        MemberProfileSpecificResponse response = memberService.getMemberProfile(userId, userId);
+        MemberProfileSpecificResponse response = memberService.getMemberProfile(userId, true);
         sortProfileCareer(response);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }

--- a/src/main/java/org/sopt/makers/internal/member/service/MemberService.java
+++ b/src/main/java/org/sopt/makers/internal/member/service/MemberService.java
@@ -130,10 +130,9 @@ public class MemberService {
 	}
 
 	@Transactional(readOnly = true)
-	public MemberProfileSpecificResponse getMemberProfile(Long profileId, Long viewerId) {
-		boolean isMine = Objects.equals(profileId, viewerId);
+	public MemberProfileSpecificResponse getMemberProfile(Long profileId, Boolean isMine) {
 		Member member = getMemberHasProfileById(profileId);
-		// 내 프로필 조회인 경우 원본 team 정보 사용, 다른 사람 프로필 조회인 경우 role 변환된 team 정보 사용
+		// 내 프로필 조회 (수정 목적)인 경우 원본 team 정보 사용, 일반 프로필 조회인 경우 role 변환된 team 정보 사용
 		InternalUserDetails userDetails = isMine
 			? platformService.getInternalUserWithOriginalTeam(profileId)
 			: platformService.getInternalUser(profileId);


### PR DESCRIPTION
## 👻 유형
- [x] 버그 수정
- [ ] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
- 조회자 userId 와 조회대상 userId 를 비교하는 대신, 내 정보 조회가 필요한 API 에서 Boolean 필드로 완벽히 분리해서 처리하도록 수정

