### PR TITLE
[Feat] 멤버탭 파트/팀 필터링 개선 및 질문 미리보기 응답 추가, 질문 위치 조회 API 추가

### DIFF
--- a/src/main/java/org/sopt/makers/internal/member/controller/MemberController.java
+++ b/src/main/java/org/sopt/makers/internal/member/controller/MemberController.java
@@ -234,7 +234,7 @@ public class MemberController {
                     orderBy :
                     1 -> 최근에 등록했순 / 2 -> 예전에 등록했순 / 3 -> 최근에 활동했순 / 4 -> 예전에 활동했순 \n
                     team :
-                    임원진, 운영팀, 미디어팀, 메이커스
+                    EXECUTIVE(임원진), OPERATION(운영팀), MEDIA(미디어팀), MAKERS(메이커스)
                     """
     )
     @GetMapping("/profile")

--- a/src/main/java/org/sopt/makers/internal/member/controller/MemberQuestionController.java
+++ b/src/main/java/org/sopt/makers/internal/member/controller/MemberQuestionController.java
@@ -191,4 +191,17 @@ public class MemberQuestionController {
 		MyLatestAnsweredQuestionLocationResponse response = memberQuestionService.getMyLatestAnsweredQuestionLocation(userId, memberId);
 		return ResponseEntity.status(HttpStatus.OK).body(response);
 	}
+
+	@Operation(
+		summary = "특정 사용자의 question 탭에서 특정 질문 위치 조회 API",
+		description = "특정 사용자의 question 탭에서 questionId에 해당하는 질문이 어느 탭(answered/unanswered)의 몇 페이지 몇 번째에 있는지 조회합니다."
+	)
+	@GetMapping("/{memberId}/questions/{questionId}/location")
+	public ResponseEntity<QuestionLocationResponse> getQuestionLocation(
+		@PathVariable Long memberId,
+		@PathVariable Long questionId
+	) {
+		QuestionLocationResponse response = memberQuestionService.getQuestionLocation(memberId, questionId);
+		return ResponseEntity.ok(response);
+	}
 }

--- a/src/main/java/org/sopt/makers/internal/member/dto/response/MemberProfileResponse.java
+++ b/src/main/java/org/sopt/makers/internal/member/dto/response/MemberProfileResponse.java
@@ -3,6 +3,8 @@ package org.sopt.makers.internal.member.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 public record MemberProfileResponse(
     @Schema(required = true)
     Long id,
@@ -28,6 +30,8 @@ public record MemberProfileResponse(
     List<MemberSoptActivityResponse> activities,
     List<MemberLinkResponse> links,
     List<MemberCareerResponse> careers,
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    MemberQuestionPreviewResponse questionPreview,
     Boolean allowOfficial,
     Boolean isCoffeeChatActivate
 ) {
@@ -63,6 +67,11 @@ public record MemberProfileResponse(
             Boolean isCurrent
     ){}
 
+    public record MemberQuestionPreviewResponse(
+        Long questionId,
+        String content
+    ) {}
+
     public static MemberProfileResponse checkIsBlindPhone(MemberProfileResponse response, String phone) {
         return new MemberProfileResponse(
             response.id(),
@@ -86,6 +95,7 @@ public record MemberProfileResponse(
             response.activities(),
             response.links(),
             response.careers(),
+            response.questionPreview(),
             response.allowOfficial(),
             response.isCoffeeChatActivate()
         );

--- a/src/main/java/org/sopt/makers/internal/member/dto/response/QuestionLocationResponse.java
+++ b/src/main/java/org/sopt/makers/internal/member/dto/response/QuestionLocationResponse.java
@@ -1,0 +1,10 @@
+package org.sopt.makers.internal.member.dto.response;
+
+import org.sopt.makers.internal.member.domain.QuestionTab;
+
+public record QuestionLocationResponse(
+	Long questionId,
+	QuestionTab tab,
+	Integer page,
+	Integer index
+) {}

--- a/src/main/java/org/sopt/makers/internal/member/mapper/MemberResponseMapper.java
+++ b/src/main/java/org/sopt/makers/internal/member/mapper/MemberResponseMapper.java
@@ -5,6 +5,7 @@ import org.sopt.makers.internal.external.platform.InternalUserDetails;
 import org.sopt.makers.internal.member.domain.Member;
 import org.sopt.makers.internal.member.domain.MemberCareer;
 import org.sopt.makers.internal.member.dto.response.MemberInfoResponse;
+import org.sopt.makers.internal.member.dto.response.MemberProfileResponse;
 import org.sopt.makers.internal.member.dto.response.MemberPropertiesResponse;
 import org.sopt.makers.internal.coffeechat.dto.request.MemberCoffeeChatPropertyDto;
 import org.sopt.makers.internal.member.util.MemberUtil;
@@ -53,6 +54,42 @@ public class MemberResponseMapper {
                 coffeeChatProperty.sentCoffeeChatCount(),
                 uploadSopticleCount,
                 uploadReviewCount
+        );
+    }
+
+    public MemberProfileResponse attachQuestionPreview(
+        MemberProfileResponse baseResponse,
+        MemberProfileResponse.MemberQuestionPreviewResponse questionPreview
+    ) {
+        if (questionPreview == null) {
+            return baseResponse;
+        }
+
+        return new MemberProfileResponse(
+            baseResponse.id(),
+            baseResponse.name(),
+            baseResponse.profileImage(),
+            baseResponse.birthday(),
+            baseResponse.phone(),
+            baseResponse.email(),
+            baseResponse.address(),
+            baseResponse.university(),
+            baseResponse.major(),
+            baseResponse.introduction(),
+            baseResponse.skill(),
+            baseResponse.mbti(),
+            baseResponse.mbtiDescription(),
+            baseResponse.sojuCapacity(),
+            baseResponse.interest(),
+            baseResponse.userFavor(),
+            baseResponse.idealType(),
+            baseResponse.selfIntroduction(),
+            baseResponse.activities(),
+            baseResponse.links(),
+            baseResponse.careers(),
+            questionPreview,
+            baseResponse.allowOfficial(),
+            baseResponse.isCoffeeChatActivate()
         );
     }
 }

--- a/src/main/java/org/sopt/makers/internal/member/repository/MemberQuestionRepository.java
+++ b/src/main/java/org/sopt/makers/internal/member/repository/MemberQuestionRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface MemberQuestionRepository extends JpaRepository<MemberQuestion, Long> {
@@ -14,7 +15,7 @@ public interface MemberQuestionRepository extends JpaRepository<MemberQuestion, 
 	@Query("SELECT q FROM MemberQuestion q " +
 			"WHERE q.receiver.id = :receiverId " +
 			"AND q.answer IS NOT NULL " +
-			"ORDER BY q.createdAt DESC")
+			"ORDER BY q.createdAt DESC, q.id DESC")
 	List<MemberQuestion> findAnsweredQuestions(
 			@Param("receiverId") Long receiverId,
 			Pageable pageable
@@ -23,7 +24,7 @@ public interface MemberQuestionRepository extends JpaRepository<MemberQuestion, 
 	@Query("SELECT q FROM MemberQuestion q " +
 			"WHERE q.receiver.id = :receiverId " +
 			"AND NOT EXISTS (SELECT a FROM MemberAnswer a WHERE a.question = q) " +
-			"ORDER BY q.createdAt DESC")
+			"ORDER BY q.createdAt DESC, q.id DESC")
 	List<MemberQuestion> findUnansweredQuestions(
 			@Param("receiverId") Long receiverId,
 			Pageable pageable
@@ -31,7 +32,7 @@ public interface MemberQuestionRepository extends JpaRepository<MemberQuestion, 
 
 	@Query("SELECT q FROM MemberQuestion q " +
 			"WHERE q.receiver.id = :receiverId " +
-			"ORDER BY q.createdAt DESC")
+			"ORDER BY q.createdAt DESC, q.id DESC")
 	List<MemberQuestion> findAllQuestions(
 			@Param("receiverId") Long receiverId,
 			Pageable pageable
@@ -65,6 +66,64 @@ public interface MemberQuestionRepository extends JpaRepository<MemberQuestion, 
 			"AND q.answer IS NOT NULL " +
 			"ORDER BY q.createdAt DESC")
 	List<Long> findAllAnsweredQuestionIdsByReceiver(@Param("receiverId") Long receiverId);
+
+	@Query("""
+    SELECT q
+    FROM MemberQuestion q
+    WHERE q.receiver.id IN :receiverIds
+      AND q.isReported = false
+      AND q.createdAt >= :since
+      AND NOT EXISTS (
+          SELECT 1
+          FROM MemberQuestion newer
+          WHERE newer.receiver.id = q.receiver.id
+            AND newer.isReported = false
+            AND newer.createdAt >= :since
+            AND (
+                newer.createdAt > q.createdAt
+                OR (newer.createdAt = q.createdAt AND newer.id > q.id)
+            )
+      )
+    ORDER BY q.createdAt DESC, q.id DESC
+""")
+	List<MemberQuestion> findLatestRecentQuestionsByReceiverIds(
+		@Param("receiverIds") List<Long> receiverIds,
+		@Param("since") LocalDateTime since
+	);
+
+	// 답변완료 질문 위치 조회용 쿼리
+	@Query("""
+        SELECT COUNT(q)
+        FROM MemberQuestion q
+        WHERE q.receiver.id = :receiverId
+          AND q.answer IS NOT NULL
+          AND (
+              q.createdAt > :createdAt
+              OR (q.createdAt = :createdAt AND q.id > :questionId)
+          )
+    """)
+	long countAnsweredQuestionsBeforeTargetInLatestOrder(
+		@Param("receiverId") Long receiverId,
+		@Param("createdAt") LocalDateTime createdAt,
+		@Param("questionId") Long questionId
+	);
+
+	// 미답변 질문 위치 조회용 쿼리
+	@Query("""
+        SELECT COUNT(q)
+        FROM MemberQuestion q
+        WHERE q.receiver.id = :receiverId
+          AND q.answer IS NULL
+          AND (
+              q.createdAt > :createdAt
+              OR (q.createdAt = :createdAt AND q.id > :questionId)
+          )
+    """)
+	long countUnansweredQuestionsBeforeTargetInLatestOrder(
+		@Param("receiverId") Long receiverId,
+		@Param("createdAt") LocalDateTime createdAt,
+		@Param("questionId") Long questionId
+	);
 
 	// ------------------
 

--- a/src/main/java/org/sopt/makers/internal/member/service/MemberQuestionRetriever.java
+++ b/src/main/java/org/sopt/makers/internal/member/service/MemberQuestionRetriever.java
@@ -2,12 +2,12 @@ package org.sopt.makers.internal.member.service;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.makers.internal.exception.NotFoundException;
-import org.sopt.makers.internal.member.domain.Member;
 import org.sopt.makers.internal.member.domain.MemberQuestion;
 import org.sopt.makers.internal.member.repository.MemberQuestionRepository;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Component
@@ -55,5 +55,36 @@ public class MemberQuestionRetriever {
 
 	public List<MemberQuestion> findByReceiverId(Long receiverId) {
 		return memberQuestionRepository.findByReceiverId(receiverId);
+	}
+
+	public List<MemberQuestion> findLatestRecentQuestionsByReceiverIds(List<Long> receiverIds, LocalDateTime since) {
+		if (receiverIds == null || receiverIds.isEmpty()) {
+			return List.of();
+		}
+		return memberQuestionRepository.findLatestRecentQuestionsByReceiverIds(receiverIds, since);
+	}
+
+	public long countAnsweredQuestionsBeforeTargetInLatestOrder(
+		Long receiverId,
+		LocalDateTime createdAt,
+		Long questionId
+	) {
+		return memberQuestionRepository.countAnsweredQuestionsBeforeTargetInLatestOrder(
+			receiverId,
+			createdAt,
+			questionId
+		);
+	}
+
+	public long countUnansweredQuestionsBeforeTargetInLatestOrder(
+		Long receiverId,
+		LocalDateTime createdAt,
+		Long questionId
+	) {
+		return memberQuestionRepository.countUnansweredQuestionsBeforeTargetInLatestOrder(
+			receiverId,
+			createdAt,
+			questionId
+		);
 	}
 }

--- a/src/main/java/org/sopt/makers/internal/member/service/MemberQuestionService.java
+++ b/src/main/java/org/sopt/makers/internal/member/service/MemberQuestionService.java
@@ -308,6 +308,46 @@ public class MemberQuestionService {
 		return new MyLatestAnsweredQuestionLocationResponse(latestQuestion.getId(), page, index);
 	}
 
+	@Transactional(readOnly = true)
+	public QuestionLocationResponse getQuestionLocation(Long receiverId, Long questionId) {
+		memberRetriever.checkExistsMemberById(receiverId);
+
+		MemberQuestion question = memberQuestionRetriever.findById(questionId);
+
+		if (!Objects.equals(question.getReceiver().getId(), receiverId)) {
+			throw new BadRequestException("해당 멤버의 질문이 아닙니다.");
+		}
+
+		QuestionTab tab;
+		long precedingQuestionCount;
+
+		if (question.hasAnswer()) {
+			tab = QuestionTab.ANSWERED;
+			precedingQuestionCount = memberQuestionRetriever.countAnsweredQuestionsBeforeTargetInLatestOrder(
+				receiverId,
+				question.getCreatedAt(),
+				question.getId()
+			);
+		} else {
+			tab = QuestionTab.UNANSWERED;
+			precedingQuestionCount = memberQuestionRetriever.countUnansweredQuestionsBeforeTargetInLatestOrder(
+				receiverId,
+				question.getCreatedAt(),
+				question.getId()
+			);
+		}
+
+		int pageSize = 10;
+		int page = (int) (precedingQuestionCount / pageSize);
+		int index = (int) (precedingQuestionCount % pageSize);
+
+		return new QuestionLocationResponse(questionId, tab, page, index);
+	}
+
+	/*
+	private methods
+	 */
+
 	private void validateQuestionOwner(MemberQuestion question, Long userId) {
 		if (question.getAsker() == null || !question.getAsker().getId().equals(userId)) {
 			throw new ForbiddenException("질문 작성자만 수정할 수 있습니다.");

--- a/src/main/java/org/sopt/makers/internal/member/service/MemberService.java
+++ b/src/main/java/org/sopt/makers/internal/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package org.sopt.makers.internal.member.service;
 
+import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -112,6 +113,10 @@ public class MemberService {
 	private final WorkPreferenceRetriever workPreferenceRetriever;
 	private final WorkPreferenceModifier workPreferenceModifier;
 	private final AskMemberId askMemberId;
+	private final MemberQuestionRetriever memberQuestionRetriever;
+
+	private static final int QUESTION_PREVIEW_DAYS = 7;
+
 	@Value("${spring.profiles.active}")
 	private String activeProfile;
 
@@ -351,12 +356,39 @@ public class MemberService {
 		if (pagedByServer.isEmpty()) {
 			return new MemberAllProfileResponse(Collections.emptyList(), false, 0);
 		}
+		List<Long> pagedMemberIds = pagedByServer.stream()
+			.map(InternalUserDetails::userId)
+			.toList();
 
-		List<MemberProfileResponse> memberList = pagedByServer.stream().map(userDetails -> {
-			Member member = memberMap.get(userDetails.userId());
-			boolean isCoffeeChatActivate = member != null && coffeeChatRetriever.existsCoffeeChat(member);
-			return memberMapper.toProfileResponse(member, userDetails, isCoffeeChatActivate);
-		}).toList();
+		Map<Long, MemberProfileResponse.MemberQuestionPreviewResponse> questionPreviewByReceiverId =
+			memberQuestionRetriever.findLatestRecentQuestionsByReceiverIds(
+				pagedMemberIds,
+				LocalDateTime.now().minusDays(QUESTION_PREVIEW_DAYS)
+			).stream().collect(Collectors.toMap(
+				question -> question.getReceiver().getId(),
+				question -> new MemberProfileResponse.MemberQuestionPreviewResponse(
+					question.getId(),
+					question.getContent()
+				)
+			));
+
+		List<MemberProfileResponse> memberList = pagedByServer.stream()
+			.map(userDetails -> {
+				Member member = memberMap.get(userDetails.userId());
+				boolean isCoffeeChatActivate = member != null && coffeeChatRetriever.existsCoffeeChat(member);
+
+				MemberProfileResponse baseResponse = memberMapper.toProfileResponse(
+					member,
+					userDetails,
+					isCoffeeChatActivate
+				);
+
+				MemberProfileResponse.MemberQuestionPreviewResponse questionPreview =
+					questionPreviewByReceiverId.get(userDetails.userId());
+
+				return memberResponseMapper.attachQuestionPreview(baseResponse, questionPreview);
+			})
+			.toList();
 
 		// 4) hasNext 및 totalCount 계산 (서버 기준)
 		boolean hasNext = (offsetValue + limitValue) < sortedUsers.size();
@@ -365,31 +397,50 @@ public class MemberService {
 		return new MemberAllProfileResponse(memberList, hasNext, totalCount);
 	}
 
-	private boolean filterPlatformConditions(InternalUserDetails userDetails, String part, String team, Integer generation) {
-		if (part == null && team == null && generation == null) return true;
+	private boolean filterPlatformConditions(
+		InternalUserDetails userDetails,
+		String part,
+		String team,
+		Integer generation
+	) {
+		if (part == null && team == null && generation == null) {
+			return true;
+		}
+
 		List<SoptActivity> activities = userDetails.soptActivities();
 
-		return activities.stream().anyMatch(a -> {
+		return activities.stream().anyMatch(activity -> {
 			// 공통 조건: generation과 part 체크
-			boolean genMatch = (generation == null || Objects.equals(a.generation(), generation));
-			boolean partMatch = (part == null || Objects.equals(a.part(), part));
+			boolean generationMatch = (generation == null || Objects.equals(activity.generation(), generation));
+			boolean partMatch = (
+				part == null ||
+					Objects.equals(normalizeMemberTabPartFilterActivityPart(activity.part()), part)
+			);
 
-			if (!genMatch || !partMatch) {
+			if (!generationMatch || !partMatch) {
 				return false;
+			}
+
+			if (team == null) {
+				return true;
 			}
 
 			// 팀 조건 체크
 			if ("임원진".equals(team)) {
 				// 임원진: 솝트 활동인 동시에 미디어팀, 운영팀이 아닌 다른 팀이 있는 경우
-				String activityTeam = a.team();
-				return activityTeam != null && a.isSopt() &&
-					   !activityTeam.isEmpty() &&
-					   !"미디어팀".equals(activityTeam) &&
-					   !"운영팀".equals(activityTeam);
-			} else {
-				// 일반 팀 필터링
-				return team == null || Objects.equals(a.team(), team);
+				String activityTeam = activity.team();
+				return activityTeam != null
+					&& activity.isSopt()
+					&& !activityTeam.isEmpty()
+					&& !"미디어팀".equals(activityTeam)
+					&& !"운영팀".equals(activityTeam);
 			}
+
+			if ("메이커스".equals(team)) {
+				return !activity.isSopt() || Objects.equals(activity.team(), "메이커스");
+			}
+
+			return Objects.equals(activity.team(), team);
 		});
 	}
 
@@ -415,21 +466,37 @@ public class MemberService {
 		return inName || inUniv || inCompany;
 	}
 
-
-	private String getMemberPart(Integer filter) {
-		if (filter == null)
+	private String normalizeMemberTabPartFilterActivityPart(String activityPart) {
+		if (activityPart == null || activityPart.isBlank()) {
 			return null;
-		return switch (filter) {
-			case 1 -> "기획";
-			case 2 -> "디자인";
-			case 3 -> "웹";
-			case 4 -> "서버";
-			case 5 -> "안드로이드";
-			case 6 -> "iOS";
-			default -> null;
+		}
+
+		return switch (activityPart) {
+			case "기획", "PLAN", "PM" -> "PLAN";
+			case "디자인", "DESIGN" -> "DESIGN";
+			case "웹", "WEB", "FRONTEND", "프론트엔드" -> "WEB";
+			case "서버", "SERVER", "BACKEND", "백엔드" -> "SERVER";
+			case "안드로이드", "ANDROID" -> "ANDROID";
+			case "iOS", "IOS" -> "IOS";
+			default -> activityPart;
 		};
 	}
 
+	private String getMemberPart(Integer filter) {
+		if (filter == null) {
+			return null;
+		}
+
+		return switch (filter) {
+			case 1 -> "PLAN";
+			case 2 -> "DESIGN";
+			case 3 -> "WEB";
+			case 4 -> "SERVER";
+			case 5 -> "ANDROID";
+			case 6 -> "IOS";
+			default -> null;
+		};
+	}
 
 	private String checkActivityTeamConditions(String team) {
 		if (team == null || team.equals("해당 없음")) {
@@ -437,13 +504,16 @@ public class MemberService {
 		}
 
 		if (team.equals("MAKERS")) {
-			return "임원진";
+			return "메이커스";
 		}
 		if (team.equals("OPERATION")) {
 			return "운영팀";
 		}
 		if (team.equals("MEDIA")) {
 			return "미디어팀";
+		}
+		if (team.equals("EXECUTIVE")) {
+			return "임원진";
 		}
 
 		return null;


### PR DESCRIPTION
## 🐬 요약
- 멤버탭 파트/팀 필터링 개선
- 멤버탭 멤버카드 응답에 질문 미리보기 추가
- 질문 위치 조회 api 추가

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [x] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
### 배경

멤버탭 필터링에서 SOPT와 Makers 활동의 파트 명칭 차이로 인해 일부 파트가 함께 조회되지 않는 문제가 있었습니다.

또한 멤버 카드에서 최근 질문 미리보기를 노출하고, 클릭 시 해당 멤버의 질문 탭에서 해당 질문 위치로 이동할 수 있도록 백엔드 지원이 필요했습니다.

### 주요 변경사항

`멤버탭 필터링 개선`

- 멤버탭 파트 필터링 시 파트 alias를 정규화하도록 수정했습니다.
- `기획=PLAN=PM`, `웹=WEB=FRONTEND`, `서버=SERVER=BACKEND`가 동일 파트로 인식되도록 반영했습니다.
- 팀 필터링에서 `MAKERS`는 메이커스 활동으로, `EXECUTIVE`는 기존 임원진 필터로 해석하도록 분리했습니다.
- 기존 임원진 필터의 내부 판별 로직은 유지했습니다.

`멤버 카드 질문 미리보기 추가`

- 멤버 프로필 응답에 `questionPreview` 필드를 추가했습니다.
- 최근 7일 이내 생성된 질문 중 신고되지 않은 질문이 존재할 경우에만 최신 질문 1건을 노출하도록 했습니다.
- 질문이 없으면 `questionPreview`는 내려주지 않도록 nullable 응답 구조로 반영했습니다.
- base profile 매핑은 기존 `MemberMapper`를 유지하고, `MemberResponseMapper`에서 질문 미리보기만 enrich 하도록 분리했습니다.

`질문 위치 조회 API 추가`

- 특정 멤버의 질문 탭에서 특정 질문이 어느 탭과 몇 페이지 몇 번째에 위치하는지 조회하는 API를 추가했습니다.
- 질문의 답변 여부를 기준으로 `answered` 또는 `unanswered` 탭을 결정합니다.
- 각 탭의 최신순 정렬 기준으로 target 질문보다 앞에 있는 질문 개수를 계산해 page/index를 반환합니다.
- 응답 `tab`은 `QuestionTab` enum을 사용하되, JSON 응답은 `answered` / `unanswered` 값으로 내려갑니다.

### API 변경사항

`멤버 프로필 조회 응답`

- `questionPreview` 필드 추가
- 구조

```
{
  "questionPreview": {
    "questionId":123,
    "content":"질문 내용"
  }
}
```

`질문 위치 조회 API 추가`

- `GET /api/v1/members/{memberId}/questions/{questionId}/location`

응답 예시

```
{
  "questionId":123,
  "tab":"answered",
  "page":0,
  "index":3
}
```

### 구현 세부사항

- 질문 위치 계산은 전체 질문 id 목록을 조회하는 방식 대신, 각 탭 기준으로 target 질문보다 앞선 질문 수를 count 하는 방식으로 구현했습니다.
- 질문 목록 조회와 위치 계산이 동일한 순서를 보장할 수 있도록 최신순 정렬 기준에 tie-breaker(`id DESC`)를 함께 적용했습니다.

### 확인 포인트

- 프론트에서 팀 필터 요청 시
    - `MAKERS` → 메이커스
    - `EXECUTIVE` → 임원진
    으로 사용해야 합니다.
- 멤버 카드 질문 미리보기는 신고되지 않은 최근 7일 질문만 노출됩니다.
- 질문 위치 조회 API는 실제 질문 탭 기준으로 `answered` / `unanswered`를 구분해 위치를 계산합니다.

###

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #917
