### PR TITLE
[Fix] 내 프로필 정보 여부 - 프로필 수정 데이터 조회 분리

### DIFF
--- a/src/main/java/org/sopt/makers/internal/member/controller/MemberController.java
+++ b/src/main/java/org/sopt/makers/internal/member/controller/MemberController.java
@@ -149,7 +149,7 @@ public class MemberController {
             @PathVariable Long id,
             @Parameter(hidden = true) @AuthenticationPrincipal Long userId
     ) {
-        MemberProfileSpecificResponse response = memberService.getMemberProfile(id, false);
+        MemberProfileSpecificResponse response = memberService.getMemberProfile(id, userId, false);
         sortProfileCareer(response);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
@@ -159,7 +159,7 @@ public class MemberController {
     public ResponseEntity<MemberProfileSpecificResponse> getMyProfile (
             @Parameter(hidden = true) @AuthenticationPrincipal Long userId
     ) {
-        MemberProfileSpecificResponse response = memberService.getMemberProfile(userId, true);
+        MemberProfileSpecificResponse response = memberService.getMemberProfile(userId, userId, true);
         sortProfileCareer(response);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }

--- a/src/main/java/org/sopt/makers/internal/member/service/MemberService.java
+++ b/src/main/java/org/sopt/makers/internal/member/service/MemberService.java
@@ -130,10 +130,11 @@ public class MemberService {
 	}
 
 	@Transactional(readOnly = true)
-	public MemberProfileSpecificResponse getMemberProfile(Long profileId, Boolean isMine) {
+	public MemberProfileSpecificResponse getMemberProfile(Long profileId, Long viewerId ,Boolean isForUpdate) {
 		Member member = getMemberHasProfileById(profileId);
+		boolean isMine = Objects.equals(profileId, viewerId);
 		// 내 프로필 조회 (수정 목적)인 경우 원본 team 정보 사용, 일반 프로필 조회인 경우 role 변환된 team 정보 사용
-		InternalUserDetails userDetails = isMine
+		InternalUserDetails userDetails = isForUpdate
 			? platformService.getInternalUserWithOriginalTeam(profileId)
 			: platformService.getInternalUser(profileId);
 		List<MemberProfileProjectDao> memberProfileProjects = getMemberProfileProjects(profileId);


### PR DESCRIPTION
## 🐬 요약
프로필 정보 조회 API 수정

## 👻 유형
- [x] 버그 수정
- [ ] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
* 핸드폰 번호 마스킹 및 프로필 수정 가능 여부 확인을 위해, 프로필 수정 목적의 데이터 조회와 내 정보를 조회 했을 때 케이스를 완전 분리
