### PR TITLE
[Feat] ART_DIRECTOR 역할 대응 및 프로필 수정 오류 방지

### DIFF
--- a/src/main/java/org/sopt/makers/internal/external/platform/PlatformService.java
+++ b/src/main/java/org/sopt/makers/internal/external/platform/PlatformService.java
@@ -186,6 +186,7 @@ public class PlatformService {
             case "GENERAL_AFFAIRS" -> "총무";
             case "PART_LEADER" -> part + " 파트장"; // 예: "기획 파트장", "디자인 파트장"
             case "TEAM_LEADER" -> originalTeam + " 팀장"; // 예: "운영팀 팀장", "미디어팀 팀장"
+            case "ART_DIRECTOR" -> "아트디렉터";
             default -> originalTeam;
         };
     }

--- a/src/main/java/org/sopt/makers/internal/member/constants/AskMemberId.java
+++ b/src/main/java/org/sopt/makers/internal/member/constants/AskMemberId.java
@@ -22,7 +22,7 @@ public class AskMemberId {
     private static final Map<Part, List<Long>> PROD_ASK_MEMBERS = Map.of(
             Part.PLAN, List.of(319L, 11L, 661L, 769L),
             Part.DESIGN, List.of(144L, 358L, 64L, 210L),
-            Part.WEB, List.of(84L, 85L, 860L, 784L, 673L, 574L, 115L, 635L),
+            Part.WEB, List.of(84L, 85L, 860L, 784L, 673L, 574L, 115L, 635L, 858L),
             Part.IOS, List.of(35L, 45L, 22L),
             Part.ANDROID, List.of(585L, 21L, 407L),
             Part.SERVER, List.of(647L, 989L, 306L, 60L, 221L, 293L)

--- a/src/main/java/org/sopt/makers/internal/member/service/MemberService.java
+++ b/src/main/java/org/sopt/makers/internal/member/service/MemberService.java
@@ -606,7 +606,8 @@ public class MemberService {
 			|| team.equals("부회장")
 			|| team.equals("총무")
 			|| team.contains("파트장")
-			|| team.contains("팀장");
+			|| team.contains("팀장")
+			|| team.equals("아트디렉터");
 	}
 
 	/**
@@ -623,7 +624,7 @@ public class MemberService {
 		}
 
 		// 회장, 부회장, 총무는 원본 team이 null
-		if (team.equals("회장") || team.equals("부회장") || team.equals("총무")) {
+		if (team.equals("회장") || team.equals("부회장") || team.equals("총무") || team.equals("아트디렉터")) {
 			return null;
 		}
 


### PR DESCRIPTION
## 🐬 요약
PR의 요약을 작성해주세요!
신규 직책 ART_DIRECTOR 대응 및 에스크 멤버 추가

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [ ] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [x] 기타... (다음 줄에 사유를 입력해주세요)
추가된 role 대응

## 🔧 작업 배경
플랫폼에서 신규 role인 ART_DIRECTOR가 추가되었으나,
기존 코드에서 해당 role에 대한 처리가 없어 다음 문제가 발생할 수 있는 상황이었습니다.

- 프로필 조회 시 team 값이 null 또는 비정상적으로 노출
- 프로필 수정 시 잘못된 team 값이 플랫폼으로 전달될 가능성
- ActivityTeam validation에서 예외 발생 가능성

---

## ✅ 주요 변경 사항

### 1. PlatformService
- ART_DIRECTOR → "아트디렉터" team 매핑 추가
→ 조회/노출 시 정상적인 team 값 제공

### 2. MemberService

#### (1) 임원진 판별 로직 보완
- "아트디렉터"를 임원진으로 처리하도록 추가

#### (2) team 역변환 로직 수정
- "아트디렉터" → null 처리
→ 플랫폼 원본 데이터와 일치하도록 보장

#### (3) 문자열 비교 안정성 개선
- contains → equals로 변경

---

## 🎯 기대 효과

- ART_DIRECTOR role 사용자 정상 조회 및 표시
- 프로필 수정 시 플랫폼 데이터 불일치 방지
- ActivityTeam validation 오류 예방

---

## ⚠️ 참고

- 현재 구조는 role이 아닌 team 문자열 기반 분기이므로
  향후 role 추가 시 동일 이슈가 재발할 수 있음
- 이후 role 기반 분기로 리팩토링 필요

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #905 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 아트디렉터 직책 지원 추가

* **Chores**
  * 멤버 관리 시스템 구성 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->