### PR TITLE
[Fix] Hibernate 6 LIKE ESCAPE 버그 해결

### DIFF
--- a/src/main/java/org/sopt/makers/internal/common/config/QueryDslConfig.java
+++ b/src/main/java/org/sopt/makers/internal/common/config/QueryDslConfig.java
@@ -1,20 +1,35 @@
 package org.sopt.makers.internal.common.config;
 
+import com.querydsl.core.types.Ops;
+import com.querydsl.jpa.HQLTemplates;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
-
 @Configuration
 public class QueryDslConfig {
+
+    // Hibernate 6 + PostgreSQL 조합에서 LIKE ... ESCAPE '!' 의 따옴표를 누락하는 버그 우회
+    private static final HQLTemplates LIKE_WITHOUT_ESCAPE = new HQLTemplates() {
+        {
+            add(Ops.LIKE, "{0} like {1}");
+            add(Ops.LIKE_IC, "lower({0}) like lower({1})");
+            add(Ops.STRING_CONTAINS, "{0} like {%1%}");
+            add(Ops.STRING_CONTAINS_IC, "lower({0}) like lower({%1%})");
+            add(Ops.STARTS_WITH, "{0} like {1%}");
+            add(Ops.STARTS_WITH_IC, "lower({0}) like lower({1%})");
+            add(Ops.ENDS_WITH, "{0} like {%1}");
+            add(Ops.ENDS_WITH_IC, "lower({0}) like lower({%1})");
+        }
+    };
 
     @PersistenceContext
     private EntityManager entityManager;
 
     @Bean
     public JPAQueryFactory jpaQueryFactory() {
-        return new JPAQueryFactory(entityManager);
+        return new JPAQueryFactory(LIKE_WITHOUT_ESCAPE, entityManager);
     }
 }


### PR DESCRIPTION
## 🐬 요약
Hibernate 6 LIKE ESCAPE 버그 우회를 위한 QueryDSL 템플릿 오버라이드

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [x] 버그 수정
- [ ] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
PR에 담긴 작업 내용을 작성해주세요!
- Hibernate 6 버전에서 querydsl 쿼리 변환 과정에서 생기는 버그로 인해 syntax error가 발생했습니다.
- Hibernate 6 LIKE ESCAPE 버그 우회를 위해 QueryDSL 템플릿을 오버라이드 했습니다.
- 근본적인 문제 해결을 위해서는 Hibernate 버전을 업그레이드 해야하지만 공수가 많이 들어서... 이 부분은 생각을 좀 해야할 것 같습니다.
## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #899 
