### PR TITLE
[Feat] 특정 사용자 기준 추천 멤버 조회 API 추가

### DIFF
--- a/src/main/java/org/sopt/makers/internal/member/controller/MemberController.java
+++ b/src/main/java/org/sopt/makers/internal/member/controller/MemberController.java
@@ -257,7 +257,7 @@ public class MemberController {
     }
 
     @Operation(
-        summary = "멤버 추천 API",
+        summary = "현재 사용자 기준 멤버 추천 API",
         description = """
             현재 사용자 기준으로 추천 멤버 최대 5명을 반환합니다.
             추천 기준 우선순위: 같은 파트 → 같은 모임 → 같은 MBTI → 같은 학교 → 같은 기수
@@ -266,11 +266,28 @@ public class MemberController {
             """
     )
     @GetMapping("/recommend/me")
-    public ResponseEntity<MemberRecommendResponse> getRecommendedMembers(
+    public ResponseEntity<MemberRecommendResponse> getRecommendedMembersForMe(
         @Parameter(hidden = true) @AuthenticationPrincipal Long userId
     ) {
         MemberRecommendResponse response = memberRecommendService.getRecommendations(userId);
         return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @Operation(
+        summary = "특정 사용자 기준 멤버 추천 API",
+        description = """
+        userId에 해당하는 사용자를 기준으로 추천 멤버 최대 5명을 반환합니다.
+        추천 기준 우선순위: 같은 파트 → 같은 모임 → 같은 MBTI → 같은 학교 → 같은 기수
+        해당 순서의 후보가 없으면 다음 순서 기준으로 대체됩니다.
+        조회 시마다 각 슬롯에서 랜덤으로 1명씩 선택됩니다.
+        """
+    )
+    @GetMapping("/recommend/{userId}")
+    public ResponseEntity<MemberRecommendResponse> getRecommendedMembersForUser(
+        @PathVariable Long userId
+    ) {
+        MemberRecommendResponse response = memberRecommendService.getRecommendations(userId);
+        return ResponseEntity.ok(response);
     }
 
     @Operation(


### PR DESCRIPTION
## 🐬 요약
- `/recommend/{userId}` 엔드포인트를 추가했습니다.
- 특정 사용자 기준으로 추천 멤버 목록을 조회할 수 있도록 구현했습니다.
- 기존 추천 멤버 조회 로직은 재사용하고, 컨트롤러 엔드포인트만 확장했습니다.
## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [x] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
PR에 담긴 작업 내용을 작성해주세요!

### 변경 사항
- 현재 사용자 기준 추천 멤버 조회 API 유지
  - `GET /recommend/me`
- 특정 사용자 기준 추천 멤버 조회 API 추가
  - `GET /recommend/{userId}`

### 구현 방식
- 추천 멤버를 계산하는 기존 service 메서드를 재사용했습니다.
- `/recommend/me` 는 인증된 사용자 ID를 사용합니다.
- `/recommend/{userId}` 는 path variable로 전달받은 사용자 ID를 사용합니다.

### 기대 효과
- 관리자/운영용 확인이나 디버깅 상황에서 특정 사용자 기준 추천 결과를 직접 조회할 수 있습니다.
- 기존 추천 로직을 중복 구현하지 않아 유지보수성을 유지할 수 있습니다.

### 기타
- 응답 스펙은 기존 `MemberRecommendResponse` 를 그대로 사용합니다.
- 추천 기준 및 랜덤 선택 방식은 기존 `/recommend/me` 와 동일합니다.

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #924 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 특정 사용자를 기준으로 멤버 추천을 받을 수 있는 새로운 API 엔드포인트가 추가되었습니다.

* **개선사항**
  * 현재 사용자 기준 멤버 추천 API의 설명이 더 명확하게 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->