### PR TITLE
[Feat] 프로필 최근 질문 여부 노출 및 최신 답변 질문 5개 조회 API 추가

### DIFF
--- a/src/main/java/org/sopt/makers/internal/member/controller/MemberQuestionController.java
+++ b/src/main/java/org/sopt/makers/internal/member/controller/MemberQuestionController.java
@@ -204,4 +204,14 @@ public class MemberQuestionController {
 		QuestionLocationResponse response = memberQuestionService.getQuestionLocation(memberId, questionId);
 		return ResponseEntity.ok(response);
 	}
+
+	@Operation(
+		summary = "최신 질문 5개 조회 API",
+		description = "삭제/신고 질문 제외, 최신순으로 최대 5개의 답변 완료된 질문을 조회합니다. 가능한 경우 서로 다른 멤버 질문을 우선 노출하고, 부족하면 동일 멤버의 다른 질문으로 채웁니다. 응답에는 질문별 탭(answered) 및 위치 정보도 함께 포함됩니다."
+	)
+	@GetMapping("/questions/latest")
+	public ResponseEntity<LatestAnsweredQuestionsResponse> getLatestAnsweredQuestions() {
+		LatestAnsweredQuestionsResponse response = memberQuestionService.getLatestAnsweredQuestions();
+		return ResponseEntity.ok(response);
+	}
 }

--- a/src/main/java/org/sopt/makers/internal/member/dto/response/LatestAnsweredQuestionsResponse.java
+++ b/src/main/java/org/sopt/makers/internal/member/dto/response/LatestAnsweredQuestionsResponse.java
@@ -1,0 +1,16 @@
+package org.sopt.makers.internal.member.dto.response;
+
+import java.util.List;
+
+public record LatestAnsweredQuestionsResponse(
+	List<LatestQuestionCardResponse> questions
+) {
+	public record LatestQuestionCardResponse(
+		Long receiverId,
+		String receiverName,
+		String receiverProfileImage,
+		Long questionId,
+		String content,
+		QuestionLocationResponse location
+	) {}
+}

