### PR TITLE
[Feat] 인증서버 메이커스 기수 표시 정책 반영

### DIFF
--- a/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostService.java
@@ -480,8 +480,10 @@ public class CommunityPostService {
 
             postOptional.ifPresent(post -> {
                 InternalUserDetails userDetails = platformService.getInternalUser(post.getMember().getId());
+                // 같은 generation에서 메이커스 활동 우선 (isSopt=false가 메이커스)
                 SoptActivity latestActivity = userDetails.soptActivities().stream()
-                        .max(Comparator.comparing(SoptActivity::generation))
+                        .max(Comparator.comparing(SoptActivity::generation)
+                                .thenComparing(activity -> !activity.isSopt())) // 메이커스(false) 우선
                         .orElse(null);
 
                 String categoryName = categoryNameMap.getOrDefault(categoryId, "");

--- a/src/main/java/org/sopt/makers/internal/external/platform/PlatformService.java
+++ b/src/main/java/org/sopt/makers/internal/external/platform/PlatformService.java
@@ -143,12 +143,16 @@ public class PlatformService {
      */
     private SoptActivity convertRoleToTeam(SoptActivity activity) {
         String teamValue = convertRoleToTeamValue(activity.role(), activity.part(), activity.team());
+        // isSopt 필드 추가 - role이 null이 아니면 SOPT 활동, null이면 메이커스 활동으로 추정
+        // 더 정확한 판단을 위해서는 실제 API 응답에서 제공하는 값을 사용해야 함
+        boolean isSopt = activity.isSopt();
         return new SoptActivity(
             activity.activityId(),
             activity.generation(),
             activity.part(),
             teamValue,
-            activity.role()
+            activity.role(),
+            isSopt
         );
     }
 

--- a/src/main/java/org/sopt/makers/internal/external/platform/SoptActivity.java
+++ b/src/main/java/org/sopt/makers/internal/external/platform/SoptActivity.java
@@ -5,5 +5,6 @@ public record SoptActivity(
         int generation,
         String part,
         String team,
-        String role
+        String role,
+        boolean isSopt
 ) {}

--- a/src/main/java/org/sopt/makers/internal/internal/dto/InternalLatestPostResponse.java
+++ b/src/main/java/org/sopt/makers/internal/internal/dto/InternalLatestPostResponse.java
@@ -32,7 +32,12 @@ public record InternalLatestPostResponse(
             ) {
         String generationAndPart = "";
         if (!post.getIsBlindWriter() && latestActivity != null) {
-            generationAndPart = String.format("%d기 %s", latestActivity.generation(), latestActivity.part());
+            // 메이커스 활동인 경우 "기수/메이커스", SOPT 활동인 경우 "기수 파트"
+            if (!latestActivity.isSopt()) {
+                generationAndPart = String.format("%d기/메이커스", latestActivity.generation());
+            } else {
+                generationAndPart = String.format("%d기 %s", latestActivity.generation(), latestActivity.part());
+            }
         }
 
         String finalName = userDetails.name();

--- a/src/main/java/org/sopt/makers/internal/member/service/MemberService.java
+++ b/src/main/java/org/sopt/makers/internal/member/service/MemberService.java
@@ -5,6 +5,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -173,14 +174,17 @@ public class MemberService {
 		MemberProfileSpecificResponse response = memberMapper.toProfileSpecificResponse(member, userDetails, isMine,
 			memberProfileProjects, activityResponses, isCoffeeChatActivate);
 
-		Map<Integer, MemberProfileProjectVo> projectMap = soptActivityResponse.stream()
-			.collect(Collectors.toMap(MemberProfileProjectVo::generation, vo -> vo));
-
+		// Map 대신 리스트를 직접 매칭하여 처리
 		// soptActivities 갱신 (response.soptActivities()에 soptActivityResponse 붙히기)
 		List<MemberProfileSpecificResponse.SoptMemberActivityResponse> updatedActivities = response.soptActivities()
 			.stream()
 			.map(sa -> {
-				MemberProfileProjectVo matched = projectMap.get(sa.generation());
+				// generation과 part가 모두 일치하는 항목 찾기
+				MemberProfileProjectVo matched = soptActivityResponse.stream()
+					.filter(vo -> vo.generation().equals(sa.generation()) &&
+								  (vo.part() == null || vo.part().equals(sa.part())))
+					.findFirst()
+					.orElse(null);
 				if (matched != null) {
 					return new MemberProfileSpecificResponse.SoptMemberActivityResponse(sa.generation(), sa.part(),
 						sa.team(), matched.projects());
@@ -249,6 +253,7 @@ public class MemberService {
 			throw new NotFoundException("30기 이전 기수 활동 회원은 공식 채널로 문의해주시기 바랍니다.");
 		}
 
+		// 같은 generation에 대한 중복 키 처리 - 첫 번째 값 유지
 		val cardinalInfoMap = soptActivities.stream()
 			.collect(Collectors.toMap(SoptActivity::generation, SoptActivity::part, (p1, p2) -> p1));
 
@@ -269,14 +274,16 @@ public class MemberService {
 
 	public List<MemberProfileProjectVo> getMemberProfileProjects(List<SoptActivity> soptActivities,
 		List<MemberProfileProjectDao> memberProfileProjects) {
-		return soptActivities.stream().map(m -> {
-			val projects = memberProfileProjects.stream()
-				.filter(p -> p.generation() != null)
-				.filter(p -> p.generation().equals(m.generation()))
-				.map(memberMapper::toActivityInfoVo)
-				.collect(Collectors.toList());
-			return memberMapper.toSoptMemberProfileProjectVo(m, projects);
-		}).collect(Collectors.toList());
+		// 모든 활동 (SOPT + 메이커스)을 포함
+		return soptActivities.stream()
+			.map(m -> {
+				val projects = memberProfileProjects.stream()
+					.filter(p -> p.generation() != null)
+					.filter(p -> p.generation().equals(m.generation()))
+					.map(memberMapper::toActivityInfoVo)
+					.collect(Collectors.toList());
+				return memberMapper.toSoptMemberProfileProjectVo(m, projects);
+			}).collect(Collectors.toList());
 	}
 
 	@Transactional(readOnly = true)
@@ -637,9 +644,10 @@ public class MemberService {
 	public Member updateMemberProfile(Long id, MemberProfileUpdateRequest request) {
 		val userDetails = platformService.getInternalUser(id);
 
+		// 같은 generation에 대한 중복 키 처리 - SOPT 활동 우선
 		Map<Integer, SoptActivity> dbActivityMap = userDetails.soptActivities()
 			.stream()
-			.collect(Collectors.toMap(SoptActivity::generation, Function.identity()));
+			.collect(Collectors.toMap(SoptActivity::generation, Function.identity(), (existing, replacement) -> existing));
 
 		List<PlatformUserUpdateRequest.SoptActivityRequest> soptActivitiesForPlatform = new ArrayList<>();
 
@@ -1078,9 +1086,10 @@ public class MemberService {
 
                 InternalUserDetails userDetails = platformService.getInternalUser(memberId);
 
-                // 최근 활동 정보 가져오기
+                // 최근 활동 정보 가져오기 - 같은 generation에서 메이커스 우선
                 SoptActivity latestActivity = userDetails.soptActivities().stream()
-                        .max((a1, a2) -> Integer.compare(a1.generation(), a2.generation()))
+                        .max(Comparator.comparing(SoptActivity::generation)
+                                .thenComparing(activity -> !activity.isSopt())) // 메이커스(false) 우선
                         .orElse(null);
 
                 if (latestActivity == null) {


### PR DESCRIPTION
## 👻 유형
- [ ] 버그 수정
- [x] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
  1. Response 구조 유지 
  - soptActivities 배열에 SOPT와 메이커스 활동 모두 포함
  - 기존 필드 구조 그대로 유지 (generation, part, team 등)
  - 추가된 isSopt 필드는 Internal API와 서버 내부에서만 사용

  2. 멤버 프로필 조회 (GET /api/v1/members/profile/{id})
  - Response의 soptActivities 배열에 모든 활동 포함
  - 37기 SOPT 활동과 37기 메이커스 활동이 각각 별도 항목으로 전달
  - 클라이언트는 기존대로 배열을 순회하며 표시

  3. 팀 표시
  - SOPT 활동: 기존대로 (null, "미디어팀", "운영팀" 등)
  - 메이커스 활동: "메이커스" 또는 "메이커스 팀장"
  - 임원진: "회장", "부회장", "총무", "XX 파트장" 등 기존대로

  4. 중복 키 에러 해결
  - 서버 내부에서만 처리 방식 변경
  - Map 대신 List 직접 매칭으로 변경
  - 클라이언트 Response는 영향 없음

  5. 우선순위 처리
  - 서버 내부 로직에서만 메이커스 우선 처리
  - 클라이언트는 받은 데이터 그대로 표시
  
 
## 🌟 관련 이슈
close: #883
