### PR TITLE
[Fix] 특정 유저 기준 멤버 추천 API 수정

### DIFF
--- a/src/main/java/org/sopt/makers/internal/member/controller/MemberController.java
+++ b/src/main/java/org/sopt/makers/internal/member/controller/MemberController.java
@@ -278,7 +278,7 @@ public class MemberController {
         summary = "특정 사용자 기준 멤버 추천 API",
         description = """
         userId에 해당하는 사용자를 기준으로 추천 멤버 최대 5명을 반환합니다.
-        추천 기준 우선순위: 같은 파트 → 같은 모임 → 같은 MBTI → 같은 학교 → 같은 기수
+        추천 기준 우선순위: 같은 파트 → 같은 모임 → 같은 프로젝트 → 같은 학교 → 같은 기수
         해당 순서의 후보가 없으면 다음 순서 기준으로 대체됩니다.
         조회 시마다 각 슬롯에서 랜덤으로 1명씩 선택됩니다.
         """
@@ -287,7 +287,7 @@ public class MemberController {
     public ResponseEntity<MemberRecommendResponse> getRecommendedMembersForUser(
         @PathVariable Long userId
     ) {
-        MemberRecommendResponse response = memberRecommendService.getRecommendations(userId);
+        MemberRecommendResponse response = memberRecommendService.getRecommendationsForUser(userId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/org/sopt/makers/internal/member/dto/response/MemberRecommendResponse.java
+++ b/src/main/java/org/sopt/makers/internal/member/dto/response/MemberRecommendResponse.java
@@ -23,6 +23,7 @@ public record MemberRecommendResponse(
         SAME_PART,       // 같은 파트
         SAME_CREW,       // 같은 모임
         SAME_MBTI,       // 같은 MBTI
+        SAME_PROJECT,    // 같은 프로젝트
         SAME_UNIVERSITY, // 같은 학교
         SAME_GENERATION  // 같은 기수
     }

--- a/src/main/java/org/sopt/makers/internal/member/service/MemberRecommendService.java
+++ b/src/main/java/org/sopt/makers/internal/member/service/MemberRecommendService.java
@@ -29,6 +29,7 @@ import org.sopt.makers.internal.member.dto.response.MemberRecommendResponse;
 import org.sopt.makers.internal.member.dto.response.MemberRecommendResponse.RecommendType;
 import org.sopt.makers.internal.member.dto.response.MemberRecommendResponse.RecommendedMember;
 import org.sopt.makers.internal.member.repository.MemberRepository;
+import org.sopt.makers.internal.project.repository.MemberProjectRelationRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,17 +41,43 @@ public class MemberRecommendService {
     private final MemberRepository memberRepository;
     private final PlatformService platformService;
     private final MakersCrewClient makersCrewClient;
+    private final MemberProjectRelationRepository memberProjectRelationRepository;
 
     private static final int RECOMMENDATION_SET_SIZE = 5;
     private static final int SAME_GENERATION_AND_PART_SET_SIZE = 4;
     private static final int PLATFORM_SEARCH_LIMIT = 200;
 
     private enum RecommendCriterion {
-        SAME_PART, SAME_CREW, SAME_MBTI, SAME_UNIVERSITY, SAME_GENERATION
+        SAME_PART, SAME_CREW, SAME_MBTI, SAME_PROJECT, SAME_UNIVERSITY, SAME_GENERATION
     }
 
+    // /recommend/me - MBTI 기준
     @Transactional(readOnly = true)
     public MemberRecommendResponse getRecommendations(Long userId) {
+        List<RecommendCriterion> criteria = List.of(
+            RecommendCriterion.SAME_PART,
+            RecommendCriterion.SAME_CREW,
+            RecommendCriterion.SAME_MBTI,
+            RecommendCriterion.SAME_UNIVERSITY,
+            RecommendCriterion.SAME_GENERATION
+        );
+        return buildRecommendations(userId, criteria);
+    }
+
+    // /recommend/{userId} - 프로젝트 기준
+    @Transactional(readOnly = true)
+    public MemberRecommendResponse getRecommendationsForUser(Long userId) {
+        List<RecommendCriterion> criteria = List.of(
+            RecommendCriterion.SAME_PART,
+            RecommendCriterion.SAME_CREW,
+            RecommendCriterion.SAME_PROJECT,
+            RecommendCriterion.SAME_UNIVERSITY,
+            RecommendCriterion.SAME_GENERATION
+        );
+        return buildRecommendations(userId, criteria);
+    }
+
+    private MemberRecommendResponse buildRecommendations(Long userId, List<RecommendCriterion> criteria) {
         Member currentMember = memberRepository.findById(userId)
             .orElseThrow(() -> new NotFoundException("해당 id의 Member를 찾을 수 없습니다."));
         InternalUserDetails currentUserDetails = platformService.getInternalUser(userId);
@@ -71,13 +98,6 @@ public class MemberRecommendService {
         excludeIds.add(userId);
 
         List<RecommendedMember> recommendations = new ArrayList<>();
-        List<RecommendCriterion> criteria = List.of(
-            RecommendCriterion.SAME_PART,
-            RecommendCriterion.SAME_CREW,
-            RecommendCriterion.SAME_MBTI,
-            RecommendCriterion.SAME_UNIVERSITY,
-            RecommendCriterion.SAME_GENERATION
-        );
 
         // criteriaPointer는 슬롯 간 공유 - 한 번 소진된 기준은 재사용하지 않음
         int criteriaPointer = 0;
@@ -89,6 +109,7 @@ public class MemberRecommendService {
                     case SAME_PART -> findSamePartCandidate(myParts, excludeIds);
                     case SAME_CREW -> findSameCrewCandidate(userId, excludeIds);
                     case SAME_MBTI -> findSameMbtiCandidate(currentMember.getMbti(), excludeIds);
+                    case SAME_PROJECT -> findSameProjectCandidate(userId, excludeIds);
                     case SAME_UNIVERSITY -> findSameUniversityCandidate(currentMember.getUniversity(), excludeIds);
                     case SAME_GENERATION -> findSameGenerationCandidate(myLatestGeneration, excludeIds);
                 };
@@ -187,6 +208,29 @@ public class MemberRecommendService {
             .toList();
 
         return pickAndBuild(candidates, Collections.emptyMap(), RecommendType.SAME_MBTI);
+    }
+
+    private Optional<RecommendedMember> findSameProjectCandidate(
+        Long userId,
+        Set<Long> excludeIds
+    ) {
+        List<Long> myProjectIds = memberProjectRelationRepository.findAllByUserId(userId).stream()
+            .map(relation -> relation.getProjectId())
+            .toList();
+
+        if (myProjectIds.isEmpty()) return Optional.empty();
+
+        Set<Long> candidateIds = myProjectIds.stream()
+            .flatMap(projectId -> memberProjectRelationRepository.findAllByProjectId(projectId).stream())
+            .map(relation -> relation.getUserId())
+            .filter(id -> !excludeIds.contains(id))
+            .collect(Collectors.toSet());
+
+        List<Long> candidates = memberRepository.findAllByHasProfileTrueAndIdIn(new ArrayList<>(candidateIds)).stream()
+            .map(Member::getId)
+            .toList();
+
+        return pickAndBuild(candidates, Collections.emptyMap(), RecommendType.SAME_PROJECT);
     }
 
     private Optional<RecommendedMember> findSameUniversityCandidate(

--- a/src/main/java/org/sopt/makers/internal/project/repository/MemberProjectRelationRepository.java
+++ b/src/main/java/org/sopt/makers/internal/project/repository/MemberProjectRelationRepository.java
@@ -8,5 +8,7 @@ import java.util.List;
 public interface MemberProjectRelationRepository extends JpaRepository<MemberProjectRelation, Long> {
     List<MemberProjectRelation> findAllByProjectId(Long projectId);
 
+    List<MemberProjectRelation> findAllByUserId(Long userId);
+
     void deleteAllByProjectId(Long projectId);
 }


### PR DESCRIPTION
## 🐬 요약
PR의 요약을 작성해주세요!

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [x] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
PR에 담긴 작업 내용을 작성해주세요!

- 특정 유저 기준 멤버 추천 API 내 기준을 기능명세서에 맞게 수정했습니다.
  - `GET /recommend/me` : 기존 추천 기준 유지 (같은 파트 → 같은 모임 → 같은 MBTI → 같은 학교 → 같은 기수)                                                                                                                                 
  - `GET /recommend/{userId}` :  추천 기준 변경 (같은 파트 → 같은 모임 → 같은 프로젝트 → 같은 학교 → 같은 기수)                                                                                                                            
  - 두 API의 공통 로직을 buildRecommendations()로 추출하여 분리                                                                                                                                                                        
  - MemberProjectRelationRepository에 findAllByUserId() 추가                                                                                                                                                                           
  - RecommendType enum에 SAME_PROJECT 추가     

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

- close: #928 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 회원 추천 목록에 같은 프로젝트 참여 이력 기반 추천 기능 추가로 더욱 정확한 네트워킹 지원

* **Improvements**
  * 특정 회원 프로필 조회 시 맞춤형 추천 우선순위 알고리즘 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->