### PR TITLE
[Fix] 프로필 조회 임원진 예외처리 제거 & 임원진 기수 팀 업데이트 시, 해당 기수 업데이트 무시하도록 처리

### DIFF
--- a/src/main/java/org/sopt/makers/internal/external/platform/PlatformService.java
+++ b/src/main/java/org/sopt/makers/internal/external/platform/PlatformService.java
@@ -29,16 +29,7 @@ public class PlatformService {
         List<InternalUserDetails> users = fetchInternalUsers(Collections.singletonList(userId));
         return convertUserDetailsWithRoleToTeam(users.get(0));
     }
-
-    /**
-     * 단일 내부 사용자 조회 (role 변환 없이 원본 team 정보 반환)
-     */
-    public InternalUserDetails getInternalUserWithOriginalTeam(Long userId) {
-        validateUserId(userId);
-        List<InternalUserDetails> users = fetchInternalUsers(Collections.singletonList(userId));
-        return users.get(0);
-    }
-
+    
     /**
      * 다중 내부 사용자 조회
      */

--- a/src/main/java/org/sopt/makers/internal/internal/InternalOpenApiController.java
+++ b/src/main/java/org/sopt/makers/internal/internal/InternalOpenApiController.java
@@ -106,7 +106,7 @@ public class InternalOpenApiController {
 	public ResponseEntity<InternalMemberProfileResponse> getUserProfile(
 		@Parameter(description = "조회할 멤버 ID", example = "1") @RequestParam String memberId) {
 		Member member = memberService.getMemberById(Long.valueOf(memberId));
-		InternalUserDetails userDetails = platformService.getInternalUserWithOriginalTeam(Long.valueOf(memberId));
+		InternalUserDetails userDetails = platformService.getInternalUser(Long.valueOf(memberId));
 
 		List<CardinalInfoResponse> activityResponses = userDetails.soptActivities()
 			.stream()

--- a/src/main/java/org/sopt/makers/internal/member/controller/MemberController.java
+++ b/src/main/java/org/sopt/makers/internal/member/controller/MemberController.java
@@ -129,11 +129,7 @@ public class MemberController {
             @Parameter(hidden = true) @AuthenticationPrincipal Long userId,
             @Valid @RequestBody MemberProfileUpdateRequest request
     ) {
-        val normalTeamNameRequest = request.activities().stream().filter(activity ->
-                ActivityTeam.hasActivityTeam(activity.team())).count();
-        if (request.activities().size() != normalTeamNameRequest) {
-            throw new ClientBadRequestException("잘못된 솝트 활동 팀 이름입니다.");
-        }
+
         val currentCount = request.careers().stream().filter(c -> c.isCurrent()).count();
         if (currentCount > 1) throw new ClientBadRequestException("현재 직장이 2개 이상입니다.");
         val member = memberService.updateMemberProfile(userId, request);
@@ -149,7 +145,7 @@ public class MemberController {
             @PathVariable Long id,
             @Parameter(hidden = true) @AuthenticationPrincipal Long userId
     ) {
-        MemberProfileSpecificResponse response = memberService.getMemberProfile(id, userId, false);
+        MemberProfileSpecificResponse response = memberService.getMemberProfile(id, userId);
         sortProfileCareer(response);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
@@ -159,7 +155,7 @@ public class MemberController {
     public ResponseEntity<MemberProfileSpecificResponse> getMyProfile (
             @Parameter(hidden = true) @AuthenticationPrincipal Long userId
     ) {
-        MemberProfileSpecificResponse response = memberService.getMemberProfile(userId, userId, true);
+        MemberProfileSpecificResponse response = memberService.getMemberProfile(userId, userId);
         sortProfileCareer(response);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }

--- a/src/main/java/org/sopt/makers/internal/member/domain/enums/ActivityTeam.java
+++ b/src/main/java/org/sopt/makers/internal/member/domain/enums/ActivityTeam.java
@@ -8,7 +8,7 @@ public enum ActivityTeam {
     NO_TEAM("해당 없음"),
     MEDIA_TEAM("미디어팀"),
     OPERATION_TEAM("운영팀"),
-    MAKERS("메이커스팀");
+    MAKERS("메이커스");
 
     final String teamName;
     ActivityTeam(String teamName) {


### PR DESCRIPTION
## 🐬 요약
임원진 멤버 프로필 정보 및 업데이트 이슈 수정

## 👻 유형
- [x] 버그 수정
- [ ] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
- 프로필 조회 임원진 예외처리 제거 & 임원진 기수 팀 업데이트 시, 해당 기수 업데이트 무시하도록 처리
  - 솝트 활동정보 팀 변환 없이 가져오는 로직 제거
  - 임원진이었던 활동 기수를 변경할 때는 플랫폼에서 받아왔던 팀정보 그대로 반환해서 업데이트 안되도록 처리

