### PR TITLE
[feat] 멤버 추천 기능 구현

### DIFF
--- a/src/main/java/org/sopt/makers/internal/external/makers/CrewMeetingApplicantListResponse.java
+++ b/src/main/java/org/sopt/makers/internal/external/makers/CrewMeetingApplicantListResponse.java
@@ -1,0 +1,31 @@
+package org.sopt.makers.internal.external.makers;
+
+import java.util.List;
+
+public record CrewMeetingApplicantListResponse(
+        List<CrewMeetingApplicant> apply,
+        PaginationMeta meta
+) {
+    public record CrewMeetingApplicant(
+            Long id,
+            Integer applyNumber,
+            String content,
+            String appliedDate,
+            String status,
+            ApplicantUser user
+    ) {}
+
+    public record ApplicantUser(
+            Long id,
+            String name,
+            Long orgId,       // playground userId
+            RecentActivity recentActivity,
+            String profileImage,
+            String phone
+    ) {}
+
+    public record RecentActivity(
+            String part,
+            Integer generation
+    ) {}
+}

--- a/src/main/java/org/sopt/makers/internal/external/makers/InternalUserWithMeetingUsersResponse.java
+++ b/src/main/java/org/sopt/makers/internal/external/makers/InternalUserWithMeetingUsersResponse.java
@@ -1,10 +1,16 @@
 package org.sopt.makers.internal.external.makers;
 
+import java.util.Collections;
 import java.util.List;
 
 public record InternalUserWithMeetingUsersResponse(
     List<UserOrgId> currentGenerationUserIds,
     List<UserOrgId> pastGenerationUserIds
 ) {
+    public InternalUserWithMeetingUsersResponse {
+        currentGenerationUserIds = currentGenerationUserIds != null ? currentGenerationUserIds : Collections.emptyList();
+        pastGenerationUserIds = pastGenerationUserIds != null ? pastGenerationUserIds : Collections.emptyList();
+    }
+
     public record UserOrgId(Integer orgUserId) {}
 }

--- a/src/main/java/org/sopt/makers/internal/external/makers/InternalUserWithMeetingUsersResponse.java
+++ b/src/main/java/org/sopt/makers/internal/external/makers/InternalUserWithMeetingUsersResponse.java
@@ -1,0 +1,10 @@
+package org.sopt.makers.internal.external.makers;
+
+import java.util.List;
+
+public record InternalUserWithMeetingUsersResponse(
+    List<UserOrgId> currentGenerationUserIds,
+    List<UserOrgId> pastGenerationUserIds
+) {
+    public record UserOrgId(Integer orgUserId) {}
+}

