### PR TITLE
[Feat] 같은 기수 같은 파트 멤버 추천 API

### DIFF
--- a/src/main/java/org/sopt/makers/internal/member/controller/MemberController.java
+++ b/src/main/java/org/sopt/makers/internal/member/controller/MemberController.java
@@ -34,6 +34,7 @@ import org.sopt.makers.internal.member.dto.response.MemberPropertiesResponse;
 import org.sopt.makers.internal.member.dto.response.MemberRecommendResponse;
 import org.sopt.makers.internal.member.dto.response.MemberResponse;
 import org.sopt.makers.internal.member.dto.response.AskMemberResponse;
+import org.sopt.makers.internal.member.dto.response.SameGenerationAndPartRecommendResponse;
 import org.sopt.makers.internal.member.dto.response.WorkPreferenceRecommendationResponse;
 import org.sopt.makers.internal.member.dto.response.WorkPreferenceResponse;
 import org.sopt.makers.internal.member.dto.response.TlMemberResponse;
@@ -287,6 +288,40 @@ public class MemberController {
         @PathVariable Long userId
     ) {
         MemberRecommendResponse response = memberRecommendService.getRecommendations(userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(
+        summary = "현재 사용자 기준 같은 기수 + 같은 파트 멤버 추천 API",
+        description = """
+            가장 최신 기수 활동을 기준으로 같은 기수 + 같은 파트 멤버를 반환합니다.
+            1. 솝트가 가장 최근 기수일 경우 → {최신 기수}기 {최신 기수 파트명} 멤버
+            2. 메이커스가 가장 최근 기수일 경우 → {최신 기수}기 메이커스 멤버
+            3. 솝트, 메이커스를 동시에 한 기수가 가장 최근 기수일 경우 → 솝트 기준으로 처리
+            """
+    )
+    @GetMapping("/recommend/me/generation-part")
+    public ResponseEntity<SameGenerationAndPartRecommendResponse> getSameGenerationAndPartMembersForMe(
+        @Parameter(hidden = true) @AuthenticationPrincipal Long userId
+    ) {
+        SameGenerationAndPartRecommendResponse response = memberRecommendService.getSameGenerationAndPartRecommendations(userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(
+        summary = "특정 사용자 기준 같은 기수 + 같은 파트 멤버 추천 API",
+        description = """
+            가장 최신 기수 활동을 기준으로 같은 기수 + 같은 파트 멤버를 반환합니다.
+            1. 솝트가 가장 최근 기수일 경우 → {최신 기수}기 {최신 기수 파트명} 멤버
+            2. 메이커스가 가장 최근 기수일 경우 → {최신 기수}기 메이커스 멤버
+            3. 솝트, 메이커스를 동시에 한 기수가 가장 최근 기수일 경우 → 솝트 기준으로 처리
+            """
+    )
+    @GetMapping("/recommend/{userId}/generation-part")
+    public ResponseEntity<SameGenerationAndPartRecommendResponse> getSameGenerationAndPartMembersForUser(
+        @PathVariable Long userId
+    ) {
+        SameGenerationAndPartRecommendResponse response = memberRecommendService.getSameGenerationAndPartRecommendations(userId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/org/sopt/makers/internal/member/dto/response/SameGenerationAndPartRecommendResponse.java
+++ b/src/main/java/org/sopt/makers/internal/member/dto/response/SameGenerationAndPartRecommendResponse.java
@@ -1,0 +1,18 @@
+package org.sopt.makers.internal.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "같은 기수 + 같은 파트 추천 멤버 응답")
+public record SameGenerationAndPartRecommendResponse(
+    List<SameGenerationAndPartMember> members
+) {
+    @Schema(description = "추천 멤버 정보")
+    public record SameGenerationAndPartMember(
+        Long id,
+        String name,
+        String profileImage,
+        Integer generation,
+        String part
+    ) {}
+}

--- a/src/main/java/org/sopt/makers/internal/member/service/MemberRecommendService.java
+++ b/src/main/java/org/sopt/makers/internal/member/service/MemberRecommendService.java
@@ -12,6 +12,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.sopt.makers.internal.member.dto.response.SameGenerationAndPartRecommendResponse;
+import org.sopt.makers.internal.member.dto.response.SameGenerationAndPartRecommendResponse.SameGenerationAndPartMember;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,6 +42,7 @@ public class MemberRecommendService {
     private final MakersCrewClient makersCrewClient;
 
     private static final int RECOMMENDATION_SET_SIZE = 5;
+    private static final int SAME_GENERATION_AND_PART_SET_SIZE = 4;
     private static final int PLATFORM_SEARCH_LIMIT = 200;
 
     private enum RecommendCriterion {
@@ -281,6 +284,113 @@ public class MemberRecommendService {
             case "CX" -> "CX";
             default -> null;
         };
+    }
+
+    @Transactional(readOnly = true)
+    public SameGenerationAndPartRecommendResponse getSameGenerationAndPartRecommendations(Long userId) {
+        InternalUserDetails currentUserDetails = platformService.getInternalUser(userId);
+        List<SoptActivity> activities = currentUserDetails.soptActivities();
+
+        Optional<SoptActivity> latestSopt = activities.stream()
+            .filter(SoptActivity::isSopt)
+            .max(Comparator.comparingInt(SoptActivity::generation));
+
+        Optional<SoptActivity> latestMakers = activities.stream()
+            .filter(a -> !a.isSopt())
+            .max(Comparator.comparingInt(SoptActivity::normalizedGeneration));
+
+        // 메이커스 활동이 없으면 최신 SOPT 기준으로 처리
+        if (latestMakers.isEmpty()) {
+            if (latestSopt.isEmpty()) return new SameGenerationAndPartRecommendResponse(List.of());
+            return new SameGenerationAndPartRecommendResponse(
+                findSameGenerationAndPartSoptCandidates(userId, latestSopt.get())
+            );
+        }
+
+        int soptNormalized = latestSopt.map(SoptActivity::normalizedGeneration).orElse(-1);
+        int makersNormalized = latestMakers.get().normalizedGeneration();
+
+        // SOPT가 더 최신이거나 동일 기수 → SOPT 기준
+        if (soptNormalized >= makersNormalized) {
+            return new SameGenerationAndPartRecommendResponse(
+                findSameGenerationAndPartSoptCandidates(userId, latestSopt.get())
+            );
+        }
+
+        // 메이커스가 더 최신 → 메이커스 기준
+        return new SameGenerationAndPartRecommendResponse(
+            findSameGenerationAndPartMakersCandidates(userId, latestMakers.get())
+        );
+    }
+
+    private List<SameGenerationAndPartMember> findSameGenerationAndPartSoptCandidates(Long excludeId, SoptActivity latestSopt) {
+        int targetGeneration = latestSopt.generation();
+        String targetPartEnum = toPartEnumName(latestSopt.part());
+        if (targetPartEnum == null) return List.of();
+
+        UserSearchResponse search = platformService.searchInternalUsers(
+            targetGeneration, targetPartEnum, null, null, PLATFORM_SEARCH_LIMIT, 0, null);
+
+        Map<Long, InternalUserDetails> platformInfoMap = search.profiles().stream()
+            .collect(Collectors.toMap(InternalUserDetails::userId, Function.identity()));
+
+        Set<Long> hasProfileIds = memberRepository.findAllByHasProfileTrueAndIdIn(new ArrayList<>(platformInfoMap.keySet()))
+            .stream().map(Member::getId).collect(Collectors.toSet());
+
+        List<Long> candidates = new ArrayList<>(platformInfoMap.keySet().stream()
+            .filter(hasProfileIds::contains)
+            .filter(id -> !id.equals(excludeId))
+            .filter(id -> platformInfoMap.get(id).soptActivities().stream()
+                .anyMatch(a -> a.isSopt()
+                    && a.generation() == targetGeneration
+                    && targetPartEnum.equals(toPartEnumName(a.part()))))
+            .toList());
+
+        Collections.shuffle(candidates);
+
+        return candidates.stream()
+            .limit(SAME_GENERATION_AND_PART_SET_SIZE)
+            .map(id -> {
+                InternalUserDetails details = platformInfoMap.get(id);
+                String partName = details.soptActivities().stream()
+                    .filter(a -> a.isSopt() && a.generation() == targetGeneration && targetPartEnum.equals(toPartEnumName(a.part())))
+                    .map(SoptActivity::part)
+                    .filter(Objects::nonNull)
+                    .findFirst()
+                    .orElse(targetPartEnum);
+                return new SameGenerationAndPartMember(id, details.name(), details.profileImage(), targetGeneration, partName);
+            })
+            .toList();
+    }
+
+    private List<SameGenerationAndPartMember> findSameGenerationAndPartMakersCandidates(Long excludeId, SoptActivity latestMakers) {
+        int targetMakersGeneration = latestMakers.generation();
+
+        UserSearchResponse search = platformService.searchInternalUsers(
+            null, null, "메이커스", null, PLATFORM_SEARCH_LIMIT, 0, null);
+
+        Map<Long, InternalUserDetails> platformInfoMap = search.profiles().stream()
+            .collect(Collectors.toMap(InternalUserDetails::userId, Function.identity()));
+
+        Set<Long> hasProfileIds = memberRepository.findAllByHasProfileTrueAndIdIn(new ArrayList<>(platformInfoMap.keySet()))
+            .stream().map(Member::getId).collect(Collectors.toSet());
+
+        List<Long> candidates = new ArrayList<>(platformInfoMap.keySet().stream()
+            .filter(hasProfileIds::contains)
+            .filter(id -> !id.equals(excludeId))
+            .filter(id -> platformInfoMap.get(id).soptActivities().stream()
+                .anyMatch(a -> !a.isSopt() && a.generation() == targetMakersGeneration))
+            .toList());
+
+        Collections.shuffle(candidates);
+
+        return candidates.stream()
+            .limit(SAME_GENERATION_AND_PART_SET_SIZE)
+            .map(id -> {
+                InternalUserDetails details = platformInfoMap.get(id);
+                return new SameGenerationAndPartMember(id, details.name(), details.profileImage(), targetMakersGeneration, "메이커스");
+            })
+            .toList();
     }
 
     private List<Long> filterHasProfileMembers(Set<Long> participantIds, Set<Long> excludeIds) {


### PR DESCRIPTION
## 🐬 요약
PR의 요약을 작성해주세요!

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [x] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
PR에 담긴 작업 내용을 작성해주세요!

- 같은 기수 같은 파트 멤버 추천 기능 구현                                                                                                                                                                                                                     
                                                                                                                                                                                                                                       
  - 가장 최신 기수 활동을 기준으로 아래 조건에 따라 추천 대상을 결정합니다.                                                                                                                                                              
   
  1. **메이커스 활동이 없는 경우** → 최신 SOPT 기수 + 파트 기준                                                                                                                                                                        
  2. **SOPT가 더 최신이거나 동일 기수인 경우** → 최신 SOPT 기수 + 파트 기준
  3. **메이커스가 더 최신인 경우** → 최신 메이커스 기수 기준                                                                                                                                                                           
                                                                                                                                                                                                                                       
  > 조건 2에서 동일 기수 처리: 같은 기수에 SOPT + 메이커스를 동시에 한 경우 SOPT 기준으로 표기                                                                                                                                         
                                                                                                                                                                                                                                       
  SOPT/메이커스 기수 비교 시 `normalizedGeneration()`을 사용하여 동일 스케일로 비교합니다.                                                                                                                                             
  (메이커스 1-4기는 SOPT 31-34기로 정규화) 

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

- closes : #926 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* 동일 세대 및 동일 파트 회원 추천 기능이 추가되었습니다.
* 현재 사용자 또는 특정 사용자에 대해 같은 세대와 파트에 속한 회원을 추천받을 수 있는 새로운 API 엔드포인트가 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->