--- a/src/main/java/org/sopt/makers/internal/member/dto/response/MemberProfileSpecificResponse.java
+++ b/src/main/java/org/sopt/makers/internal/member/dto/response/MemberProfileSpecificResponse.java
@@ -36,6 +36,7 @@ public record MemberProfileSpecificResponse(
         List<MemberProjectResponse> projects,
         List<MemberCareerResponse> careers,
         Boolean allowOfficial,
+        Boolean hasRecentQuestion,
         Boolean isCoffeeChatActivate,
         @Schema(required = true)
         Boolean isMine
@@ -126,6 +127,7 @@ public record MemberProfileSpecificResponse(
             response.projects(),
             response.careers(),
             response.allowOfficial(),
+            response.hasRecentQuestion(),
             isCoffeeChatActivate,
             isMine
         );

--- a/src/main/java/org/sopt/makers/internal/member/repository/MemberQuestionRepository.java
+++ b/src/main/java/org/sopt/makers/internal/member/repository/MemberQuestionRepository.java
@@ -55,7 +55,7 @@ public interface MemberQuestionRepository extends JpaRepository<MemberQuestion, 
 	@Query("SELECT q FROM MemberQuestion q " +
 			"WHERE q.asker.id = :askerId AND q.receiver.id = :receiverId " +
 			"AND q.answer IS NOT NULL " +
-			"ORDER BY q.createdAt DESC")
+			"ORDER BY q.createdAt DESC, q.id DESC")
 	List<MemberQuestion> findAllAnsweredByAskerAndReceiverOrderByLatest(
 			@Param("askerId") Long askerId,
 			@Param("receiverId") Long receiverId
@@ -64,7 +64,7 @@ public interface MemberQuestionRepository extends JpaRepository<MemberQuestion, 
 	@Query("SELECT q.id FROM MemberQuestion q " +
 			"WHERE q.receiver.id = :receiverId " +
 			"AND q.answer IS NOT NULL " +
-			"ORDER BY q.createdAt DESC")
+			"ORDER BY q.createdAt DESC, q.id DESC")
 	List<Long> findAllAnsweredQuestionIdsByReceiver(@Param("receiverId") Long receiverId);
 
 	@Query("""
@@ -124,6 +124,26 @@ public interface MemberQuestionRepository extends JpaRepository<MemberQuestion, 
 		@Param("createdAt") LocalDateTime createdAt,
 		@Param("questionId") Long questionId
 	);
+
+	@Query("""
+    SELECT CASE WHEN COUNT(q) > 0 THEN true ELSE false END
+    FROM MemberQuestion q
+    WHERE q.receiver.id = :receiverId
+      AND q.createdAt >= :since
+""")
+	boolean existsRecentQuestionByReceiver(
+		@Param("receiverId") Long receiverId,
+		@Param("since") LocalDateTime since
+	);
+
+	@Query("""
+    SELECT q
+    FROM MemberQuestion q
+    WHERE q.isReported = false
+      AND q.answer IS NOT NULL
+    ORDER BY q.createdAt DESC, q.id DESC
+""")
+	List<MemberQuestion> findLatestAnsweredQuestions(Pageable pageable);
 
 	// ------------------
 

--- a/src/main/java/org/sopt/makers/internal/member/service/MemberQuestionRetriever.java
+++ b/src/main/java/org/sopt/makers/internal/member/service/MemberQuestionRetriever.java
@@ -87,4 +87,12 @@ public class MemberQuestionRetriever {
 			questionId
 		);
 	}
+
+	public boolean existsRecentQuestionByReceiver(Long receiverId, LocalDateTime since) {
+		return memberQuestionRepository.existsRecentQuestionByReceiver(receiverId, since);
+	}
+
+	public List<MemberQuestion> findLatestAnsweredQuestions(int size) {
+		return memberQuestionRepository.findLatestAnsweredQuestions(PageRequest.of(0, size));
+	}
 }

--- a/src/main/java/org/sopt/makers/internal/member/service/MemberQuestionService.java
+++ b/src/main/java/org/sopt/makers/internal/member/service/MemberQuestionService.java
@@ -27,8 +27,13 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -55,6 +60,8 @@ public class MemberQuestionService {
 
 	private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ISO_DATE_TIME;
 	private static final int NEW_QUESTION_DAYS = 7;
+	private static final int LATEST_QUESTION_CARD_COUNT = 5;
+	private static final int LATEST_QUESTION_FETCH_SIZE = 50;
 
 	@Transactional
 	public Long createQuestion(Long askerId, Long receiverId, QuestionSaveRequest request) {
@@ -318,30 +325,49 @@ public class MemberQuestionService {
 			throw new BadRequestException("해당 멤버의 질문이 아닙니다.");
 		}
 
-		QuestionTab tab;
-		long precedingQuestionCount;
+		return calculateQuestionLocation(question);
+	}
 
-		if (question.hasAnswer()) {
-			tab = QuestionTab.ANSWERED;
-			precedingQuestionCount = memberQuestionRetriever.countAnsweredQuestionsBeforeTargetInLatestOrder(
-				receiverId,
-				question.getCreatedAt(),
-				question.getId()
-			);
-		} else {
-			tab = QuestionTab.UNANSWERED;
-			precedingQuestionCount = memberQuestionRetriever.countUnansweredQuestionsBeforeTargetInLatestOrder(
-				receiverId,
-				question.getCreatedAt(),
-				question.getId()
-			);
+	@Transactional(readOnly = true)
+	public LatestAnsweredQuestionsResponse getLatestAnsweredQuestions() {
+		List<MemberQuestion> recentQuestions =
+			memberQuestionRetriever.findLatestAnsweredQuestions(LATEST_QUESTION_FETCH_SIZE);
+
+		if (recentQuestions.isEmpty()) {
+			return new LatestAnsweredQuestionsResponse(List.of());
 		}
 
-		int pageSize = 10;
-		int page = (int) (precedingQuestionCount / pageSize);
-		int index = (int) (precedingQuestionCount % pageSize);
+		List<MemberQuestion> selectedQuestions = selectLatestQuestionsForCards(recentQuestions);
 
-		return new QuestionLocationResponse(questionId, tab, page, index);
+		List<Long> receiverIds = selectedQuestions.stream()
+			.map(question -> question.getReceiver().getId())
+			.distinct()
+			.toList();
+
+		Map<Long, InternalUserDetails> receiverInfoMap = platformService.getInternalUsers(receiverIds).stream()
+			.collect(Collectors.toMap(
+				InternalUserDetails::userId,
+				Function.identity(),
+				(existing, replacement) -> existing
+			));
+
+		List<LatestAnsweredQuestionsResponse.LatestQuestionCardResponse> questions = selectedQuestions.stream()
+			.map(question -> {
+				Long receiverId = question.getReceiver().getId();
+				InternalUserDetails receiverInfo = receiverInfoMap.get(receiverId);
+
+				return new LatestAnsweredQuestionsResponse.LatestQuestionCardResponse(
+					receiverId,
+					receiverInfo != null ? receiverInfo.name() : null,
+					receiverInfo != null ? receiverInfo.profileImage() : null,
+					question.getId(),
+					question.getContent(),
+					calculateQuestionLocation(question)
+				);
+			})
+			.toList();
+
+		return new LatestAnsweredQuestionsResponse(questions);
 	}
 
 	/*
@@ -460,5 +486,71 @@ public class MemberQuestionService {
 			isMine,
 			isReceived
 		);
+	}
+
+	private QuestionLocationResponse calculateQuestionLocation(MemberQuestion question) {
+		QuestionTab tab;
+		long precedingQuestionCount;
+
+		if (question.hasAnswer()) {
+			tab = QuestionTab.ANSWERED;
+			precedingQuestionCount = memberQuestionRetriever.countAnsweredQuestionsBeforeTargetInLatestOrder(
+				question.getReceiver().getId(),
+				question.getCreatedAt(),
+				question.getId()
+			);
+		} else {
+			tab = QuestionTab.UNANSWERED;
+			precedingQuestionCount = memberQuestionRetriever.countUnansweredQuestionsBeforeTargetInLatestOrder(
+				question.getReceiver().getId(),
+				question.getCreatedAt(),
+				question.getId()
+			);
+		}
+
+		int pageSize = 10;
+		int page = (int) (precedingQuestionCount / pageSize);
+		int index = (int) (precedingQuestionCount % pageSize);
+
+		return new QuestionLocationResponse(question.getId(), tab, page, index);
+	}
+
+	private List<MemberQuestion> selectLatestQuestionsForCards(List<MemberQuestion> recentQuestions) {
+		List<MemberQuestion> selectedQuestions = new ArrayList<>();
+		Set<Long> selectedQuestionIds = new HashSet<>();
+		Set<Long> selectedReceiverIds = new HashSet<>();
+
+		// 1차: receiver 중복 없이 우선 채우기
+		for (MemberQuestion question : recentQuestions) {
+			Long receiverId = question.getReceiver().getId();
+
+			if (selectedReceiverIds.contains(receiverId)) {
+				continue;
+			}
+
+			selectedQuestions.add(question);
+			selectedQuestionIds.add(question.getId());
+			selectedReceiverIds.add(receiverId);
+
+			if (selectedQuestions.size() == LATEST_QUESTION_CARD_COUNT) {
+				return selectedQuestions;
+			}
+		}
+
+		// 2차: 부족하면 receiver 중복 허용해서 채우기
+		for (MemberQuestion question : recentQuestions) {
+			if (selectedQuestionIds.contains(question.getId())) {
+				continue;
+			}
+
+			selectedQuestions.add(question);
+			selectedQuestionIds.add(question.getId());
+
+			if (selectedQuestions.size() == LATEST_QUESTION_CARD_COUNT) {
+				break;
+			}
+		}
+
+		return selectedQuestions;
 	}
 }

--- a/src/main/java/org/sopt/makers/internal/member/service/MemberService.java
+++ b/src/main/java/org/sopt/makers/internal/member/service/MemberService.java
@@ -116,6 +116,7 @@ public class MemberService {
 	private final MemberQuestionRetriever memberQuestionRetriever;
 
 	private static final int QUESTION_PREVIEW_DAYS = 7;
+	private static final int RECENT_QUESTION_DAYS = 7;
 
 	@Value("${spring.profiles.active}")
 	private String activeProfile;
@@ -175,7 +176,13 @@ public class MemberService {
 			.stream()
 			.map(entry -> new MemberActivityResponse(entry.getKey(), entry.getValue()))
 			.collect(Collectors.toList());
+
 		boolean isCoffeeChatActivate = coffeeChatRetriever.existsCoffeeChat(member);
+		boolean hasRecentQuestion = memberQuestionRetriever.existsRecentQuestionByReceiver(
+			profileId,
+			LocalDateTime.now().minusDays(RECENT_QUESTION_DAYS)
+		);
+
 		MemberProfileSpecificResponse response = memberMapper.toProfileSpecificResponse(member, userDetails, isMine,
 			memberProfileProjects, activityResponses, isCoffeeChatActivate);
 
@@ -192,7 +199,7 @@ public class MemberService {
 			response.mbti(), response.mbtiDescription(), response.sojuCapacity(), response.interest(),
 			response.userFavor(), response.idealType(), response.selfIntroduction(), response.workPreference(), response.activities(),
 			updatedActivities, response.links(), response.projects(), response.careers(), response.allowOfficial(),
-			response.isCoffeeChatActivate(), response.isMine());
+			hasRecentQuestion, response.isCoffeeChatActivate(), response.isMine());
 		return MemberProfileSpecificResponse.applyPhoneMasking(updateResponse, isMine, isCoffeeChatActivate);
 	}
 


### PR DESCRIPTION
## 🐬 요약
- 프로필 상세 조회 응답에 `hasRecentQuestion` 필드 추가
- 최근 7일 내 질문 존재 여부 조회 로직 추가
- 최신 답변 완료 질문 5개 조회 API 추가
- 최신 질문 카드 응답에 receiver 정보와 question 위치 정보 포함
- 최신 질문 노출 시 가능한 경우 서로 다른 멤버 질문을 우선 노출하고, 부족하면 동일 멤버의 다른 질문으로 채워 최대 5개 유지
- 질문 목록/위치 계산 정렬 기준을 `createdAt DESC, id DESC`로 보강

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [x] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
### 프로필 상세 조회 응답 필드 추가

- 조회 대상 멤버에게 최근 7일 이내 등록된 질문이 1건 이상 있는 경우 `hasRecentQuestion=true`
- 질문이 없으면 `false`

### 신규 API - 최신 답변 완료 질문 5개 조회

`GET /api/v1/members/questions/latest`

- 답변 완료된 질문만 대상
- 삭제/신고 질문 제외
- 최신순 정렬
- 가능한 경우 서로 다른 멤버 질문 우선 노출
- 서로 다른 멤버 기준으로 5개가 부족하면 동일 멤버의 다른 질문으로 채워 최대 5개 유지
- 각 카드에 아래 정보 포함
    - 질문 받은 사용자 id / 이름 / 프로필 이미지
    - questionId / 질문 내용
    - 이동용 위치 정보(`tab`, `page`, `index`)

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #919 
