### PR TITLE
Deploy: dev 서버 배포 워크플로우 수동 실행으로 변경

### DIFF
--- a/.github/workflows/cd-to-dev.yml
+++ b/.github/workflows/cd-to-dev.yml
@@ -12,10 +12,10 @@ on:
         - info
         - warning
         - debug
-  repository_dispatch:
-    types: [deploy-to-test-event]
-  push:
-    branches: [ develop ]
+#  repository_dispatch:
+#    types: [deploy-to-test-event]
+#  push:
+#    branches: [ develop ]
 
 env:
   SPRING_PROFILES_ACTIVE: dev


### PR DESCRIPTION
## 🐬 요약
dev 서버 배포 워크플로우의 자동 실행 트리거 비활성화

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [ ] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [x] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
PR에 담긴 작업 내용을 작성해주세요!

- dev 서버 배포 워크플로우의 자동 실행 트리거를 비활성화했습니다.
- `push` 트리거와 `repository_dispatch` 트리거를 주석 처리했습니다.
- `workflow_dispatch`는 유지하여 필요 시 GitHub Actions에서 수동으로 배포할 수 있도록 했습니다.

## 변경 이유

현재 EC2 dev 서버 배포와 Lambda 배포 워크플로우는 분리되어 있어 직접적인 충돌은 없지만, `develop` 브랜치 push 시 EC2 dev 서버 배포가 자동 실행될 수 있었습니다. 현재 EC2 dev 서버를 이용하지 않으므로 해당 자동 배포 플로우를 주석처리했습니다. 필요시 EC2 배포는 수동 실행 가능합니다.

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #936 

## To Reviewers
ip 변경에 따른 yml 수정사항 노션과 s3에 반영했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 출시 노트

* **Chores**
  * 테스트 환경으로의 배포 트리거 설정을 변경했습니다. 이전에는 저장소 이벤트 및 개발 브랜치로의 푸시로 인해 자동으로 배포가 진행되었으나, 이제는 수동 명령어를 통해서만 배포를 시작할 수 있습니다. 배포 작업의 실제 로직, 빌드 과정 및 배포 프로세스는 변경되지 않았습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->