--- a/src/main/java/org/sopt/makers/internal/external/makers/MakersCrewClient.java
+++ b/src/main/java/org/sopt/makers/internal/external/makers/MakersCrewClient.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
+
 @FeignClient(value = "makersCrewClient", url = "${internal.crew.url}")
 public interface MakersCrewClient {
 
@@ -28,6 +29,20 @@ public interface MakersCrewClient {
             @RequestParam("page") Integer page,
             @RequestParam("take") Integer take,
             @RequestParam("orgUserId") Long orgUserId
+    );
+
+    @GetMapping("/meeting/v2/{meetingId}/list")
+    CrewMeetingApplicantListResponse getMeetingApplicants(
+            @PathVariable("meetingId") Long meetingId,
+            @RequestParam("page") Integer page,
+            @RequestParam("take") Integer take,
+            @RequestParam(value = "status", required = false) String status,
+            @RequestParam(value = "date", required = false) String date
+    );
+
+    @GetMapping("/internal/meetings/related-user-ids/{userId}")
+    InternalUserWithMeetingUsersResponse getRelatedUserIds(
+            @PathVariable("userId") Integer userId
     );
 
     @GetMapping("/internal/meeting/stats/fastest-applied/{orgId}")

--- a/src/main/java/org/sopt/makers/internal/member/controller/MemberController.java
+++ b/src/main/java/org/sopt/makers/internal/member/controller/MemberController.java
@@ -31,12 +31,14 @@ import org.sopt.makers.internal.member.dto.response.MemberInfoResponse;
 import org.sopt.makers.internal.member.dto.response.MemberProfileResponse;
 import org.sopt.makers.internal.member.dto.response.MemberProfileSpecificResponse;
 import org.sopt.makers.internal.member.dto.response.MemberPropertiesResponse;
+import org.sopt.makers.internal.member.dto.response.MemberRecommendResponse;
 import org.sopt.makers.internal.member.dto.response.MemberResponse;
 import org.sopt.makers.internal.member.dto.response.AskMemberResponse;
 import org.sopt.makers.internal.member.dto.response.WorkPreferenceRecommendationResponse;
 import org.sopt.makers.internal.member.dto.response.WorkPreferenceResponse;
 import org.sopt.makers.internal.member.dto.response.TlMemberResponse;
 import org.sopt.makers.internal.member.mapper.MemberMapper;
+import org.sopt.makers.internal.member.service.MemberRecommendService;
 import org.sopt.makers.internal.member.service.MemberService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -61,6 +63,7 @@ import jakarta.validation.Valid;
 @Tag(name = "Member 관련 API", description = "Member와 관련 API들")
 public class MemberController {
     private final MemberService memberService;
+    private final MemberRecommendService memberRecommendService;
     private final CoffeeChatService coffeeChatService;
     private final MemberMapper memberMapper;
     private final MakersCrewClient makersCrewClient;
@@ -250,6 +253,23 @@ public class MemberController {
             @RequestParam(required = false, name = "team") String team
     ) {
         MemberAllProfileResponse response = memberService.getMemberProfiles(filter, limit, offset, search, generation, employed, orderBy, mbti, team);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @Operation(
+        summary = "멤버 추천 API",
+        description = """
+            현재 사용자 기준으로 추천 멤버 최대 5명을 반환합니다.
+            추천 기준 우선순위: 같은 파트 → 같은 모임 → 같은 MBTI → 같은 학교 → 같은 기수
+            해당 순서의 후보가 없으면 다음 순서 기준으로 대체됩니다.
+            새로고침할 때마다 각 슬롯에서 랜덤으로 1명씩 선택됩니다.
+            """
+    )
+    @GetMapping("/recommend")
+    public ResponseEntity<MemberRecommendResponse> getRecommendedMembers(
+        @Parameter(hidden = true) @AuthenticationPrincipal Long userId
+    ) {
+        MemberRecommendResponse response = memberRecommendService.getRecommendations(userId);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 

--- a/src/main/java/org/sopt/makers/internal/member/dto/response/MemberRecommendResponse.java
+++ b/src/main/java/org/sopt/makers/internal/member/dto/response/MemberRecommendResponse.java
@@ -1,0 +1,29 @@
+package org.sopt.makers.internal.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "멤버 추천 응답")
+public record MemberRecommendResponse(
+    List<RecommendedMember> members
+) {
+    @Schema(description = "추천 멤버 정보")
+    public record RecommendedMember(
+
+        Long id,
+        String name,
+        String profileImage,
+        Integer generation,
+        String part,
+        RecommendType recommendType
+    ) {}
+
+    @Schema(description = "추천 기준 타입")
+    public enum RecommendType {
+        SAME_PART,       // 같은 파트
+        SAME_CREW,       // 같은 모임
+        SAME_MBTI,       // 같은 MBTI
+        SAME_UNIVERSITY, // 같은 학교
+        SAME_GENERATION  // 같은 기수
+    }
+}

--- a/src/main/java/org/sopt/makers/internal/member/repository/MemberRepository.java
+++ b/src/main/java/org/sopt/makers/internal/member/repository/MemberRepository.java
@@ -18,4 +18,10 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     List<Member> findAllByHasProfileTrueAndIdInWithCareers(@Param("memberIds") List<Long> memberIds);
 
     List<Member> findAllByWorkPreferenceNotNull();
+
+    List<Member> findAllByHasProfileTrue();
+
+    List<Member> findAllByMbtiAndHasProfileTrue(String mbti);
+
+    List<Member> findAllByUniversityAndHasProfileTrue(String university);
 }

--- a/src/main/java/org/sopt/makers/internal/member/service/MemberRecommendService.java
+++ b/src/main/java/org/sopt/makers/internal/member/service/MemberRecommendService.java
@@ -140,7 +140,9 @@ public class MemberRecommendService {
 
         List<Long> currentCandidates = filterHasProfileMembers(
             response.currentGenerationUserIds().stream()
-                .map(u -> u.orgUserId().longValue())
+                .map(InternalUserWithMeetingUsersResponse.UserOrgId::orgUserId)
+                .filter(Objects::nonNull)
+                .map(Integer::longValue)
                 .collect(Collectors.toSet()),
             excludeIds
         );
@@ -150,7 +152,9 @@ public class MemberRecommendService {
 
         List<Long> pastCandidates = filterHasProfileMembers(
             response.pastGenerationUserIds().stream()
-                .map(u -> u.orgUserId().longValue())
+                .map(InternalUserWithMeetingUsersResponse.UserOrgId::orgUserId)
+                .filter(Objects::nonNull)
+                .map(Integer::longValue)
                 .collect(Collectors.toSet()),
             excludeIds
         );

--- a/src/main/java/org/sopt/makers/internal/member/service/MemberRecommendService.java
+++ b/src/main/java/org/sopt/makers/internal/member/service/MemberRecommendService.java
@@ -1,0 +1,264 @@
+package org.sopt.makers.internal.member.service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.makers.internal.exception.NotFoundException;
+import org.sopt.makers.internal.external.makers.InternalUserWithMeetingUsersResponse;
+import org.sopt.makers.internal.external.makers.MakersCrewClient;
+import org.sopt.makers.internal.external.platform.InternalUserDetails;
+import org.sopt.makers.internal.external.platform.PlatformService;
+import org.sopt.makers.internal.external.platform.SoptActivity;
+import org.sopt.makers.internal.external.platform.UserSearchResponse;
+import org.sopt.makers.internal.member.domain.Member;
+import org.sopt.makers.internal.member.dto.response.MemberRecommendResponse;
+import org.sopt.makers.internal.member.dto.response.MemberRecommendResponse.RecommendType;
+import org.sopt.makers.internal.member.dto.response.MemberRecommendResponse.RecommendedMember;
+import org.sopt.makers.internal.member.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberRecommendService {
+
+    private final MemberRepository memberRepository;
+    private final PlatformService platformService;
+    private final MakersCrewClient makersCrewClient;
+
+    private static final int RECOMMENDATION_SET_SIZE = 5;
+    private static final int PLATFORM_SEARCH_LIMIT = 300;
+
+    private enum RecommendCriterion {
+        SAME_PART, SAME_CREW, SAME_MBTI, SAME_UNIVERSITY, SAME_GENERATION
+    }
+
+    @Transactional(readOnly = true)
+    public MemberRecommendResponse getRecommendations(Long userId) {
+        Member currentMember = memberRepository.findById(userId)
+            .orElseThrow(() -> new NotFoundException("해당 id의 Member를 찾을 수 없습니다."));
+        InternalUserDetails currentUserDetails = platformService.getInternalUser(userId);
+
+        Set<String> myParts = currentUserDetails.soptActivities().stream()
+            .filter(SoptActivity::isSopt)
+            .map(SoptActivity::part)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+
+        int myLatestGeneration = currentUserDetails.soptActivities().stream()
+            .filter(SoptActivity::isSopt)
+            .mapToInt(SoptActivity::generation)
+            .max()
+            .orElse(-1);
+
+        Set<Long> excludeIds = new HashSet<>();
+        excludeIds.add(userId);
+
+        List<RecommendedMember> recommendations = new ArrayList<>();
+        List<RecommendCriterion> criteria = List.of(
+            RecommendCriterion.SAME_PART,
+            RecommendCriterion.SAME_CREW,
+            RecommendCriterion.SAME_MBTI,
+            RecommendCriterion.SAME_UNIVERSITY,
+            RecommendCriterion.SAME_GENERATION
+        );
+
+        // criteriaPointer는 슬롯 간 공유 - 한 번 소진된 기준은 재사용하지 않음
+        int criteriaPointer = 0;
+        for (int slot = 0; slot < RECOMMENDATION_SET_SIZE && criteriaPointer < criteria.size(); slot++) {
+            boolean isFound = false;
+            while (criteriaPointer < criteria.size() && !isFound) {
+                RecommendCriterion currentCriteria = criteria.get(criteriaPointer++);
+                Optional<RecommendedMember> result = switch (currentCriteria) {
+                    case SAME_PART -> findSamePartCandidate(myParts, excludeIds);
+                    case SAME_CREW -> findSameCrewCandidate(userId, excludeIds);
+                    case SAME_MBTI -> findSameMbtiCandidate(currentMember.getMbti(), excludeIds);
+                    case SAME_UNIVERSITY -> findSameUniversityCandidate(currentMember.getUniversity(), excludeIds);
+                    case SAME_GENERATION -> findSameGenerationCandidate(myLatestGeneration, excludeIds);
+                };
+                if (result.isPresent()) {
+                    recommendations.add(result.get());
+                    excludeIds.add(result.get().id());
+                    isFound = true;
+                }
+            }
+        }
+
+        return new MemberRecommendResponse(recommendations);
+    }
+
+    private Optional<RecommendedMember> findSamePartCandidate(
+        Set<String> myParts,
+        Set<Long> excludeIds
+    ) {
+        if (myParts.isEmpty()) return Optional.empty();
+
+        Map<Long, InternalUserDetails> platformInfoMap = new HashMap<>();
+        for (String part : myParts) {
+            UserSearchResponse search = platformService.searchInternalUsers(
+                null, part, null, null, PLATFORM_SEARCH_LIMIT, 0, null);
+            search.profiles().forEach(d -> platformInfoMap.put(d.userId(), d));
+        }
+
+        Set<Long> hasProfileIds = memberRepository.findAllByHasProfileTrueAndIdIn(new ArrayList<>(platformInfoMap.keySet()))
+            .stream().map(Member::getId).collect(Collectors.toSet());
+
+        List<Long> candidates = platformInfoMap.keySet().stream()
+            .filter(hasProfileIds::contains)
+            .filter(id -> !excludeIds.contains(id))
+            .filter(id -> platformInfoMap.get(id).soptActivities().stream()
+                .anyMatch(a -> a.isSopt() && myParts.contains(a.part())))
+            .toList();
+
+        return pickAndBuild(candidates, platformInfoMap, RecommendType.SAME_PART);
+    }
+
+    private Optional<RecommendedMember> findSameCrewCandidate(
+        Long userId,
+        Set<Long> excludeIds
+    ) {
+        InternalUserWithMeetingUsersResponse response;
+        try {
+            response = makersCrewClient.getRelatedUserIds(userId.intValue());
+        } catch (Exception e) {
+            log.warn("모임 관련 유저 조회 실패 - userId: {}, error: {}", userId, e.getMessage());
+            return Optional.empty();
+        }
+
+        List<Long> currentCandidates = filterHasProfileMembers(
+            response.currentGenerationUserIds().stream()
+                .map(u -> u.orgUserId().longValue())
+                .collect(Collectors.toSet()),
+            excludeIds
+        );
+        if (!currentCandidates.isEmpty()) {
+            return pickAndBuild(currentCandidates, Collections.emptyMap(), RecommendType.SAME_CREW);
+        }
+
+        List<Long> pastCandidates = filterHasProfileMembers(
+            response.pastGenerationUserIds().stream()
+                .map(u -> u.orgUserId().longValue())
+                .collect(Collectors.toSet()),
+            excludeIds
+        );
+        if (!pastCandidates.isEmpty()) {
+            return pickAndBuild(pastCandidates, Collections.emptyMap(), RecommendType.SAME_CREW);
+        }
+
+        return Optional.empty();
+    }
+
+    private Optional<RecommendedMember> findSameMbtiCandidate(
+        String currentMbti,
+        Set<Long> excludeIds
+    ) {
+        if (currentMbti == null || currentMbti.isBlank()) return Optional.empty();
+
+        List<Long> candidates = memberRepository.findAllByMbtiAndHasProfileTrue(currentMbti).stream()
+            .map(Member::getId)
+            .filter(id -> !excludeIds.contains(id))
+            .toList();
+
+        return pickAndBuild(candidates, Collections.emptyMap(), RecommendType.SAME_MBTI);
+    }
+
+    private Optional<RecommendedMember> findSameUniversityCandidate(
+        String currentUniversity,
+        Set<Long> excludeIds
+    ) {
+        if (currentUniversity == null || currentUniversity.isBlank()) return Optional.empty();
+
+        List<Long> candidates = memberRepository.findAllByUniversityAndHasProfileTrue(currentUniversity).stream()
+            .map(Member::getId)
+            .filter(id -> !excludeIds.contains(id))
+            .toList();
+
+        return pickAndBuild(candidates, Collections.emptyMap(), RecommendType.SAME_UNIVERSITY);
+    }
+
+    private Optional<RecommendedMember> findSameGenerationCandidate(
+        int myLatestGeneration,
+        Set<Long> excludeIds
+    ) {
+        if (myLatestGeneration < 0) return Optional.empty();
+
+        UserSearchResponse search = platformService.searchInternalUsers(
+            myLatestGeneration, null, null, null, PLATFORM_SEARCH_LIMIT, 0, null);
+
+        Map<Long, InternalUserDetails> platformInfoMap = search.profiles().stream()
+            .collect(Collectors.toMap(InternalUserDetails::userId, Function.identity()));
+
+        Set<Long> hasProfileIds = memberRepository.findAllByHasProfileTrueAndIdIn(new ArrayList<>(platformInfoMap.keySet()))
+            .stream().map(Member::getId).collect(Collectors.toSet());
+
+        List<Long> candidates = platformInfoMap.keySet().stream()
+            .filter(hasProfileIds::contains)
+            .filter(id -> !excludeIds.contains(id))
+            .filter(id -> platformInfoMap.get(id).soptActivities().stream()
+                .anyMatch(a -> a.isSopt() && a.generation() == myLatestGeneration))
+            .toList();
+
+        return pickAndBuild(candidates, platformInfoMap, RecommendType.SAME_GENERATION);
+    }
+
+    private Optional<RecommendedMember> pickAndBuild(
+        List<Long> candidates,
+        Map<Long, InternalUserDetails> cachedPlatformInfo,
+        RecommendType type
+    ) {
+        if (candidates.isEmpty()) return Optional.empty();
+
+        List<Long> shuffled = new ArrayList<>(candidates);
+        Collections.shuffle(shuffled);
+        Long picked = shuffled.get(0);
+
+        InternalUserDetails details = Optional.ofNullable(cachedPlatformInfo.get(picked))
+            .orElseGet(() -> platformService.getInternalUser(picked));
+
+        SoptActivity latestActivity = details.soptActivities().stream()
+            .max(Comparator.comparingInt(SoptActivity::normalizedGeneration))
+            .orElse(null);
+
+        SoptActivity latestSoptActivity = details.soptActivities().stream()
+            .filter(SoptActivity::isSopt)
+            .max(Comparator.comparingInt(SoptActivity::generation))
+            .orElse(null);
+
+        Integer generation = latestActivity != null ? latestActivity.generation() : details.lastGeneration();
+        String part = (latestActivity != null && !latestActivity.isSopt())
+            ? "메이커스"
+            : (latestSoptActivity != null ? latestSoptActivity.part() : null);
+
+        return Optional.of(new RecommendedMember(
+            picked,
+            details.name(),
+            details.profileImage(),
+            generation,
+            part,
+            type
+        ));
+    }
+
+    private List<Long> filterHasProfileMembers(Set<Long> participantIds, Set<Long> excludeIds) {
+        List<Long> filtered = participantIds.stream()
+            .filter(id -> !excludeIds.contains(id))
+            .toList();
+
+        return memberRepository.findAllByHasProfileTrueAndIdIn(filtered).stream()
+            .map(Member::getId)
+            .toList();
+    }
+}


### PR DESCRIPTION
## 🐬 요약
PR의 요약을 작성해주세요!
- 멤버 추천 기능 구현
## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [x] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
PR에 담긴 작업 내용을 작성해주세요!

- 멤버 추천 기능을 추가했습니다.
   
   `getRecommendations`

  - 현재 유저의 DB 정보와 플랫폼 정보를 조회해 추천에 필요한 파트, 기수를 추출합니다.
  추천 기준 5개(파트 → 모임 → MBTI → 학교 → 기수)를 순서대로 순회하며 최대 5개 슬롯을 채웁니다.
  criteriaPointer가 기준을 앞으로만 소진하며, 후보가 없으면 다음 기준으로 넘어갑니다.
  추천된 멤버는 excludeIds에 추가되어 같은 세트 내 중복이 방지됩니다.

  `findSamePartCandidate`

  - 내 SOPT 파트별로 플랫폼 API를 호출해 같은 파트 멤버를 수집합니다.
  수집된 멤버 중 DB에 프로필이 등록되어 있고, SOPT 활동에서 해당 파트가 있는 멤버만 후보로 추립니다.

  `findSameCrewCandidate`

  - Crew 내부 API(getRelatedUserIds)를 한 번 호출해 현재 기수 모임 참여자와 과거 모임 참여자를 한 번에 받습니다.
  현재 기수 모임 후보가 있으면 바로 반환하고, 없으면 과거 모임 후보에서 선택합니다.
  API 호출 실패 시 경고 로그를 남기고 다음 기준으로 넘어갑니다.

  `findSameMbtiCandidate`

  - MBTI가 없으면 즉시 skip합니다.
  DB에서 같은 MBTI이고 프로필이 등록된 멤버 목록을 조회해 후보로 사용합니다.

  `findSameUniversityCandidate`

  - 학교 정보가 없으면 즉시 skip합니다.
  DB에서 같은 학교이고 프로필이 등록된 멤버 목록을 조회해 후보로 사용합니다.

  `findSameGenerationCandidate`

  - SOPT 활동이 없으면 즉시 skip합니다.
  플랫폼 API로 같은 SOPT 기수 멤버를 검색하고, 그 중 실제로 해당 기수 SOPT 활동이 있는 멤버만 후보로 추립니다. (Makers 동일 기수 번호 혼입 방지)

  `pickAndBuild`

  - 후보 목록을 셔플해 첫 번째 ID를 선택합니다.
  이미 조회된 플랫폼 정보가 있으면 재사용하고, 없으면 개별 API를 호출합니다.
  최신 활동 기수는 Makers 포함 전체 기준으로, 파트는 SOPT 기준으로 표시합니다.
  단, 최신 활동이 Makers인 경우 파트를 "메이커스"로 반환합니다.


## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #916 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 회원 추천 기능이 추가되었습니다. 인증된 사용자는 GET /api/v1/members/recommend로 최대 5명의 맞춤형 추천을 받을 수 있습니다.
  * 추천은 동일 파트, 동일 크루, 동일 MBTI, 동일 대학, 동일 기수 순의 다양한 기준을 바탕으로 중복 없이 선별됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->