### PR TITLE
[Fix] 메이커스 태그 표기 이슈 수정

### DIFF
--- a/src/main/java/org/sopt/makers/internal/community/dto/MemberVo.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/MemberVo.java
@@ -19,8 +19,8 @@ public record MemberVo(
         if (userDetails == null) return null;
 
         SoptActivity latestSoptActivity = userDetails.soptActivities() == null ? null : userDetails.soptActivities().stream()
-                .max(Comparator.comparing(SoptActivity::generation)
-                        .thenComparing(activity -> !activity.isSopt())) // 같은 기수에서 메이커스(isSopt=false) 우선
+                .max(Comparator.comparing(SoptActivity::normalizedGeneration)
+                        .thenComparing(SoptActivity::isSopt)) // 같은 기수에서 SOPT(isSopt=true) 우선
                 .orElse(null);
 
         SoptActivityVo activityVo = latestSoptActivity != null

--- a/src/main/java/org/sopt/makers/internal/external/platform/SoptActivity.java
+++ b/src/main/java/org/sopt/makers/internal/external/platform/SoptActivity.java
@@ -7,4 +7,16 @@ public record SoptActivity(
         String team,
         String role,
         boolean isSopt
-) {}
+) {
+    /**
+     * 메이커스 기수를 SOPT 기수로 정규화하여 정렬에 사용
+     * 메이커스 1기 = SOPT 31기, 메이커스 2기 = SOPT 32기, 메이커스 3기 = SOPT 33기, 메이커스 4기 = SOPT 34기
+     * 메이커스 35기 이상은 SOPT와 동일한 기수 번호 사용
+     */
+    public int normalizedGeneration() {
+        if (!isSopt && generation >= 1 && generation <= 4) {
+            return generation + 30;
+        }
+        return generation;
+    }
+}

--- a/src/main/java/org/sopt/makers/internal/member/mapper/MemberMapper.java
+++ b/src/main/java/org/sopt/makers/internal/member/mapper/MemberMapper.java
@@ -34,8 +34,8 @@ public interface MemberMapper {
             return null;
         }
         return soptActivities.stream()
-                .sorted(Comparator.comparing(SoptActivity::generation)
-                        .thenComparing(SoptActivity::isSopt)) // 같은 기수에서 메이커스(isSopt=false) 우선
+                .sorted(Comparator.comparing(SoptActivity::normalizedGeneration)
+                        .thenComparing(activity -> !activity.isSopt())) // 같은 기수에서 SOPT(isSopt=true) 우선
                 .map(activity -> new MemberProfileResponse.MemberSoptActivityResponse(
                         (long) activity.activityId(),
                         activity.generation(),


### PR DESCRIPTION
## 🐬 요약
- 메이커스 활동에서 팀장 정보 제거
- 메이커스, 솝트 기수 순서 처리 개선 
- - 기수 우선 (높은 기수 후순위)
- - 솝트 활동 우선 (메이커스 데이터 후순위)

## 👻 유형
- [x] 버그 수정
- [ ] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🌟 관련 이슈
- #883
