### PR TITLE
[Feat] 커뮤니티 피드 구조 개편 및 목록 조회 성능 개선

### DIFF
--- a/src/main/java/org/sopt/makers/internal/community/controller/CommunityController.java
+++ b/src/main/java/org/sopt/makers/internal/community/controller/CommunityController.java
@@ -4,12 +4,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
-import org.sopt.makers.internal.common.util.InfiniteScrollUtil;
-import org.sopt.makers.internal.community.dto.CommunityPostMemberVo;
-import org.sopt.makers.internal.community.dto.comment.CommentInfo;
+// import org.sopt.makers.internal.common.util.InfiniteScrollUtil;
+import org.sopt.makers.internal.community.domain.enums.CommunityPostListCategory;
+import org.sopt.makers.internal.community.domain.enums.CommunityPostListFilter;
 import org.sopt.makers.internal.community.dto.request.CommunityHitRequest;
 import org.sopt.makers.internal.community.dto.request.PostSaveRequest;
 import org.sopt.makers.internal.community.dto.request.PostUpdateRequest;
@@ -17,7 +16,7 @@ import org.sopt.makers.internal.community.dto.response.*;
 import org.sopt.makers.internal.community.service.post.CommunityPostService;
 import org.sopt.makers.internal.community.mapper.CommunityResponseMapper;
 import org.sopt.makers.internal.community.service.comment.CommunityCommentService;
-import org.sopt.makers.internal.community.service.comment.CommunityCommentLikeService;
+// import org.sopt.makers.internal.community.service.comment.CommunityCommentLikeService;
 import org.sopt.makers.internal.vote.dto.request.VoteSelectionRequest;
 import org.sopt.makers.internal.vote.dto.response.VoteResponse;
 import org.sopt.makers.internal.vote.service.VoteService;
@@ -27,10 +26,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import jakarta.validation.Valid;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor
@@ -42,11 +39,9 @@ public class CommunityController {
     private final CommunityPostService communityPostService;
     private final VoteService voteService;
     private final CommunityCommentService communityCommentService;
-    private final CommunityCommentLikeService commentLikeService;
+    // private final CommunityCommentLikeService commentLikeService;
     private final CommunityResponseMapper communityResponseMapper;
-    private final InfiniteScrollUtil infiniteScrollUtil;
-
-    private static final Long MEETING_CATEGORY_ID = 24L;
+    // private final InfiniteScrollUtil infiniteScrollUtil;
 
     @Operation(summary = "커뮤니티 글 상세 조회")
     @GetMapping("/posts/{postId}")
@@ -65,53 +60,34 @@ public class CommunityController {
     }
 
     @Operation(
-            summary = "커뮤니티 글 전체 조회",
-            description = """
-                        categoryId: 카테고리 전체조회시 id값, 전체일 경우 null
-                        cursor: 처음 조회시 null, 이외에 마지막 글 id
-            """
+        summary = "커뮤니티 글 목록 조회",
+        description = """
+                category: FREE, PROMOTION, SOPTICLE
+                filter:
+                  - FREE: 사용하지 않음
+                  - PROMOTION: ALL, EVENT, PROJECT, RECRUIT, ETC
+                  - SOPTICLE: ALL, PLAN, DESIGN, SERVER, WEB, IOS, ANDROID, ETC
+                cursor: 처음 조회 시 null, 이후 응답의 nextCursor 사용
+                """
     )
     @GetMapping("/posts")
     public ResponseEntity<PostAllResponse> getAllPosts(
-            @Parameter(hidden = true) @AuthenticationPrincipal Long userId,
-            @RequestParam(required = false, name = "categoryId") Long categoryId,
-            @RequestParam(value = "isBlockOn", required = false, defaultValue = "true") Boolean isBlockOn,
-            @RequestParam(required = false, name = "limit") Integer limit,
-            @RequestParam(required = false, name = "cursor") Long cursor,
-            @RequestParam(required = false, name = "page", defaultValue = "1") Integer page
+        @Parameter(hidden = true) @AuthenticationPrincipal Long userId,
+        @RequestParam(name = "category") CommunityPostListCategory category,
+        @RequestParam(name = "filter", required = false) CommunityPostListFilter filter,
+        @RequestParam(value = "isBlockOn", required = false, defaultValue = "true") Boolean isBlockOn,
+        @RequestParam(required = false, name = "limit") Integer limit,
+        @RequestParam(required = false, name = "cursor") String cursor
     ) {
-        if(Objects.equals(categoryId, MEETING_CATEGORY_ID)){
-            PostAllResponse response = communityPostService.getMeetingPosts(userId, page, limit);
-            return ResponseEntity.status(HttpStatus.OK).body(response);
-        }
+        PostAllResponse response = communityPostService.getPosts(
+            userId,
+            category,
+            filter,
+            isBlockOn,
+            limit,
+            cursor
+        );
 
-        List<CommunityPostMemberVo> posts = communityPostService.getAllPosts(categoryId, isBlockOn, userId,
-                infiniteScrollUtil.checkLimitForPagination(limit), cursor);
-        Boolean hasNextPosts = infiniteScrollUtil.checkHasNextElement(limit, posts);
-        Map<Long, List<CommentInfo>> postCommentsMap = posts.stream()
-                .collect(Collectors.toMap(
-                        post -> post.post().id(),
-                        post -> communityCommentService.getPostCommentList(post.post().id(), userId, isBlockOn)
-                ));
-        List<Long> allCommentIds = postCommentsMap.values().stream()
-                .flatMap(List::stream)
-                .map(c -> c.commentDao().comment().getId())
-                .collect(Collectors.toList());
-
-        Map<Long, Boolean> commentLikedMap = commentLikeService.getLikedMapByCommentIds(userId, allCommentIds);
-        Map<Long, Integer> commentLikeCountMap = commentLikeService.getLikeCountMapByCommentIds(allCommentIds);
-
-        val postResponse = posts.stream().map(post -> {
-            List<CommentInfo> comments = postCommentsMap.get(post.post().id());
-            val anonymousPostProfile = communityPostService.getAnonymousPostProfile(post.post().id());
-            val isLiked = communityPostService.isLiked(userId, post.post().id());
-            val likes = communityPostService.getLikes(post.post().id());
-
-            return communityResponseMapper.toPostResponse(post, comments, userId, anonymousPostProfile,
-                    isLiked, likes, commentLikedMap, commentLikeCountMap);
-        }).collect(Collectors.toList());
-
-        val response = new PostAllResponse(categoryId, hasNextPosts, postResponse);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
@@ -202,9 +178,11 @@ public class CommunityController {
     @Operation(summary = "커뮤니티 홈 인기글 조회 API")
     @GetMapping("/posts/popular")
     public ResponseEntity<List<PopularPostResponse>> getPopularPost(
+            @Parameter(hidden = true) @AuthenticationPrincipal Long userId,
             @Parameter(description = "조회할 인기글 개수 (기본값: 3)")
-            @RequestParam(defaultValue = "3") int limit) {
-        return ResponseEntity.ok(communityPostService.getPopularPosts(limit));
+            @RequestParam(defaultValue = "3") int limit
+    ) {
+        return ResponseEntity.ok(communityPostService.getPopularPosts(userId, limit));
     }
 
     @Operation(summary = "커뮤니티 홈 최근 솝티클 목록 조회 API")

--- a/src/main/java/org/sopt/makers/internal/community/domain/CommunityPost.java
+++ b/src/main/java/org/sopt/makers/internal/community/domain/CommunityPost.java
@@ -13,6 +13,7 @@ import org.sopt.makers.internal.vote.domain.Vote;
 import jakarta.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Entity
 @Getter
@@ -88,7 +89,7 @@ public class CommunityPost extends AuditingTimeEntity {
         Boolean isBlindWriter,
         String sopticleUrl
     ) {
-        this.category = category;
+        this.category = Objects.requireNonNull(category, "category must not be null");
         this.title = title;
         this.content = content;
         this.images = images;

--- a/src/main/java/org/sopt/makers/internal/community/domain/CommunityPost.java
+++ b/src/main/java/org/sopt/makers/internal/community/domain/CommunityPost.java
@@ -4,6 +4,7 @@ import lombok.*;
 import io.hypersistence.utils.hibernate.type.array.ListArrayType;
 import org.hibernate.annotations.Type;
 import org.sopt.makers.internal.community.domain.anonymous.AnonymousProfile;
+import org.sopt.makers.internal.community.domain.category.Category;
 import org.sopt.makers.internal.community.domain.comment.CommunityComment;
 import org.sopt.makers.internal.member.domain.Member;
 import org.sopt.makers.internal.common.AuditingTimeEntity;
@@ -29,8 +30,9 @@ public class CommunityPost extends AuditingTimeEntity {
     @JoinColumn(name = "writer_id", nullable = false)
     private Member member;
 
-    @Column(nullable = false)
-    private Long categoryId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
 
     @Column
     private String title;
@@ -78,13 +80,19 @@ public class CommunityPost extends AuditingTimeEntity {
     @JoinColumn(name = "anonymous_profile_id")
     private AnonymousProfile anonymousProfile;
 
-    public void updatePost(Long categoryId, String title, String content,
-                           List<String> images, Boolean isQuestion, Boolean isBlindWriter, String sopticleUrl) {
-        this.categoryId = categoryId;
+    public void updatePost(
+        Category category,
+        String title,
+        String content,
+        List<String> images,
+        Boolean isBlindWriter,
+        String sopticleUrl
+    ) {
+        this.category = category;
         this.title = title;
         this.content = content;
         this.images = images;
-        this.isQuestion = isQuestion;
+        this.isQuestion = false;
         this.isBlindWriter = isBlindWriter;
         this.sopticleUrl = sopticleUrl;
     }

--- a/src/main/java/org/sopt/makers/internal/community/domain/category/Category.java
+++ b/src/main/java/org/sopt/makers/internal/community/domain/category/Category.java
@@ -6,6 +6,9 @@ import jakarta.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.sopt.makers.internal.community.domain.enums.CommunityCategoryCode;
+import org.sopt.makers.internal.community.domain.enums.CommunityCategoryGroup;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -14,6 +17,14 @@ public class Category {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "category_id")
     private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(unique = true)
+    private CommunityCategoryCode code;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category_group")
+    private CommunityCategoryGroup categoryGroup;
 
     @Column
     private String name;
@@ -30,27 +41,45 @@ public class Category {
     @Column
     private Boolean hasQuestion;
 
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive = true;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent")
     private Category parent;
 
-    @OneToMany(mappedBy = "parent", fetch = FetchType.EAGER)
+    @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY)
     private List<Category> children = new ArrayList<>();
 
     @Column
     private Integer displayOrder;
 
     @Builder
-    private Category(Long id, String name, String content, Boolean hasAll, Boolean hasBlind,
-                     Boolean hasQuestion, Category parent, List<Category> children, Integer displayOrder) {
+    private Category(
+        Long id,
+        CommunityCategoryCode code,
+        CommunityCategoryGroup categoryGroup,
+        String name,
+        String content,
+        Boolean hasAll,
+        Boolean hasBlind,
+        Boolean hasQuestion,
+        Boolean isActive,
+        Category parent,
+        List<Category> children,
+        Integer displayOrder
+    ) {
         this.id = id;
+        this.code = code;
+        this.categoryGroup = categoryGroup;
         this.name = name;
         this.content = content;
         this.hasAll = hasAll;
         this.hasBlind = hasBlind;
         this.hasQuestion = hasQuestion;
+        this.isActive = isActive == null || isActive;
         this.parent = parent;
-        this.children = children;
+        this.children = children == null ? new ArrayList<>() : children;
         this.displayOrder = displayOrder;
     }
 }

--- a/src/main/java/org/sopt/makers/internal/community/domain/category/Category.java
+++ b/src/main/java/org/sopt/makers/internal/community/domain/category/Category.java
@@ -19,11 +19,11 @@ public class Category {
     private Long id;
 
     @Enumerated(EnumType.STRING)
-    @Column(unique = true)
+    @Column(unique = true, nullable = false)
     private CommunityCategoryCode code;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "category_group")
+    @Column(name = "category_group", nullable = false)
     private CommunityCategoryGroup categoryGroup;
 
     @Column

--- a/src/main/java/org/sopt/makers/internal/community/domain/enums/CommunityCategoryCode.java
+++ b/src/main/java/org/sopt/makers/internal/community/domain/enums/CommunityCategoryCode.java
@@ -1,0 +1,20 @@
+package org.sopt.makers.internal.community.domain.enums;
+
+public enum CommunityCategoryCode {
+	FREE,
+
+	PROMOTION,
+	PROMOTION_EVENT,
+	PROMOTION_PROJECT,
+	PROMOTION_RECRUIT,
+	PROMOTION_ETC,
+
+	SOPTICLE,
+	SOPTICLE_PLAN,
+	SOPTICLE_DESIGN,
+	SOPTICLE_SERVER,
+	SOPTICLE_WEB,
+	SOPTICLE_IOS,
+	SOPTICLE_ANDROID,
+	SOPTICLE_ETC
+}

--- a/src/main/java/org/sopt/makers/internal/community/domain/enums/CommunityCategoryGroup.java
+++ b/src/main/java/org/sopt/makers/internal/community/domain/enums/CommunityCategoryGroup.java
@@ -1,0 +1,8 @@
+package org.sopt.makers.internal.community.domain.enums;
+
+// DB category row의 상위 분류
+public enum CommunityCategoryGroup {
+	FREE,
+	PROMOTION,
+	SOPTICLE
+}

--- a/src/main/java/org/sopt/makers/internal/community/domain/enums/CommunityPostListCategory.java
+++ b/src/main/java/org/sopt/makers/internal/community/domain/enums/CommunityPostListCategory.java
@@ -1,0 +1,8 @@
+package org.sopt.makers.internal.community.domain.enums;
+
+// API 요청 모델
+public enum CommunityPostListCategory {
+	FREE,
+	PROMOTION,
+	SOPTICLE
+}

--- a/src/main/java/org/sopt/makers/internal/community/domain/enums/CommunityPostListFilter.java
+++ b/src/main/java/org/sopt/makers/internal/community/domain/enums/CommunityPostListFilter.java
@@ -1,0 +1,21 @@
+package org.sopt.makers.internal.community.domain.enums;
+
+public enum CommunityPostListFilter {
+	ALL,
+
+	// PROMOTION
+	EVENT,
+	PROJECT,
+	RECRUIT,
+
+	// SOPTICLE
+	PLAN,
+	DESIGN,
+	SERVER,
+	WEB,
+	IOS,
+	ANDROID,
+
+	// SHARED
+	ETC
+}

--- a/src/main/java/org/sopt/makers/internal/community/domain/enums/CommunityPostSourceType.java
+++ b/src/main/java/org/sopt/makers/internal/community/domain/enums/CommunityPostSourceType.java
@@ -1,0 +1,7 @@
+package org.sopt.makers.internal.community.domain.enums;
+
+// 데이터 출처/행동 분기용 메타데이터
+public enum CommunityPostSourceType {
+	COMMUNITY,
+	MEETING
+}

--- a/src/main/java/org/sopt/makers/internal/community/domain/enums/CommunityPostTag.java
+++ b/src/main/java/org/sopt/makers/internal/community/domain/enums/CommunityPostTag.java
@@ -1,0 +1,22 @@
+package org.sopt.makers.internal.community.domain.enums;
+
+// 화면 표시용 카테고리 태그
+public enum CommunityPostTag {
+	FREE("자유"),
+	MEETING("모임"),
+	EVENT("행사"),
+	PROJECT("프로젝트"),
+	RECRUIT("채용"),
+	PROMOTION("홍보"),
+	SOPTICLE("솝티클");
+
+	private final String label;
+
+	CommunityPostTag(String label) {
+		this.label = label;
+	}
+
+	public String getLabel() {
+		return label;
+	}
+}

--- a/src/main/java/org/sopt/makers/internal/community/dto/CategoryVo.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/CategoryVo.java
@@ -1,11 +1,15 @@
 package org.sopt.makers.internal.community.dto;
 
+import org.sopt.makers.internal.community.domain.enums.CommunityCategoryCode;
+import org.sopt.makers.internal.community.domain.enums.CommunityCategoryGroup;
 import org.springframework.aot.hint.annotation.Reflective;
 
 @Reflective
 public record CategoryVo(
-        Long id,
-        String name,
-        Long parentId,
-        String parentCategoryName
-) {}
+	CommunityCategoryGroup categoryGroup,
+	CommunityCategoryCode code,
+	String name,
+	CommunityCategoryCode parentCode,
+	String parentCategoryName
+) {
+}

--- a/src/main/java/org/sopt/makers/internal/community/dto/CommunityDbCursor.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/CommunityDbCursor.java
@@ -1,0 +1,9 @@
+package org.sopt.makers.internal.community.dto;
+
+import java.time.LocalDateTime;
+
+public record CommunityDbCursor(
+	LocalDateTime createdAt,
+	Long postId
+) {
+}

--- a/src/main/java/org/sopt/makers/internal/community/dto/CommunityFeedCursor.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/CommunityFeedCursor.java
@@ -1,0 +1,18 @@
+package org.sopt.makers.internal.community.dto;
+
+import java.time.LocalDateTime;
+
+public record CommunityFeedCursor(
+	LocalDateTime snapshotTime,
+	CommunityDbCursor community,
+	Integer meetingConsumedCount
+) {
+
+	public static CommunityFeedCursor initial(LocalDateTime snapshotTime) {
+		return new CommunityFeedCursor(snapshotTime, null, 0);
+	}
+
+	public int safeMeetingConsumedCount() {
+		return meetingConsumedCount == null ? 0 : meetingConsumedCount;
+	}
+}

--- a/src/main/java/org/sopt/makers/internal/community/dto/CommunityFeedCursor.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/CommunityFeedCursor.java
@@ -7,6 +7,17 @@ public record CommunityFeedCursor(
 	CommunityDbCursor community,
 	Integer meetingConsumedCount
 ) {
+	public CommunityFeedCursor {
+		if (snapshotTime == null) {
+			throw new IllegalArgumentException("snapshot time must not be null");
+		}
+		if (meetingConsumedCount != null && meetingConsumedCount < 0) {
+			throw new IllegalArgumentException("meeting consumed count must not be negative");
+		}
+		if (community != null && (community.createdAt() == null || community.postId() == null)) {
+			throw new IllegalArgumentException("community must include both createdAt and postId");
+		}
+	}
 
 	public static CommunityFeedCursor initial(LocalDateTime snapshotTime) {
 		return new CommunityFeedCursor(snapshotTime, null, 0);

--- a/src/main/java/org/sopt/makers/internal/community/dto/CommunityPostVo.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/CommunityPostVo.java
@@ -2,6 +2,8 @@ package org.sopt.makers.internal.community.dto;
 
 import java.util.List;
 
+import org.sopt.makers.internal.community.domain.enums.CommunityCategoryCode;
+import org.sopt.makers.internal.community.domain.enums.CommunityCategoryGroup;
 import org.springframework.aot.hint.annotation.Reflective;
 import org.sopt.makers.internal.vote.dto.response.VoteResponse;
 
@@ -10,16 +12,17 @@ import java.time.LocalDateTime;
 @Reflective
 public record CommunityPostVo(
         Long id,
-        Long categoryId,
+        CommunityCategoryGroup categoryGroup,
+        CommunityCategoryCode categoryCode,
         String title,
         String content,
         Integer hits,
         List<String> images,
-        Boolean isQuestion,
         Boolean isBlindWriter,
         String sopticleUrl,
         Boolean isReported,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
         VoteResponse vote
-) {}
+) {
+}

--- a/src/main/java/org/sopt/makers/internal/community/dto/request/PostSaveRequest.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/request/PostSaveRequest.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
+import org.sopt.makers.internal.community.domain.enums.CommunityCategoryCode;
 import org.sopt.makers.internal.vote.dto.request.VoteRequest;
 
 import java.util.List;
@@ -13,18 +14,14 @@ import java.util.List;
 @Builder
 public record PostSaveRequest(
         @Schema(required = true)
-        @NotNull(message = "카테고리 id는 필수 입력값입니다.")
-        Long categoryId,
+        @NotNull(message = "카테고리 코드는 필수 입력값입니다.")
+		CommunityCategoryCode categoryCode,
 
         String title,
 
         @Schema(required = true)
         @NotBlank(message = "게시글 본문은 공백일 수 없습니다.")
         String content,
-
-        @Schema(required = true)
-        @NotNull(message = "질문글 여부 필드는 필수 입력값입니다.")
-        Boolean isQuestion,
 
         @Schema(required = true)
         @NotNull(message = "익명글 여부 필드는 필수 입력값입니다.")

--- a/src/main/java/org/sopt/makers/internal/community/dto/request/PostUpdateRequest.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/request/PostUpdateRequest.java
@@ -9,19 +9,19 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 public record PostUpdateRequest(
-        @Schema(required = true)
-        @NotNull
-        Long postId,
+	@Schema(required = true)
+	@NotNull
+	Long postId,
 
-        @Schema(required = true)
-        @NotNull
-		CommunityCategoryCode categoryCode,
+	@Schema(required = true)
+	@NotNull
+	CommunityCategoryCode categoryCode,
 
-        String title,
-        String content,
-        Boolean isBlindWriter,
-        List<String> images,
-        String link,
+	String title,
+	String content,
+	Boolean isBlindWriter,
+	List<String> images,
+	String link,
 
-        MentionRequest mention
+	MentionRequest mention
 ) { }

--- a/src/main/java/org/sopt/makers/internal/community/dto/request/PostUpdateRequest.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/request/PostUpdateRequest.java
@@ -2,6 +2,8 @@ package org.sopt.makers.internal.community.dto.request;
 
 import java.util.List;
 
+import org.sopt.makers.internal.community.domain.enums.CommunityCategoryCode;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import jakarta.validation.constraints.NotNull;
@@ -13,11 +15,10 @@ public record PostUpdateRequest(
 
         @Schema(required = true)
         @NotNull
-        Long categoryId,
+		CommunityCategoryCode categoryCode,
 
         String title,
         String content,
-        Boolean isQuestion,
         Boolean isBlindWriter,
         List<String> images,
         String link,

--- a/src/main/java/org/sopt/makers/internal/community/dto/response/CommunityCategoryResponse.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/response/CommunityCategoryResponse.java
@@ -1,45 +1,64 @@
 package org.sopt.makers.internal.community.dto.response;
 
-import java.util.Comparator;
-import org.sopt.makers.internal.community.domain.category.Category;
-
 import java.util.List;
+import org.sopt.makers.internal.community.domain.category.Category;
+import org.sopt.makers.internal.community.domain.enums.CommunityPostListFilter;
 
 public record CommunityCategoryResponse(
-
-        Long id,
-
-        String name,
-
-        String content,
-
-        Boolean hasAll,
-
-        Boolean hasBlind,
-
-        Boolean hasQuestion,
-
-        List<CommunityCategoryResponse> children
+    String code,
+    String name,
+    String content,
+    Boolean hasBlind,
+    List<CommunityCategoryResponse> children
 ) {
 
-    public static CommunityCategoryResponse of(Category category, List<CommunityCategoryResponse> children) {
+    public static CommunityCategoryResponse fromRoot(Category category) {
+        List<CommunityCategoryResponse> children = switch (category.getCode()) {
+            case FREE -> List.of();
+            case PROMOTION -> promotionFilters();
+            case SOPTICLE -> sopticleFilters();
+            default -> List.of();
+        };
+
         return new CommunityCategoryResponse(
-                category.getId(),
-                category.getName(),
-                category.getContent(),
-                category.getHasAll(),
-                category.getHasBlind(),
-                category.getHasQuestion(),
-                children
+            category.getCode().name(),
+            category.getName(),
+            category.getContent(),
+            category.getHasBlind(),
+            children
         );
     }
 
-    public static CommunityCategoryResponse from(Category category) {
-        List<CommunityCategoryResponse> children = category.getChildren().stream()
-                .sorted(Comparator.comparing(Category::getDisplayOrder))
-                .map(CommunityCategoryResponse::from)
-                .toList();
+    private static List<CommunityCategoryResponse> promotionFilters() {
+        return List.of(
+            filter(CommunityPostListFilter.ALL, "전체"),
+            filter(CommunityPostListFilter.EVENT, "행사"),
+            filter(CommunityPostListFilter.PROJECT, "프로젝트"),
+            filter(CommunityPostListFilter.RECRUIT, "채용"),
+            filter(CommunityPostListFilter.ETC, "기타")
+        );
+    }
 
-        return CommunityCategoryResponse.of(category, children);
+    private static List<CommunityCategoryResponse> sopticleFilters() {
+        return List.of(
+            filter(CommunityPostListFilter.ALL, "전체"),
+            filter(CommunityPostListFilter.PLAN, "기획"),
+            filter(CommunityPostListFilter.DESIGN, "디자인"),
+            filter(CommunityPostListFilter.SERVER, "서버"),
+            filter(CommunityPostListFilter.WEB, "웹"),
+            filter(CommunityPostListFilter.IOS, "iOS"),
+            filter(CommunityPostListFilter.ANDROID, "Android"),
+            filter(CommunityPostListFilter.ETC, "기타")
+        );
+    }
+
+    private static CommunityCategoryResponse filter(CommunityPostListFilter filter, String name) {
+        return new CommunityCategoryResponse(
+            filter.name(),
+            name,
+            null,
+            false,
+            List.of()
+        );
     }
 }

--- a/src/main/java/org/sopt/makers/internal/community/dto/response/PopularPostResponse.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/response/PopularPostResponse.java
@@ -1,12 +1,16 @@
 package org.sopt.makers.internal.community.dto.response;
 
+import org.sopt.makers.internal.community.domain.enums.CommunityPostTag;
 import org.sopt.makers.internal.member.dto.response.MemberNameAndProfileImageResponse;
 
 public record PopularPostResponse(
-        Long id,
-        String category,
-        String title,
-        MemberNameAndProfileImageResponse member,
-        Integer hits
+	Long id,
+	String title,
+	MemberNameAndProfileImageResponse member,
+	Integer hits,
+	int likeCount,
+	int commentCount,
+	CommunityPostTag categoryTag,
+	String categoryTagLabel
 ) {
 }

--- a/src/main/java/org/sopt/makers/internal/community/dto/response/PostAllResponse.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/response/PostAllResponse.java
@@ -2,8 +2,12 @@ package org.sopt.makers.internal.community.dto.response;
 
 import java.util.List;
 
+import org.sopt.makers.internal.community.domain.enums.CommunityPostListCategory;
+
 public record PostAllResponse(
-        Long categoryId,
-        Boolean hasNext,
-        List<PostResponse> posts
-) {}
+	CommunityPostListCategory category,
+	Boolean hasNext,
+	String nextCursor,
+	List<PostResponse> posts
+) {
+}

--- a/src/main/java/org/sopt/makers/internal/community/dto/response/PostResponse.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/response/PostResponse.java
@@ -1,6 +1,11 @@
 package org.sopt.makers.internal.community.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+
+import org.sopt.makers.internal.community.domain.enums.CommunityCategoryCode;
+import org.sopt.makers.internal.community.domain.enums.CommunityCategoryGroup;
+import org.sopt.makers.internal.community.domain.enums.CommunityPostSourceType;
+import org.sopt.makers.internal.community.domain.enums.CommunityPostTag;
 import org.sopt.makers.internal.community.dto.AnonymousProfileVo;
 import org.sopt.makers.internal.community.dto.MemberVo;
 import org.sopt.makers.internal.vote.dto.response.VoteResponse;
@@ -10,19 +15,21 @@ import java.util.List;
 public record PostResponse(
         @Schema(required = true)
         Long id,
+        CommunityPostSourceType sourceType,
         MemberVo member,
         Long writerId,
         Boolean isMine,
         Boolean isLiked,
         Integer likes,
-        Long categoryId,
+        CommunityCategoryGroup categoryGroup,
+        CommunityCategoryCode categoryCode,
         String categoryName,
+        List<CommunityPostTag> tags,
         String title,
         String content,
         Integer hits,
         Integer commentCount,
         List<String> images,
-        Boolean isQuestion,
         Boolean isBlindWriter,
         String sopticleUrl,
         AnonymousProfileVo anonymousProfile,

--- a/src/main/java/org/sopt/makers/internal/community/dto/response/PostSaveResponse.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/response/PostSaveResponse.java
@@ -5,17 +5,17 @@ import java.util.List;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
-import org.sopt.makers.internal.vote.dto.response.VoteResponse;
+
+import org.sopt.makers.internal.community.domain.enums.CommunityCategoryCode;
 
 public record PostSaveResponse(
         @Schema(required = true)
         Long id,
-        Long categoryId,
+        CommunityCategoryCode code,
         String title,
         String content,
         Integer hits,
         List<String> images,
-        Boolean isQuestion,
         Boolean isBlindWriter,
         LocalDateTime createdAt
 ) {}

--- a/src/main/java/org/sopt/makers/internal/community/dto/response/PostUpdateResponse.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/response/PostUpdateResponse.java
@@ -6,15 +6,16 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+import org.sopt.makers.internal.community.domain.enums.CommunityCategoryCode;
+
 public record PostUpdateResponse(
         @Schema(required = true)
         Long id,
-        Long categoryId,
+        CommunityCategoryCode code,
         String title,
         String content,
         Integer hits,
         List<String> images,
-        Boolean isQuestion,
         Boolean isBlindWriter,
         LocalDateTime createdAt,
         LocalDateTime updatedAt

--- a/src/main/java/org/sopt/makers/internal/community/dto/response/RecentPostResponse.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/response/RecentPostResponse.java
@@ -1,15 +1,16 @@
 package org.sopt.makers.internal.community.dto.response;
 
+import org.sopt.makers.internal.community.domain.enums.CommunityPostTag;
+
 public record RecentPostResponse(
-        Long id,
-        String title,
-        String content,
-        String createdAt,
-        int likeCount,
-        int commentCount,
-        Long categoryId,
-        String categoryName,
-        Integer totalVoteCount,
-        Boolean isAnswered
+	Long id,
+	String title,
+	String content,
+	String createdAt,
+	int likeCount,
+	int commentCount,
+	CommunityPostTag categoryTag,
+	String categoryTagLabel,
+	Integer totalVoteCount
 ) {
 }

--- a/src/main/java/org/sopt/makers/internal/community/mapper/CommunityResponseMapper.java
+++ b/src/main/java/org/sopt/makers/internal/community/mapper/CommunityResponseMapper.java
@@ -216,9 +216,9 @@ public class CommunityResponseMapper {
             isMine,
             isLiked,
             likes,
-            category.categoryGroup(),
-            category.code(),
-            category.name(),
+            category == null ? null : category.categoryGroup(),
+            category == null ? null : category.code(),
+            category == null ? null : category.name(),
             List.of(),
             post.title(),
             post.content(),
@@ -409,6 +409,9 @@ public class CommunityResponseMapper {
                 anonymousProfile.getProfileImg().getImageUrl()
             );
         } else {
+            if (userDetails == null) {
+                throw new IllegalStateException("user details is required for non-blind post");
+            }
             memberResponse = MemberNameAndProfileImageResponse.from(userDetails);
         }
 

--- a/src/main/java/org/sopt/makers/internal/community/mapper/CommunityResponseMapper.java
+++ b/src/main/java/org/sopt/makers/internal/community/mapper/CommunityResponseMapper.java
@@ -10,6 +10,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import lombok.val;
+
+import org.sopt.makers.internal.community.domain.enums.CommunityCategoryCode;
+import org.sopt.makers.internal.community.domain.enums.CommunityCategoryGroup;
+import org.sopt.makers.internal.community.domain.enums.CommunityPostSourceType;
+import org.sopt.makers.internal.community.domain.enums.CommunityPostTag;
 import org.sopt.makers.internal.community.utils.MentionCleaner;
 import org.sopt.makers.internal.community.domain.CommunityPost;
 import org.sopt.makers.internal.community.domain.anonymous.AnonymousProfile;
@@ -87,71 +92,145 @@ public class CommunityResponseMapper {
     }
 
     public PostUpdateResponse toPostUpdateResponse(CommunityPost post) {
-        return new PostUpdateResponse(post.getId(), post.getCategoryId(), post.getTitle(),
-                post.getContent(), post.getHits(), post.getImages(), post.getIsQuestion(),
+        return new PostUpdateResponse(post.getId(), post.getCategory().getCode(), post.getTitle(),
+                post.getContent(), post.getHits(), post.getImages(),
                 post.getIsBlindWriter(), post.getCreatedAt(), post.getUpdatedAt());
     }
 
     public PostSaveResponse toPostSaveResponse(CommunityPost post) {
-        return new PostSaveResponse(post.getId(), post.getCategoryId(), post.getTitle(),
-                post.getContent(), post.getHits(), post.getImages(), post.getIsQuestion(),
+        return new PostSaveResponse(post.getId(), post.getCategory().getCode(), post.getTitle(),
+                post.getContent(), post.getHits(), post.getImages(),
                 post.getIsBlindWriter(), post.getCreatedAt());
     }
 
-    public PostDetailResponse toPostDetailReponse(PostDetailData dto, Long viewerId, Boolean isLiked, Integer likes, AnonymousProfile anonymousProfile) {
+    public PostDetailResponse toPostDetailReponse(
+        PostDetailData dto,
+        Long viewerId,
+        Boolean isLiked,
+        Integer likes,
+        AnonymousProfile anonymousProfile
+    ) {
         val postEntity = dto.post();
         val authorDetails = dto.userDetails();
         val memberVo = postEntity.getIsBlindWriter()
-                ? null
-                : MemberVo.of(authorDetails, dto.authorCareer());
+            ? null
+            : MemberVo.of(authorDetails, dto.authorCareer());
 
         val isMine = Objects.equals(authorDetails.userId(), viewerId);
 
         val anonymousProfileVo = postEntity.getIsBlindWriter() && anonymousProfile != null
-                ? toAnonymousProfileVo(anonymousProfile)
-                : null;
+            ? toAnonymousProfileVo(anonymousProfile)
+            : null;
 
-        val postVo = toPostVo(postEntity, dto.vote());
+        val postVo = toPostVo(postEntity, dto.category(), dto.vote());
         val categoryVo = toCategoryResponse(dto.category());
 
         return new PostDetailResponse(memberVo, postVo, categoryVo, isMine, isLiked, likes, anonymousProfileVo);
     }
 
     public CategoryVo toCategoryResponse(Category category) {
-        if(category == null) return null;
-        val parentCategoryName = category.getParent() == null ? null : category.getParent().getName();
-        val parentId = category.getParent() == null ? null : category.getParent().getId();
-        return new CategoryVo(category.getId(), category.getName(), parentId, parentCategoryName);
+        if (category == null) {
+            return null;
+        }
+
+        CommunityCategoryCode parentCode = category.getParent() == null
+            ? null
+            : category.getParent().getCode();
+
+        String parentCategoryName = category.getParent() == null
+            ? null
+            : category.getParent().getName();
+
+        return new CategoryVo(
+            category.getCategoryGroup(),
+            category.getCode(),
+            category.getName(),
+            parentCode,
+            parentCategoryName
+        );
+    }
+
+    public CommunityPostVo toPostVo(
+        CommunityPost post,
+        Category category,
+        VoteResponse voteResponse
+    ) {
+        return new CommunityPostVo(
+            post.getId(),
+            category.getCategoryGroup(),
+            category.getCode(),
+            post.getTitle(),
+            post.getContent(),
+            post.getHits(),
+            post.getImages(),
+            post.getIsBlindWriter(),
+            post.getSopticleUrl(),
+            post.getIsReported(),
+            post.getCreatedAt(),
+            post.getUpdatedAt(),
+            voteResponse
+        );
     }
 
     public CommunityPostVo toPostVo(CommunityPost post, VoteResponse voteResponse) {
-        return new CommunityPostVo(post.getId(), post.getCategoryId(), post.getTitle(), post.getContent(), post.getHits(),
-                post.getImages(), post.getIsQuestion(), post.getIsBlindWriter(), post.getSopticleUrl(), post.getIsReported(), post.getCreatedAt(), post.getUpdatedAt(),
-                voteResponse);
+        return toPostVo(post, post.getCategory(), voteResponse);
     }
 
-    public PostResponse toPostResponse (CommunityPostMemberVo dao, List<CommentInfo> commentInfos, Long memberId, AnonymousProfile anonymousProfile, Boolean isLiked, Integer likes, Map<Long, Boolean> commentLikedMap, Map<Long, Integer> commentLikeCountMap) {
+    public PostResponse toPostResponse(
+        CommunityPostMemberVo dao,
+        List<CommentInfo> commentInfos,
+        Long memberId,
+        AnonymousProfile anonymousProfile,
+        Boolean isLiked,
+        Integer likes,
+        Map<Long, Boolean> commentLikedMap,
+        Map<Long, Integer> commentLikeCountMap
+    ) {
         val post = dao.post();
         val category = dao.category();
         val member = dao.post().isBlindWriter() ? null : dao.member();
         val writerId = dao.post().isBlindWriter() ? null : dao.member().id();
         val isMine = Objects.equals(dao.member().id(), memberId);
+
         val comments = commentInfos.stream()
-                .map(info -> {
-                    Long commentId = info.commentDao().comment().getId();
-                    Boolean commentIsLiked = commentLikedMap.getOrDefault(commentId, false);
-                    Integer commentLikeCount = commentLikeCountMap.getOrDefault(commentId, 0);
-                    return toCommentResponse(info, memberId, commentIsLiked, commentLikeCount);
-                })
-                .collect(toList());
-        val anonymousProfileVo = dao.post().isBlindWriter() && anonymousProfile != null ? toAnonymousProfileVo(anonymousProfile) : null;
+            .map(info -> {
+                Long commentId = info.commentDao().comment().getId();
+                Boolean commentIsLiked = commentLikedMap.getOrDefault(commentId, false);
+                Integer commentLikeCount = commentLikeCountMap.getOrDefault(commentId, 0);
+                return toCommentResponse(info, memberId, commentIsLiked, commentLikeCount);
+            })
+            .collect(toList());
+
+        val anonymousProfileVo = dao.post().isBlindWriter() && anonymousProfile != null
+            ? toAnonymousProfileVo(anonymousProfile)
+            : null;
+
         val createdAt = getRelativeTime(dao.post().createdAt());
 
         return new PostResponse(
-                post.id(), member, writerId, isMine, isLiked, likes, post.categoryId(),
-                category.name(), post.title(), post.content(), post.hits(),
-                (int) comments.stream().filter(c -> !c.isDeleted()).count(), post.images(), post.isQuestion(), post.isBlindWriter(),
-                post.sopticleUrl(), anonymousProfileVo, createdAt, comments, dao.post().vote(), null
+            post.id(),
+            CommunityPostSourceType.COMMUNITY,
+            member,
+            writerId,
+            isMine,
+            isLiked,
+            likes,
+            category.categoryGroup(),
+            category.code(),
+            category.name(),
+            List.of(),
+            post.title(),
+            post.content(),
+            post.hits(),
+            (int) comments.stream().filter(comment -> !comment.isDeleted()).count(),
+            post.images(),
+            post.isBlindWriter(),
+            post.sopticleUrl(),
+            anonymousProfileVo,
+            createdAt,
+            comments,
+            dao.post().vote(),
+            null
         );
     }
 
@@ -159,41 +238,43 @@ public class CommunityResponseMapper {
         val crewUser = crewPost.user();
 
         val soptActivityVo = new SoptActivityVo(
-                crewUser.partInfo().generation(),
-                crewUser.partInfo().part(),
-                null
+            crewUser.partInfo().generation(),
+            crewUser.partInfo().part(),
+            null
         );
 
         val memberVo = new MemberVo(
-                crewUser.id(),
-                crewUser.name(),
-                crewUser.profileImage(),
-                soptActivityVo,
-                null
+            crewUser.id(),
+            crewUser.name(),
+            crewUser.profileImage(),
+            soptActivityVo,
+            null
         );
 
         return new PostResponse(
-                crewPost.id(),
-                memberVo,
-                crewUser.id(),
-                Objects.equals(crewUser.orgId(), viewerId),
-                crewPost.isLiked(),
-                crewPost.likeCount(),
-                24L,
-                "모임",
-                crewPost.title(),
-                crewPost.contents(),
-                crewPost.viewCount(),
-                crewPost.commentCount(),
-                crewPost.images(),
-                false,
-                false,
-                null,
-                null,
-                getRelativeTime(crewPost.createdDate()),
-                Collections.emptyList(),
-                null, // vote
-                crewPost.meetingId()
+            crewPost.id(),
+            CommunityPostSourceType.MEETING,
+            memberVo,
+            crewUser.id(),
+            Objects.equals(crewUser.orgId(), viewerId),
+            crewPost.isLiked(),
+            crewPost.likeCount(),
+            CommunityCategoryGroup.FREE,
+            CommunityCategoryCode.FREE,
+            "자유",
+            List.of(CommunityPostTag.MEETING),
+            crewPost.title(),
+            crewPost.contents(),
+            crewPost.viewCount(),
+            crewPost.commentCount(),
+            crewPost.images(),
+            false,
+            null,
+            null,
+            getRelativeTime(crewPost.createdDate()),
+            Collections.emptyList(),
+            null,
+            crewPost.meetingId()
         );
     }
 
@@ -209,18 +290,39 @@ public class CommunityResponseMapper {
         );
     }
 
-    public RecentPostResponse toRecentPostResponse(CommunityPost post, int likeCount, int commentCount, Long categoryId, String categoryName, Integer totalVoteCount) {
+    public RecentPostResponse toRecentPostResponse(
+        CommunityPost post,
+        int likeCount,
+        int commentCount,
+        CommunityPostTag categoryTag,
+        Integer totalVoteCount
+    ) {
         return new RecentPostResponse(
-                post.getId(),
-                post.getTitle(),
-                post.getContent(),
-                getRelativeTime(post.getCreatedAt()),
-                likeCount,
-                commentCount,
-                categoryId,
-                categoryName,
-                totalVoteCount,
-                commentCount > 0
+            post.getId(),
+            post.getTitle(),
+            post.getContent(),
+            getRelativeTime(post.getCreatedAt()),
+            likeCount,
+            commentCount,
+            categoryTag,
+            categoryTag == null ? null : categoryTag.getLabel(),
+            totalVoteCount
+        );
+    }
+
+    public RecentPostResponse toRecentPostResponse(CrewPost crewPost) {
+        CommunityPostTag categoryTag = CommunityPostTag.MEETING;
+
+        return new RecentPostResponse(
+            crewPost.id(),
+            crewPost.title(),
+            crewPost.contents(),
+            getRelativeTime(crewPost.createdDate()),
+            crewPost.likeCount(),
+            crewPost.commentCount(),
+            categoryTag,
+            categoryTag.getLabel(),
+            null
         );
     }
 
@@ -262,20 +364,57 @@ public class CommunityResponseMapper {
         }
     }
 
-    public PopularPostResponse toPopularPostResponse(CommunityPost post, AnonymousProfile anonymousProfile, InternalUserDetails userDetails, String categoryName) {
+    public PopularPostResponse toPopularPostResponse(
+        CommunityPost post,
+        AnonymousProfile anonymousProfile,
+        InternalUserDetails userDetails,
+        int likeCount,
+        int commentCount,
+        CommunityPostTag categoryTag
+    ) {
         MemberNameAndProfileImageResponse memberResponse;
+
         if (Boolean.TRUE.equals(post.getIsBlindWriter()) && anonymousProfile != null) {
             memberResponse = new MemberNameAndProfileImageResponse(
-                    anonymousProfile.getId(),
-                    anonymousProfile.getNickname().getNickname(),
-                    anonymousProfile.getProfileImg().getImageUrl()
+                anonymousProfile.getId(),
+                anonymousProfile.getNickname().getNickname(),
+                anonymousProfile.getProfileImg().getImageUrl()
             );
         } else {
             memberResponse = MemberNameAndProfileImageResponse.from(userDetails);
         }
 
         return new PopularPostResponse(
-                post.getId(), categoryName, post.getTitle(), memberResponse, post.getHits()
+            post.getId(),
+            post.getTitle(),
+            memberResponse,
+            post.getHits(),
+            likeCount,
+            commentCount,
+            categoryTag,
+            categoryTag == null ? null : categoryTag.getLabel()
+        );
+    }
+
+    public PopularPostResponse toPopularPostResponse(CrewPost crewPost) {
+        CrewPost.CrewUser crewUser = crewPost.user();
+        CommunityPostTag categoryTag = CommunityPostTag.MEETING;
+
+        MemberNameAndProfileImageResponse memberResponse = new MemberNameAndProfileImageResponse(
+            crewUser.id(),
+            crewUser.name(),
+            crewUser.profileImage()
+        );
+
+        return new PopularPostResponse(
+            crewPost.id(),
+            crewPost.title(),
+            memberResponse,
+            crewPost.viewCount(),       // hits 의미: 조회수
+            crewPost.likeCount(),
+            crewPost.commentCount(),
+            categoryTag,
+            categoryTag.getLabel()
         );
     }
 

--- a/src/main/java/org/sopt/makers/internal/community/mapper/CommunityResponseMapper.java
+++ b/src/main/java/org/sopt/makers/internal/community/mapper/CommunityResponseMapper.java
@@ -155,10 +155,11 @@ public class CommunityResponseMapper {
         Category category,
         VoteResponse voteResponse
     ) {
+        Category resolvedCategory = category != null ? category : post.getCategory();
         return new CommunityPostVo(
             post.getId(),
-            category.getCategoryGroup(),
-            category.getCode(),
+            resolvedCategory == null ? null : resolvedCategory.getCategoryGroup(),
+            resolvedCategory == null ? null : resolvedCategory.getCode(),
             post.getTitle(),
             post.getContent(),
             post.getHits(),
@@ -237,6 +238,8 @@ public class CommunityResponseMapper {
     public PostResponse toPostResponse(CrewPost crewPost, Long viewerId) {
         val crewUser = crewPost.user();
 
+        Long writerId = crewUser.orgId();
+
         val soptActivityVo = new SoptActivityVo(
             crewUser.partInfo().generation(),
             crewUser.partInfo().part(),
@@ -244,7 +247,7 @@ public class CommunityResponseMapper {
         );
 
         val memberVo = new MemberVo(
-            crewUser.id(),
+            writerId,
             crewUser.name(),
             crewUser.profileImage(),
             soptActivityVo,
@@ -255,8 +258,8 @@ public class CommunityResponseMapper {
             crewPost.id(),
             CommunityPostSourceType.MEETING,
             memberVo,
-            crewUser.id(),
-            Objects.equals(crewUser.orgId(), viewerId),
+            writerId,
+            Objects.equals(writerId, viewerId),
             crewPost.isLiked(),
             crewPost.likeCount(),
             CommunityCategoryGroup.FREE,
@@ -330,38 +333,59 @@ public class CommunityResponseMapper {
         return new AnonymousProfileVo(anonymousProfile.getNickname().getNickname(), anonymousProfile.getProfileImg().getImageUrl());
     }
 
-    public InternalPopularPostResponse toInternalPopularPostResponse(CommunityPost post, AnonymousProfile anonymousProfile, InternalUserDetails userDetails, String categoryName, int rank, String baseUrl) {
-        if (Boolean.TRUE.equals(post.getIsBlindWriter()) && anonymousProfile != null) {
+    public InternalPopularPostResponse toInternalPopularPostResponse(
+        CommunityPost post,
+        AnonymousProfile anonymousProfile,
+        InternalUserDetails userDetails,
+        String categoryName,
+        int rank,
+        String baseUrl
+    ) {
+        if (Boolean.TRUE.equals(post.getIsBlindWriter())) {
+            if (anonymousProfile == null) {
+                throw new IllegalStateException("anonymous profile is required for blind post");
+            }
+
             return InternalPopularPostResponse.builder()
-                    .id(post.getId())
-                    .userId(null)
-                    .profileImage(anonymousProfile.getProfileImg().getImageUrl())
-                    .name(anonymousProfile.getNickname().getNickname())
-                    .generationAndPart("")
-                    .rank(rank)
-                    .category(categoryName)
-                    .title(post.getTitle())
-                    .content(MentionCleaner.removeMentionIds(post.getContent()))
-                    .webLink(baseUrl + post.getId())
-                    .build();
-        } else {
-            SoptActivity lastActivity = userDetails.soptActivities().stream()
-                    .max(Comparator.comparing(SoptActivity::generation))
-                    .orElse(null);
-            String generationAndPart = String.format("%d기 %s", Objects.requireNonNull(lastActivity).generation(), lastActivity.part());
-            return InternalPopularPostResponse.builder()
-                    .id(post.getId())
-                    .userId(userDetails.userId())
-                    .profileImage(userDetails.profileImage())
-                    .name(userDetails.name())
-                    .generationAndPart(generationAndPart)
-                    .rank(rank)
-                    .category(categoryName)
-                    .title(post.getTitle())
-                    .content(MentionCleaner.removeMentionIds(post.getContent()))
-                    .webLink(baseUrl + post.getId())
-                    .build();
+                .id(post.getId())
+                .userId(null)
+                .profileImage(anonymousProfile.getProfileImg().getImageUrl())
+                .name(anonymousProfile.getNickname().getNickname())
+                .generationAndPart("")
+                .rank(rank)
+                .category(categoryName)
+                .title(post.getTitle())
+                .content(MentionCleaner.removeMentionIds(post.getContent()))
+                .webLink(baseUrl + post.getId())
+                .build();
         }
+
+        if (userDetails == null) {
+            throw new IllegalStateException("user details is required for non-blind post");
+        }
+
+        SoptActivity lastActivity = userDetails.soptActivities() == null
+            ? null
+            : userDetails.soptActivities().stream()
+              .max(Comparator.comparing(SoptActivity::generation))
+              .orElse(null);
+
+        String generationAndPart = lastActivity == null
+            ? ""
+            : String.format("%d기 %s", lastActivity.generation(), lastActivity.part());
+
+        return InternalPopularPostResponse.builder()
+            .id(post.getId())
+            .userId(userDetails.userId())
+            .profileImage(userDetails.profileImage())
+            .name(userDetails.name())
+            .generationAndPart(generationAndPart)
+            .rank(rank)
+            .category(categoryName)
+            .title(post.getTitle())
+            .content(MentionCleaner.removeMentionIds(post.getContent()))
+            .webLink(baseUrl + post.getId())
+            .build();
     }
 
     public PopularPostResponse toPopularPostResponse(
@@ -374,7 +398,11 @@ public class CommunityResponseMapper {
     ) {
         MemberNameAndProfileImageResponse memberResponse;
 
-        if (Boolean.TRUE.equals(post.getIsBlindWriter()) && anonymousProfile != null) {
+        if (Boolean.TRUE.equals(post.getIsBlindWriter())) {
+            if (anonymousProfile == null) {
+                throw new IllegalStateException("anonymous profile is required for blind post");
+            }
+
             memberResponse = new MemberNameAndProfileImageResponse(
                 anonymousProfile.getId(),
                 anonymousProfile.getNickname().getNickname(),
@@ -401,7 +429,7 @@ public class CommunityResponseMapper {
         CommunityPostTag categoryTag = CommunityPostTag.MEETING;
 
         MemberNameAndProfileImageResponse memberResponse = new MemberNameAndProfileImageResponse(
-            crewUser.id(),
+            crewUser.orgId(),
             crewUser.name(),
             crewUser.profileImage()
         );

--- a/src/main/java/org/sopt/makers/internal/community/repository/CommunityQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/community/repository/CommunityQueryRepository.java
@@ -12,7 +12,9 @@ import org.sopt.makers.internal.community.domain.anonymous.AnonymousProfile;
 import org.sopt.makers.internal.community.domain.anonymous.QAnonymousProfile;
 import org.sopt.makers.internal.community.domain.category.QCategory;
 import org.sopt.makers.internal.community.domain.comment.QCommunityComment;
+import org.sopt.makers.internal.community.domain.enums.CommunityCategoryCode;
 import org.sopt.makers.internal.community.dto.CategoryPostMemberDao;
+import org.sopt.makers.internal.community.dto.CommunityDbCursor;
 import org.sopt.makers.internal.community.dto.comment.CommentDao;
 import org.sopt.makers.internal.member.domain.QMember;
 import org.sopt.makers.internal.member.domain.QMemberBlock;
@@ -31,80 +33,55 @@ public class CommunityQueryRepository {
 
     private final JPAQueryFactory queryFactory;
 
-    private static final long CATEGORY_PART_TALK = 2L;
-    private static final long CATEGORY_PROMOTION = 4L;
-
-    public List<CategoryPostMemberDao> findAllParentCategoryPostByCursor(Long categoryId, Integer limit, Long cursor, Long memberId, boolean filterBlockedUsers) {
-        val posts = QCommunityPost.communityPost;
+    public List<CategoryPostMemberDao> findPostsByCategoryCodes(
+        List<CommunityCategoryCode> categoryCodes,
+        CommunityDbCursor cursor,
+        LocalDateTime snapshotTime,
+        Integer limit,
+        Long memberId,
+        boolean filterBlockedUsers
+    ) {
+        val post = QCommunityPost.communityPost;
         val member = QMember.member;
         val category = QCategory.category;
-        val careers = QMemberCareer.memberCareer;
         val memberBlock = QMemberBlock.memberBlock;
 
-        JPAQuery<CategoryPostMemberDao> query;
-        if (categoryId == CATEGORY_PART_TALK || categoryId == CATEGORY_PROMOTION) {
-            query = queryFactory.select(Projections.constructor(CategoryPostMemberDao.class, posts, member, category))
-                    .from(posts)
-                    .innerJoin(posts.member, member)
-                    .leftJoin(member.careers, careers).on(member.id.eq(careers.memberId))
-                    .innerJoin(category).on(posts.categoryId.eq(category.id))
-                    .where(ltPostId(cursor), category.id.eq(categoryId).or(category.parent.id.eq(categoryId)))
-                    .limit(limit)
-                    .distinct()
-                    .orderBy(posts.createdAt.desc());
-        } else {
-            query = queryFactory.select(Projections.constructor(CategoryPostMemberDao.class, posts, member, category))
-                    .from(posts)
-                    .innerJoin(posts.member, member)
-                    .leftJoin(member.careers, careers).on(member.id.eq(careers.memberId))
-                    .innerJoin(category).on(posts.categoryId.eq(category.id))
-                    .where(ltPostId(cursor), category.id.eq(categoryId).or(category.parent.id.eq(categoryId)))
-                    .limit(limit)
-                    .distinct()
-                    .orderBy(category.displayOrder.asc(), posts.createdAt.desc());
-        }
+        JPAQuery<CategoryPostMemberDao> query = queryFactory
+            .select(Projections.constructor(CategoryPostMemberDao.class, post, member, category))
+            .from(post)
+            .innerJoin(post.member, member)
+            .innerJoin(post.category, category)
+            .where(
+                category.code.in(categoryCodes),
+                post.createdAt.loe(snapshotTime),
+                ltCursor(cursor)
+            )
+            .limit(limit)
+            .orderBy(post.createdAt.desc(), post.id.desc());
 
         if (filterBlockedUsers) {
             query.leftJoin(memberBlock).on(
-                            memberBlock.blocker.id.eq(memberId)
-                                    .and(memberBlock.blockedMember.id.eq(member.id))
-                                    .and(memberBlock.isBlocked.isTrue())
-                    )
-                    .where(memberBlock.isNull());
+                    memberBlock.blocker.id.eq(memberId)
+                        .and(memberBlock.blockedMember.id.eq(member.id))
+                        .and(memberBlock.isBlocked.isTrue())
+                )
+                .where(memberBlock.isNull());
         }
 
         return query.fetch();
     }
 
     public CategoryPostMemberDao getPostById(Long postId) {
-        val posts = QCommunityPost.communityPost;
+        val post = QCommunityPost.communityPost;
         val category = QCategory.category;
         val member = QMember.member;
 
-        return queryFactory.select(Projections.constructor(CategoryPostMemberDao.class, posts, member, category))
-                .from(posts)
-                .innerJoin(posts.member, member)
-                .innerJoin(category).on(posts.categoryId.eq(category.id))
-                .where(posts.id.eq(postId)).distinct().fetchOne();
-    }
-
-    public Map<Long, String> getCategoryNamesByIds(List<Long> categoryIds) {
-        if (categoryIds == null || categoryIds.isEmpty()) {
-            return Collections.emptyMap();
-        }
-
-        QCategory category = QCategory.category;
-
-        return queryFactory
-                .select(category.id, category.name)
-                .from(category)
-                .where(category.id.in(categoryIds))
-                .fetch()
-                .stream()
-                .collect(Collectors.toMap(
-                        tuple -> tuple.get(category.id),
-                        tuple -> tuple.get(category.name) // category.name은 NOT NULL 보장
-                ));
+        return queryFactory.select(Projections.constructor(CategoryPostMemberDao.class, post, member, category))
+            .from(post)
+            .innerJoin(post.member, member)
+            .innerJoin(post.category, category)
+            .where(post.id.eq(postId))
+            .fetchOne();
     }
 
     public Map<Long, AnonymousProfile> getAnonymousProfilesByPostId(List<Long> postIds) {
@@ -116,47 +93,44 @@ public class CommunityQueryRepository {
         QCommunityPost post = QCommunityPost.communityPost;
 
         return queryFactory
-                .selectFrom(anonymousProfile)
-                .join(anonymousProfile.post, post).fetchJoin()
-                .leftJoin(anonymousProfile.nickname).fetchJoin()
-                .leftJoin(anonymousProfile.profileImg).fetchJoin()
-                .where(
-                        anonymousProfile.post.id.in(postIds),
-                        anonymousProfile.member.id.eq(post.member.id)
-                )
-                .fetch()
-                .stream()
-                .collect(Collectors.toMap(
-                        profile -> profile.getPost().getId(),
-                        profile -> profile
-                ));
+            .selectFrom(anonymousProfile)
+            .join(anonymousProfile.post, post).fetchJoin()
+            .leftJoin(anonymousProfile.nickname).fetchJoin()
+            .leftJoin(anonymousProfile.profileImg).fetchJoin()
+            .where(
+                anonymousProfile.post.id.in(postIds),
+                anonymousProfile.member.id.eq(post.member.id)
+            )
+            .fetch()
+            .stream()
+            .collect(Collectors.toMap(
+                profile -> profile.getPost().getId(),
+                profile -> profile
+            ));
     }
 
     public List<CommentDao> findCommentByPostId(Long postId, Long memberId, boolean isBlockedOn) {
         val comment = QCommunityComment.communityComment;
         val member = QMember.member;
-        val careers = QMemberCareer.memberCareer;
         val memberBlock = QMemberBlock.memberBlock;
         val anonymousProfile = QAnonymousProfile.anonymousProfile;
 
         JPAQuery<CommentDao> query = queryFactory.select(Projections.constructor(CommentDao.class, member, comment))
-                .from(comment)
-                .innerJoin(member).on(member.id.eq(comment.writerId))
-                .leftJoin(member.careers, careers)
-                .leftJoin(comment.anonymousProfile, anonymousProfile).fetchJoin()
-                .leftJoin(anonymousProfile.nickname).fetchJoin()
-                .leftJoin(anonymousProfile.profileImg).fetchJoin()
-                .where(comment.postId.eq(postId))
-                .distinct()
-                .orderBy(comment.id.asc());
+            .from(comment)
+            .innerJoin(member).on(member.id.eq(comment.writerId))
+            .leftJoin(comment.anonymousProfile, anonymousProfile).fetchJoin()
+            .leftJoin(anonymousProfile.nickname).fetchJoin()
+            .leftJoin(anonymousProfile.profileImg).fetchJoin()
+            .where(comment.postId.eq(postId))
+            .orderBy(comment.id.asc());
 
         if (isBlockedOn) {
             query.leftJoin(memberBlock).on(
-                            memberBlock.blocker.id.eq(memberId)
-                                    .and(memberBlock.blockedMember.id.eq(member.id))
-                                    .and(memberBlock.isBlocked.isTrue())
-                    )
-                    .where(memberBlock.isNull());
+                    memberBlock.blocker.id.eq(memberId)
+                        .and(memberBlock.blockedMember.id.eq(member.id))
+                        .and(memberBlock.isBlocked.isTrue())
+                )
+                .where(memberBlock.isNull());
         }
 
         return query.fetch();
@@ -181,24 +155,90 @@ public class CommunityQueryRepository {
             .execute();
     }
 
+    // 조회수 기준 인기 게시글 - 현재 앱팀 internal api에 사용중
     public List<CommunityPost> findPopularPosts(int limitCount) {
         QCommunityPost communityPost = QCommunityPost.communityPost;
         QMember member = QMember.member;
+        QCategory category = QCategory.category;
+        QCategory parentCategory = new QCategory("parentCategory");
 
         LocalDateTime oneMonthAgo = LocalDateTime.now().minusMonths(1);
 
         return queryFactory
-                .selectFrom(communityPost)
-                .leftJoin(communityPost.member, member).fetchJoin()
-                .where(communityPost.createdAt.after(oneMonthAgo))
-                .orderBy(communityPost.hits.desc())
-                .limit(limitCount)
-                .fetch();
+            .selectFrom(communityPost)
+            .leftJoin(communityPost.member, member).fetchJoin()
+            .leftJoin(communityPost.category, category).fetchJoin()
+            .leftJoin(category.parent, parentCategory).fetchJoin()
+            .where(communityPost.createdAt.after(oneMonthAgo))
+            .orderBy(communityPost.hits.desc())
+            .limit(limitCount)
+            .fetch();
     }
-    
-    private BooleanExpression ltPostId(Long cursor) {
-        val posts = QCommunityPost.communityPost;
-        if(cursor == null || cursor == 0) return null;
-        return posts.id.lt(cursor);
+
+    // 인기글 후보용 최근 1달 게시글 조회 - 38기부터 인기글 조회에 사용중
+    public List<CommunityPost> findPopularCandidatePosts(LocalDateTime since) {
+        QCommunityPost communityPost = QCommunityPost.communityPost;
+        QMember member = QMember.member;
+        QCategory category = QCategory.category;
+        QCategory parentCategory = new QCategory("parentCategory");
+
+        return queryFactory
+            .selectFrom(communityPost)
+            .leftJoin(communityPost.member, member).fetchJoin()
+            .leftJoin(communityPost.category, category).fetchJoin()
+            .leftJoin(category.parent, parentCategory).fetchJoin()
+            .where(
+                communityPost.createdAt.goe(since),
+                communityPost.isReported.isFalse()
+            )
+            .orderBy(communityPost.createdAt.desc(), communityPost.id.desc())
+            .fetch();
+    }
+
+    public List<CommentDao> findCommentsByPostIds(
+        List<Long> postIds,
+        Long memberId,
+        boolean isBlockedOn
+    ) {
+        if (postIds == null || postIds.isEmpty()) {
+            return List.of();
+        }
+
+        val comment = QCommunityComment.communityComment;
+        val member = QMember.member;
+        val memberBlock = QMemberBlock.memberBlock;
+        val anonymousProfile = QAnonymousProfile.anonymousProfile;
+
+        JPAQuery<CommentDao> query = queryFactory
+            .select(Projections.constructor(CommentDao.class, member, comment))
+            .from(comment)
+            .innerJoin(member).on(member.id.eq(comment.writerId))
+            .leftJoin(comment.anonymousProfile, anonymousProfile).fetchJoin()
+            .leftJoin(anonymousProfile.nickname).fetchJoin()
+            .leftJoin(anonymousProfile.profileImg).fetchJoin()
+            .where(comment.postId.in(postIds))
+            .orderBy(comment.postId.asc(), comment.id.asc());
+
+        if (isBlockedOn) {
+            query.leftJoin(memberBlock).on(
+                    memberBlock.blocker.id.eq(memberId)
+                        .and(memberBlock.blockedMember.id.eq(member.id))
+                        .and(memberBlock.isBlocked.isTrue())
+                )
+                .where(memberBlock.isNull());
+        }
+
+        return query.fetch();
+    }
+
+    private BooleanExpression ltCursor(CommunityDbCursor cursor) {
+        val post = QCommunityPost.communityPost;
+
+        if (cursor == null || cursor.createdAt() == null || cursor.postId() == null) {
+            return null;
+        }
+
+        return post.createdAt.lt(cursor.createdAt())
+            .or(post.createdAt.eq(cursor.createdAt()).and(post.id.lt(cursor.postId())));
     }
 }

--- a/src/main/java/org/sopt/makers/internal/community/repository/CommunityQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/community/repository/CommunityQueryRepository.java
@@ -41,6 +41,9 @@ public class CommunityQueryRepository {
         Long memberId,
         boolean filterBlockedUsers
     ) {
+        if (filterBlockedUsers && memberId == null) {
+            throw new IllegalArgumentException("memberId is required when filterBlockedUsers is true");
+        }
         val post = QCommunityPost.communityPost;
         val member = QMember.member;
         val category = QCategory.category;
@@ -110,6 +113,10 @@ public class CommunityQueryRepository {
     }
 
     public List<CommentDao> findCommentByPostId(Long postId, Long memberId, boolean isBlockedOn) {
+        if (isBlockedOn && memberId == null) {
+            throw new IllegalArgumentException("memberId is required when isBlockedOn is true");
+        }
+
         val comment = QCommunityComment.communityComment;
         val member = QMember.member;
         val memberBlock = QMemberBlock.memberBlock;
@@ -200,6 +207,9 @@ public class CommunityQueryRepository {
         Long memberId,
         boolean isBlockedOn
     ) {
+        if (isBlockedOn && memberId == null) {
+            throw new IllegalArgumentException("memberId is required when isBlockedOn is true");
+        }
         if (postIds == null || postIds.isEmpty()) {
             return List.of();
         }

--- a/src/main/java/org/sopt/makers/internal/community/repository/category/CategoryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/community/repository/category/CategoryRepository.java
@@ -1,10 +1,20 @@
 package org.sopt.makers.internal.community.repository.category;
 
 import org.sopt.makers.internal.community.domain.category.Category;
+import org.sopt.makers.internal.community.domain.enums.CommunityCategoryCode;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
-    Optional<Category> findById(Long id);
+
+    Optional<Category> findByCodeAndIsActiveTrue(CommunityCategoryCode code);
+
+    List<Category> findAllByCodeInAndIsActiveTrue(List<CommunityCategoryCode> codes);
+
+	List<Category> findAllByIsActiveTrueAndParentIsNullAndCodeInOrderByDisplayOrderAsc(
+		List<CommunityCategoryCode> codes
+	);
 }

--- a/src/main/java/org/sopt/makers/internal/community/repository/comment/CommunityCommentRepository.java
+++ b/src/main/java/org/sopt/makers/internal/community/repository/comment/CommunityCommentRepository.java
@@ -2,9 +2,12 @@ package org.sopt.makers.internal.community.repository.comment;
 
 import org.sopt.makers.internal.community.domain.comment.CommunityComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
+
 
 public interface CommunityCommentRepository extends JpaRepository<CommunityComment, Long> {
     List<CommunityComment> findAllByPostId(Long postId);
@@ -16,4 +19,21 @@ public interface CommunityCommentRepository extends JpaRepository<CommunityComme
     int countAllByPostIdAndIsDeleted(Long postId, Boolean isDeleted);
 
     int countAllByWriterIdAndCreatedAtBetween(Long memberId, LocalDateTime start, LocalDateTime end);
+
+    @Query("""
+        SELECT comment.postId AS postId,
+               COUNT(comment) AS commentCount
+        FROM CommunityComment comment
+        WHERE comment.postId IN :postIds
+          AND comment.isDeleted = false
+        GROUP BY comment.postId
+    """)
+    List<PostCommentCountProjection> countCommentsByPostIds(
+        @Param("postIds") List<Long> postIds
+    );
+
+    interface PostCommentCountProjection {
+        Long getPostId();
+        Long getCommentCount();
+    }
 }

--- a/src/main/java/org/sopt/makers/internal/community/repository/post/CommunityPostLikeRepository.java
+++ b/src/main/java/org/sopt/makers/internal/community/repository/post/CommunityPostLikeRepository.java
@@ -2,9 +2,13 @@ package org.sopt.makers.internal.community.repository.post;
 
 import org.sopt.makers.internal.community.domain.CommunityPostLike;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
+
 
 public interface CommunityPostLikeRepository extends JpaRepository<CommunityPostLike, Long> {
 
@@ -19,6 +23,32 @@ public interface CommunityPostLikeRepository extends JpaRepository<CommunityPost
 
     Integer countAllByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime start, LocalDateTime end);
 
+    @Query("""
+        SELECT postLike.post.id
+        FROM CommunityPostLike postLike
+        WHERE postLike.member.id = :memberId
+          AND postLike.post.id IN :postIds
+    """)
+	List<Long> findLikedPostIdsByMemberIdAndPostIds(
+        @Param("memberId") Long memberId,
+        @Param("postIds") List<Long> postIds
+    );
+
+    @Query("""
+        SELECT postLike.post.id AS postId,
+               COUNT(postLike) AS likeCount
+        FROM CommunityPostLike postLike
+        WHERE postLike.post.id IN :postIds
+        GROUP BY postLike.post.id
+    """)
+    List<PostLikeCountProjection> countLikesByPostIds(
+        @Param("postIds") List<Long> postIds
+    );
+
+    interface PostLikeCountProjection {
+        Long getPostId();
+        Long getLikeCount();
+    }
     // UPDATE
 
     // DELETE

--- a/src/main/java/org/sopt/makers/internal/community/repository/post/CommunityPostRepository.java
+++ b/src/main/java/org/sopt/makers/internal/community/repository/post/CommunityPostRepository.java
@@ -5,32 +5,72 @@ import java.util.List;
 import java.util.Optional;
 
 import org.sopt.makers.internal.community.domain.CommunityPost;
+import org.sopt.makers.internal.community.domain.enums.CommunityCategoryCode;
+import org.sopt.makers.internal.community.domain.enums.CommunityCategoryGroup;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface CommunityPostRepository extends JpaRepository<CommunityPost, Long>, CommunityPostRepositoryCustom {
+
     Optional<CommunityPost> findById(Long id);
+
+    @EntityGraph(attributePaths = {"category", "category.parent", "member"})
+    @Query("""
+        SELECT post
+        FROM CommunityPost post
+        WHERE post.id = :postId
+    """)
+    Optional<CommunityPost> findByIdWithCategoryAndMember(@Param("postId") Long postId);
 
     List<CommunityPost> findAllByCreatedAtBetween(LocalDateTime start, LocalDateTime end);
 
     Integer countAllByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime start, LocalDateTime end);
 
-    List<CommunityPost> findTop5ByCategoryIdOrderByCreatedAtDesc(Long categoryId);
+    @EntityGraph(attributePaths = {"category", "member"})
+    List<CommunityPost> findTop5ByCategory_CodeInOrderByCreatedAtDesc(
+        List<CommunityCategoryCode> categoryCodes
+    );
 
-    List<CommunityPost> findTop5ByCategoryIdNotOrderByCreatedAtDesc(Long categoryId);
+    @EntityGraph(attributePaths = {"category", "category.parent"})
+    List<CommunityPost> findTop3ByCategory_CategoryGroupInOrderByCreatedAtDesc(
+        List<CommunityCategoryGroup> categoryGroups
+    );
 
-    Optional<CommunityPost> findFirstByCategoryIdInOrderByCreatedAtDesc(List<Long> categoryIds);
+    @EntityGraph(attributePaths = {"category", "category.parent"})
+    Optional<CommunityPost> findFirstByCategory_CodeInOrderByCreatedAtDesc(
+        List<CommunityCategoryCode> categoryCodes
+    );
 
     @Modifying
-    @Query("UPDATE CommunityPost p SET p.hits = p.hits + 1 WHERE p.id = :postId")
+    @Query("UPDATE CommunityPost post SET post.hits = post.hits + 1 WHERE post.id = :postId")
     void increaseHitsDirect(@Param("postId") Long postId);
 
-    @Query(value =
-            "SELECT COUNT(*) " +
-            "FROM CommunityPost p " +
-            "WHERE p.categoryId = 21 AND p.member.id = :memberId"
-            )
-    long countSopticleByMemberId(@Param("memberId") Long memberId);
+    @Query("""
+        SELECT COUNT(post)
+        FROM CommunityPost post
+        WHERE post.category.code IN :categoryCodes
+          AND post.member.id = :memberId
+    """)
+    long countByMemberIdAndCategoryCodes(
+        @Param("memberId") Long memberId,
+        @Param("categoryCodes") List<CommunityCategoryCode> categoryCodes
+    );
+
+    @Query("""
+        SELECT COUNT(post)
+        FROM CommunityPost post
+        WHERE post.member.id = :memberId
+          AND post.category.categoryGroup = :categoryGroup
+    """)
+    long countByMemberIdAndCategoryGroup(
+        @Param("memberId") Long memberId,
+        @Param("categoryGroup") CommunityCategoryGroup categoryGroup
+    );
+
+    default long countSopticleByMemberId(Long memberId) {
+        return countByMemberIdAndCategoryGroup(memberId, CommunityCategoryGroup.SOPTICLE);
+    }
 }

--- a/src/main/java/org/sopt/makers/internal/community/repository/post/CommunityPostRepositoryCustom.java
+++ b/src/main/java/org/sopt/makers/internal/community/repository/post/CommunityPostRepositoryCustom.java
@@ -1,8 +1,9 @@
 package org.sopt.makers.internal.community.repository.post;
 
+import org.sopt.makers.internal.community.domain.enums.CommunityCategoryGroup;
 import org.sopt.makers.internal.community.dto.PostCategoryDao;
 
 public interface CommunityPostRepositoryCustom {
 
-	PostCategoryDao findRecentPostByCategory(String categoryName);
+	PostCategoryDao findRecentPostByCategoryGroup(CommunityCategoryGroup categoryGroup);
 }

--- a/src/main/java/org/sopt/makers/internal/community/repository/post/CommunityPostRepositoryCustomImpl.java
+++ b/src/main/java/org/sopt/makers/internal/community/repository/post/CommunityPostRepositoryCustomImpl.java
@@ -1,11 +1,11 @@
 package org.sopt.makers.internal.community.repository.post;
 
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.sopt.makers.internal.community.domain.QCommunityPost;
 import org.sopt.makers.internal.community.domain.category.QCategory;
+import org.sopt.makers.internal.community.domain.enums.CommunityCategoryGroup;
 import org.sopt.makers.internal.community.dto.PostCategoryDao;
 
 @RequiredArgsConstructor
@@ -13,22 +13,17 @@ public class CommunityPostRepositoryCustomImpl implements CommunityPostRepositor
 
 	private final JPAQueryFactory queryFactory;
 
-	private BooleanExpression checkCategoryEqualsName(String categoryName) {
-		if (categoryName == null) return null;
-		return QCategory.category.name.eq(categoryName);
-	}
-
 	@Override
-	public PostCategoryDao findRecentPostByCategory(String categoryName) {
-		QCommunityPost posts = QCommunityPost.communityPost;
+	public PostCategoryDao findRecentPostByCategoryGroup(CommunityCategoryGroup categoryGroup) {
+		QCommunityPost post = QCommunityPost.communityPost;
 		QCategory category = QCategory.category;
 
 		return queryFactory
-				.select(Projections.constructor(PostCategoryDao.class, posts, category))
-				.from(posts)
-				.innerJoin(category).on(posts.categoryId.eq(category.id))
-				.where(checkCategoryEqualsName(categoryName))
-				.orderBy(posts.id.desc())
-				.fetchFirst();
+			.select(Projections.constructor(PostCategoryDao.class, post, category))
+			.from(post)
+			.innerJoin(post.category, category)
+			.where(category.categoryGroup.eq(categoryGroup))
+			.orderBy(post.createdAt.desc(), post.id.desc())
+			.fetchFirst();
 	}
 }

--- a/src/main/java/org/sopt/makers/internal/community/service/category/CategoryRetriever.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/category/CategoryRetriever.java
@@ -1,10 +1,9 @@
 package org.sopt.makers.internal.community.service.category;
 
-import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
 import org.sopt.makers.internal.community.domain.category.Category;
+import org.sopt.makers.internal.community.domain.enums.CommunityCategoryCode;
 import org.sopt.makers.internal.community.repository.category.CategoryRepository;
-import org.sopt.makers.internal.exception.BadRequestException;
 import org.sopt.makers.internal.exception.NotFoundException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,38 +16,25 @@ public class CategoryRetriever {
 
     private final CategoryRepository categoryRepository;
 
-    public List<Category> getAllCategories() {
-
-        return categoryRepository.findAll();
-    }
-
-    public void checkExistsCategoryById(Long categoryId) {
-        if (!categoryRepository.existsById(categoryId)) {
-            throw new NotFoundException("존재하지 않는 category id 값입니다.");
-        }
-    }
-
-    public List<Category> findAllByIds(List<Long> ids) {
-        return categoryRepository.findAllById(ids);
+    @Transactional(readOnly = true)
+    public Category findActiveCategoryByCode(CommunityCategoryCode code) {
+        return categoryRepository.findByCodeAndIsActiveTrue(code)
+            .orElseThrow(() -> new NotFoundException("존재하지 않는 category code 값입니다."));
     }
 
     @Transactional(readOnly = true)
-    public List<Long> findAllDescendantIds(Long parentId) {
-        List<Category> allCategories = categoryRepository.findAll();
-        Category parent = allCategories.stream()
-                .filter(c -> c.getId().equals(parentId))
-                .findFirst()
-                .orElseThrow(() -> new BadRequestException("존재하지 않는 카테고리입니다."));
-
-        List<Long> descendantIds = new ArrayList<>();
-        collectDescendantIds(parent, descendantIds, allCategories);
-        return descendantIds;
+    public List<Category> findActiveRootListCategories() {
+        return categoryRepository.findAllByIsActiveTrueAndParentIsNullAndCodeInOrderByDisplayOrderAsc(
+            List.of(
+                CommunityCategoryCode.FREE,
+                CommunityCategoryCode.PROMOTION,
+                CommunityCategoryCode.SOPTICLE
+            )
+        );
     }
 
-    private void collectDescendantIds(Category category, List<Long> ids, List<Category> allCategories) {
-        ids.add(category.getId());
-        allCategories.stream()
-                .filter(c -> category.getId().equals(c.getParent() != null ? c.getParent().getId() : null))
-                .forEach(child -> collectDescendantIds(child, ids, allCategories));
+    @Transactional(readOnly = true)
+    public List<Category> findActiveCategoriesByCodes(List<CommunityCategoryCode> codes) {
+        return categoryRepository.findAllByCodeInAndIsActiveTrue(codes);
     }
 }

--- a/src/main/java/org/sopt/makers/internal/community/service/category/CategoryService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/category/CategoryService.java
@@ -2,10 +2,8 @@ package org.sopt.makers.internal.community.service.category;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.makers.internal.community.dto.response.CommunityCategoryResponse;
-import org.sopt.makers.internal.community.domain.category.Category;
 import org.springframework.stereotype.Service;
 
-import java.util.Comparator;
 import java.util.List;
 
 @Service
@@ -15,13 +13,8 @@ public class CategoryService {
     private final CategoryRetriever categoryRetriever;
 
     public List<CommunityCategoryResponse> getAllCategoriesWithChildren() {
-
-        List<Category> categories = categoryRetriever.getAllCategories();
-
-        return categories.stream()
-                .filter(category -> category.getParent() == null)
-                .sorted(Comparator.comparing(Category::getDisplayOrder))
-                .map(CommunityCategoryResponse::from)
-                .toList();
+        return categoryRetriever.findActiveRootListCategories().stream()
+            .map(CommunityCategoryResponse::fromRoot)
+            .toList();
     }
 }

--- a/src/main/java/org/sopt/makers/internal/community/service/category/CommunityCategoryPolicy.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/category/CommunityCategoryPolicy.java
@@ -1,0 +1,181 @@
+package org.sopt.makers.internal.community.service.category;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.sopt.makers.internal.community.domain.category.Category;
+import org.sopt.makers.internal.community.domain.enums.CommunityCategoryCode;
+import org.sopt.makers.internal.community.domain.enums.CommunityCategoryGroup;
+import org.sopt.makers.internal.community.domain.enums.CommunityPostListCategory;
+import org.sopt.makers.internal.community.domain.enums.CommunityPostListFilter;
+import org.sopt.makers.internal.community.domain.enums.CommunityPostTag;
+import org.sopt.makers.internal.exception.BadRequestException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CommunityCategoryPolicy {
+
+	private static final List<CommunityCategoryCode> PROMOTION_ALL_CODES = List.of(
+		CommunityCategoryCode.PROMOTION,
+		CommunityCategoryCode.PROMOTION_EVENT,
+		CommunityCategoryCode.PROMOTION_PROJECT,
+		CommunityCategoryCode.PROMOTION_RECRUIT,
+		CommunityCategoryCode.PROMOTION_ETC
+	);
+
+	private static final List<CommunityCategoryCode> SOPTICLE_ALL_CODES = List.of(
+		CommunityCategoryCode.SOPTICLE,
+		CommunityCategoryCode.SOPTICLE_PLAN,
+		CommunityCategoryCode.SOPTICLE_DESIGN,
+		CommunityCategoryCode.SOPTICLE_SERVER,
+		CommunityCategoryCode.SOPTICLE_WEB,
+		CommunityCategoryCode.SOPTICLE_IOS,
+		CommunityCategoryCode.SOPTICLE_ANDROID,
+		CommunityCategoryCode.SOPTICLE_ETC
+	);
+
+	private static final Map<CommunityPostListFilter, CommunityCategoryCode> PROMOTION_FILTER_CODE_MAP = Map.of(
+		CommunityPostListFilter.EVENT, CommunityCategoryCode.PROMOTION_EVENT,
+		CommunityPostListFilter.PROJECT, CommunityCategoryCode.PROMOTION_PROJECT,
+		CommunityPostListFilter.RECRUIT, CommunityCategoryCode.PROMOTION_RECRUIT,
+		CommunityPostListFilter.ETC, CommunityCategoryCode.PROMOTION_ETC
+	);
+
+	private static final Map<CommunityPostListFilter, CommunityCategoryCode> SOPTICLE_FILTER_CODE_MAP = Map.of(
+		CommunityPostListFilter.PLAN, CommunityCategoryCode.SOPTICLE_PLAN,
+		CommunityPostListFilter.DESIGN, CommunityCategoryCode.SOPTICLE_DESIGN,
+		CommunityPostListFilter.SERVER, CommunityCategoryCode.SOPTICLE_SERVER,
+		CommunityPostListFilter.WEB, CommunityCategoryCode.SOPTICLE_WEB,
+		CommunityPostListFilter.IOS, CommunityCategoryCode.SOPTICLE_IOS,
+		CommunityPostListFilter.ANDROID, CommunityCategoryCode.SOPTICLE_ANDROID,
+		CommunityPostListFilter.ETC, CommunityCategoryCode.SOPTICLE_ETC
+	);
+
+	private static final Set<CommunityPostListFilter> PROMOTION_FILTERS = Set.of(
+		CommunityPostListFilter.ALL,
+		CommunityPostListFilter.EVENT,
+		CommunityPostListFilter.PROJECT,
+		CommunityPostListFilter.RECRUIT,
+		CommunityPostListFilter.ETC
+	);
+
+	private static final Set<CommunityPostListFilter> SOPTICLE_FILTERS = Set.of(
+		CommunityPostListFilter.ALL,
+		CommunityPostListFilter.PLAN,
+		CommunityPostListFilter.DESIGN,
+		CommunityPostListFilter.SERVER,
+		CommunityPostListFilter.WEB,
+		CommunityPostListFilter.IOS,
+		CommunityPostListFilter.ANDROID,
+		CommunityPostListFilter.ETC
+	);
+
+	public List<CommunityCategoryCode> resolveCategoryCodes(
+		CommunityPostListCategory category,
+		CommunityPostListFilter filter
+	) {
+		return switch (category) {
+			case FREE -> resolveFreeCodes(filter);
+			case PROMOTION -> resolvePromotionCodes(normalizeFilter(filter));
+			case SOPTICLE -> resolveSopticleCodes(normalizeFilter(filter));
+		};
+	}
+
+	public boolean isSopticleCategoryCode(CommunityCategoryCode categoryCode) {
+		return SOPTICLE_ALL_CODES.contains(categoryCode);
+	}
+
+	public List<CommunityPostListFilter> getAvailableFilters(CommunityPostListCategory category) {
+		return switch (category) {
+			case FREE -> List.of();
+			case PROMOTION -> List.of(
+				CommunityPostListFilter.ALL,
+				CommunityPostListFilter.EVENT,
+				CommunityPostListFilter.PROJECT,
+				CommunityPostListFilter.RECRUIT,
+				CommunityPostListFilter.ETC
+			);
+			case SOPTICLE -> List.of(
+				CommunityPostListFilter.ALL,
+				CommunityPostListFilter.PLAN,
+				CommunityPostListFilter.DESIGN,
+				CommunityPostListFilter.SERVER,
+				CommunityPostListFilter.WEB,
+				CommunityPostListFilter.IOS,
+				CommunityPostListFilter.ANDROID,
+				CommunityPostListFilter.ETC
+			);
+		};
+	}
+
+	public CommunityPostTag resolvePreviewTag(Category category) {
+		if (category == null || category.getCategoryGroup() == null) {
+			return null;
+		}
+
+		if (category.getCategoryGroup() == CommunityCategoryGroup.FREE) {
+			return CommunityPostTag.FREE;
+		}
+
+		if (category.getCategoryGroup() == CommunityCategoryGroup.SOPTICLE) {
+			return CommunityPostTag.SOPTICLE;
+		}
+
+		if (category.getCategoryGroup() == CommunityCategoryGroup.PROMOTION) {
+			return resolvePromotionPreviewTag(category.getCode());
+		}
+
+		return null;
+	}
+
+	private CommunityPostTag resolvePromotionPreviewTag(CommunityCategoryCode code) {
+		if (code == null) {
+			return CommunityPostTag.PROMOTION;
+		}
+
+		return switch (code) {
+			case PROMOTION_EVENT -> CommunityPostTag.EVENT;
+			case PROMOTION_PROJECT -> CommunityPostTag.PROJECT;
+			case PROMOTION_RECRUIT -> CommunityPostTag.RECRUIT;
+			case PROMOTION, PROMOTION_ETC -> CommunityPostTag.PROMOTION;
+			default -> CommunityPostTag.PROMOTION;
+		};
+	}
+
+	private List<CommunityCategoryCode> resolveFreeCodes(CommunityPostListFilter filter) {
+		if (filter != null) {
+			throw new BadRequestException("자유 카테고리는 filter 값을 받을 수 없습니다.");
+		}
+
+		return List.of(CommunityCategoryCode.FREE);
+	}
+
+	private List<CommunityCategoryCode> resolvePromotionCodes(CommunityPostListFilter filter) {
+		if (!PROMOTION_FILTERS.contains(filter)) {
+			throw new BadRequestException("홍보 카테고리에서 사용할 수 없는 filter 값입니다.");
+		}
+
+		if (filter == CommunityPostListFilter.ALL) {
+			return PROMOTION_ALL_CODES;
+		}
+
+		return List.of(PROMOTION_FILTER_CODE_MAP.get(filter));
+	}
+
+	private List<CommunityCategoryCode> resolveSopticleCodes(CommunityPostListFilter filter) {
+		if (!SOPTICLE_FILTERS.contains(filter)) {
+			throw new BadRequestException("솝티클 카테고리에서 사용할 수 없는 filter 값입니다.");
+		}
+
+		if (filter == CommunityPostListFilter.ALL) {
+			return SOPTICLE_ALL_CODES;
+		}
+
+		return List.of(SOPTICLE_FILTER_CODE_MAP.get(filter));
+	}
+
+	private CommunityPostListFilter normalizeFilter(CommunityPostListFilter filter) {
+		return filter == null ? CommunityPostListFilter.ALL : filter;
+	}
+}

--- a/src/main/java/org/sopt/makers/internal/community/service/comment/CommunityCommentLikeService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/comment/CommunityCommentLikeService.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 @Service
@@ -27,11 +28,7 @@ public class CommunityCommentLikeService {
 
 	@Transactional
 	public void addCommentLike(Long memberId, Long postId, Long commentId) {
-		CommunityPost post = communityPostRetriever.findCommunityPostById(postId);
-		CommunityComment comment = commentsRetriever.findCommunityCommentById(commentId);
-		if (!post.getComments().contains(comment)) {
-			throw new BadRequestException("해당 게시글의 댓글이 아닙니다.");
-		}
+		CommunityComment comment = validateCommentBelongsToPost(postId, commentId);
 		Member member = memberRetriever.findMemberById(memberId);
 
 		boolean alreadyLiked = commentLikeRetriever.isLiked(memberId, commentId);
@@ -44,13 +41,11 @@ public class CommunityCommentLikeService {
 
 	@Transactional
 	public void cancelCommentLike(Long memberId, Long postId, Long commentId) {
-		CommunityPost post = communityPostRetriever.findCommunityPostById(postId);
-		CommunityComment comment = commentsRetriever.findCommunityCommentById(commentId);
-		if (!post.getComments().contains(comment)) {
-			throw new BadRequestException("해당 게시글의 댓글이 아닙니다.");
-		}
+		validateCommentBelongsToPost(postId, commentId);
 
-		Optional<CommunityCommentLike> existingLike = commentLikeRetriever.findByMemberIdAndCommentId(memberId, commentId);
+		Optional<CommunityCommentLike> existingLike =
+			commentLikeRetriever.findByMemberIdAndCommentId(memberId, commentId);
+
 		if (existingLike.isEmpty()) {
 			throw new BadRequestException("좋아요를 누르지 않은 댓글입니다.");
 		}
@@ -76,5 +71,15 @@ public class CommunityCommentLikeService {
 	@Transactional(readOnly = true)
 	public Map<Long, Integer> getLikeCountMapByCommentIds(List<Long> commentIds) {
 		return commentLikeRetriever.getLikeCountMapByCommentIds(commentIds);
+	}
+
+	private CommunityComment validateCommentBelongsToPost(Long postId, Long commentId) {
+		CommunityComment comment = commentsRetriever.findCommunityCommentById(commentId);
+
+		if (!Objects.equals(comment.getPostId(), postId)) {
+			throw new BadRequestException("해당 게시글의 댓글이 아닙니다.");
+		}
+
+		return comment;
 	}
 }

--- a/src/main/java/org/sopt/makers/internal/community/service/comment/CommunityCommentService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/comment/CommunityCommentService.java
@@ -4,8 +4,10 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.sopt.makers.internal.community.domain.CommunityPost;
 import org.sopt.makers.internal.community.domain.anonymous.AnonymousProfile;
@@ -16,6 +18,7 @@ import org.sopt.makers.internal.community.dto.request.comment.CommentUpdateReque
 import org.sopt.makers.internal.community.service.anonymous.AnonymousProfileService;
 import org.sopt.makers.internal.community.service.anonymous.AnonymousProfileRetriever;
 import org.sopt.makers.internal.community.service.anonymous.AnonymousNicknameRetriever;
+import org.sopt.makers.internal.community.service.member.CommunityMemberVoAssembler;
 import org.sopt.makers.internal.community.service.post.CommunityPostRetriever;
 import org.sopt.makers.internal.external.platform.InternalUserDetails;
 import org.sopt.makers.internal.external.platform.PlatformService;
@@ -38,7 +41,6 @@ import org.sopt.makers.internal.community.repository.comment.DeletedCommunityCom
 import org.sopt.makers.internal.community.repository.comment.ReportCommentRepository;
 import org.sopt.makers.internal.common.event.PushNotificationEvent;
 import org.sopt.makers.internal.member.service.MemberRetriever;
-import org.sopt.makers.internal.member.service.career.MemberCareerRetriever;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -53,7 +55,7 @@ import lombok.val;
 public class CommunityCommentService {
 
     private final PlatformService platformService;
-    private final MemberCareerRetriever memberCareerRetriever;
+    private final CommunityMemberVoAssembler communityMemberVoAssembler;
 
     private final DeletedCommunityCommentRepository deletedCommunityCommentRepository;
     private final CommunityCommentRepository communityCommentsRepository;
@@ -104,15 +106,53 @@ public class CommunityCommentService {
     @Transactional(readOnly = true)
     public List<CommentInfo> getPostCommentList(Long postId, Long memberId, Boolean isBlockedOn) {
         communityPostRetriever.checkExistsCommunityPostById(postId);
-        List<CommentDao> commentDaos = communityQueryRepository.findCommentByPostId(postId, memberId, isBlockedOn);
 
-        return commentDaos.stream().map(dao -> {
-            val authorDetails = platformService.getInternalUser(dao.member().getId());
-            val authorCareer = memberCareerRetriever.findMemberLastCareerByMemberId(dao.member().getId());
-            val memberVo = MemberVo.of(authorDetails, authorCareer);
-            val anonymousProfile = getAnonymousCommentProfile(dao.comment());
-            return new CommentInfo(dao, memberVo, anonymousProfile);
-        }).toList();
+        return getPostCommentMap(List.of(postId), memberId, isBlockedOn)
+            .getOrDefault(postId, List.of());
+    }
+
+    @Transactional(readOnly = true)
+    public Map<Long, List<CommentInfo>> getPostCommentMap(
+        List<Long> postIds,
+        Long memberId,
+        Boolean isBlockedOn
+    ) {
+        if (postIds == null || postIds.isEmpty()) {
+            return Map.of();
+        }
+
+        List<CommentDao> commentDaos = communityQueryRepository.findCommentsByPostIds(
+            postIds,
+            memberId,
+            Boolean.TRUE.equals(isBlockedOn)
+        );
+
+        List<Long> commentWriterIds = commentDaos.stream()
+            .map(commentDao -> commentDao.member().getId())
+            .distinct()
+            .toList();
+
+        Map<Long, MemberVo> memberVoMap = communityMemberVoAssembler.getMemberVoMap(commentWriterIds);
+
+        Map<Long, List<CommentInfo>> commentInfoMap = commentDaos.stream()
+            .map(commentDao -> {
+                Long commentWriterId = commentDao.member().getId();
+
+                return new CommentInfo(
+                    commentDao,
+                    memberVoMap.get(commentWriterId),
+                    getAnonymousCommentProfile(commentDao.comment())
+                );
+            })
+            .collect(Collectors.groupingBy(
+                commentInfo -> commentInfo.commentDao().comment().getPostId()
+            ));
+
+        return postIds.stream()
+            .collect(Collectors.toMap(
+                postId -> postId,
+                postId -> commentInfoMap.getOrDefault(postId, List.of())
+            ));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/makers/internal/community/service/member/CommunityMemberVoAssembler.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/member/CommunityMemberVoAssembler.java
@@ -58,6 +58,9 @@ public class CommunityMemberVoAssembler {
 	}
 
 	public MemberVo getMemberVo(Long memberId) {
+		if (memberId == null) {
+			return null;
+		}
 		return getMemberVoMap(List.of(memberId)).get(memberId);
 	}
 }

--- a/src/main/java/org/sopt/makers/internal/community/service/member/CommunityMemberVoAssembler.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/member/CommunityMemberVoAssembler.java
@@ -1,0 +1,63 @@
+package org.sopt.makers.internal.community.service.member;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.sopt.makers.internal.community.dto.MemberVo;
+import org.sopt.makers.internal.external.platform.InternalUserDetails;
+import org.sopt.makers.internal.external.platform.PlatformService;
+import org.sopt.makers.internal.member.domain.MemberCareer;
+import org.sopt.makers.internal.member.service.career.MemberCareerRetriever;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CommunityMemberVoAssembler {
+
+	private final PlatformService platformService;
+	private final MemberCareerRetriever memberCareerRetriever;
+
+	public Map<Long, MemberVo> getMemberVoMap(List<Long> memberIds) {
+		if (memberIds == null || memberIds.isEmpty()) {
+			return Map.of();
+		}
+
+		List<Long> distinctMemberIds = memberIds.stream()
+			.filter(Objects::nonNull)
+			.distinct()
+			.toList();
+
+		if (distinctMemberIds.isEmpty()) {
+			return Map.of();
+		}
+
+		Map<Long, InternalUserDetails> userDetailsMap =
+			platformService.getInternalUserDetailsMap(distinctMemberIds);
+
+		Map<Long, MemberCareer> careerMap =
+			memberCareerRetriever.findMemberLastCareerMapByMemberIds(distinctMemberIds);
+
+		Map<Long, MemberVo> memberVoMap = new LinkedHashMap<>();
+
+		for (Long memberId : distinctMemberIds) {
+			InternalUserDetails userDetails = userDetailsMap.get(memberId);
+
+			if (userDetails == null) {
+				continue;
+			}
+
+			memberVoMap.put(
+				memberId,
+				MemberVo.of(userDetails, careerMap.get(memberId))
+			);
+		}
+
+		return memberVoMap;
+	}
+
+	public MemberVo getMemberVo(Long memberId) {
+		return getMemberVoMap(List.of(memberId)).get(memberId);
+	}
+}

--- a/src/main/java/org/sopt/makers/internal/community/service/post/CommunityFeedCursorCodec.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/post/CommunityFeedCursorCodec.java
@@ -1,0 +1,46 @@
+package org.sopt.makers.internal.community.service.post;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import lombok.RequiredArgsConstructor;
+import org.sopt.makers.internal.community.dto.CommunityFeedCursor;
+import org.sopt.makers.internal.exception.BadRequestException;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CommunityFeedCursorCodec {
+
+	private final ObjectMapper objectMapper;
+
+	public CommunityFeedCursor decodeOrInitial(String cursor) {
+		if (cursor == null || cursor.isBlank()) {
+			return CommunityFeedCursor.initial(LocalDateTime.now());
+		}
+
+		try {
+			String json = new String(
+				Base64.getUrlDecoder().decode(cursor),
+				StandardCharsets.UTF_8
+			);
+
+			return objectMapper.readValue(json, CommunityFeedCursor.class);
+		} catch (Exception e) {
+			throw new BadRequestException("유효하지 않은 cursor 값입니다.");
+		}
+	}
+
+	public String encode(CommunityFeedCursor cursor) {
+		try {
+			String json = objectMapper.writeValueAsString(cursor);
+
+			return Base64.getUrlEncoder()
+				.withoutPadding()
+				.encodeToString(json.getBytes(StandardCharsets.UTF_8));
+		} catch (Exception e) {
+			throw new IllegalStateException("cursor 생성에 실패했습니다.", e);
+		}
+	}
+}

--- a/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostModifier.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostModifier.java
@@ -2,6 +2,8 @@ package org.sopt.makers.internal.community.service.post;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import org.sopt.makers.internal.community.domain.category.Category;
 import org.sopt.makers.internal.community.dto.request.PostSaveRequest;
 import org.sopt.makers.internal.community.repository.post.CommunityPostRepository;
 import org.sopt.makers.internal.member.domain.Member;
@@ -19,19 +21,18 @@ public class CommunityPostModifier {
     private final CommunityPostRepository communityPostRepository;
 
     // CREATE
-    public CommunityPost createCommunityPost(Member member, PostSaveRequest request) {
-
+    public CommunityPost createCommunityPost(Member member, Category category, PostSaveRequest request) {
         return communityPostRepository.save(CommunityPost.builder()
-                .member(member)
-                .categoryId(request.categoryId())
-                .title(request.title())
-                .content(request.content())
-                .images(request.images())
-                .isQuestion(request.isQuestion())
-                .isBlindWriter(request.isBlindWriter())
-                .sopticleUrl(request.link())
-                .comments(new ArrayList<>())
-                .build());
+            .member(member)
+            .category(category)
+            .title(request.title())
+            .content(request.content())
+            .images(request.images())
+            .isQuestion(false)
+            .isBlindWriter(request.isBlindWriter())
+            .sopticleUrl(request.link())
+            .comments(new ArrayList<>())
+            .build());
     }
 
     @Transactional

--- a/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostRetriever.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostRetriever.java
@@ -1,13 +1,14 @@
 package org.sopt.makers.internal.community.service.post;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.makers.internal.community.domain.CommunityPost;
 import org.sopt.makers.internal.community.domain.CommunityPostLike;
 import org.sopt.makers.internal.community.repository.post.CommunityPostLikeRepository;
-import org.sopt.makers.internal.community.domain.CommunityPost;
+import org.sopt.makers.internal.community.repository.post.CommunityPostRepository;
 import org.sopt.makers.internal.exception.BadRequestException;
 import org.sopt.makers.internal.exception.NotFoundException;
-import org.sopt.makers.internal.community.repository.post.CommunityPostRepository;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -16,9 +17,10 @@ public class CommunityPostRetriever {
     private final CommunityPostRepository communityPostRepository;
     private final CommunityPostLikeRepository communityPostLikeRepository;
 
+    @Transactional(readOnly = true)
     public CommunityPost findCommunityPostById(Long postId) {
-        return communityPostRepository.findById(postId)
-                .orElseThrow(() -> new NotFoundException("존재하지 않는 게시글의 id값 입니다."));
+        return communityPostRepository.findByIdWithCategoryAndMember(postId)
+            .orElseThrow(() -> new NotFoundException("존재하지 않는 게시글의 id값 입니다."));
     }
 
     public void checkExistsCommunityPostById(Long postId) {
@@ -35,6 +37,6 @@ public class CommunityPostRetriever {
 
     public CommunityPostLike findCommunityPostLike(Long memberId, Long postId) {
         return communityPostLikeRepository.findCommunityPostLikeByMemberIdAndPostId(memberId, postId)
-                .orElseThrow(() -> new NotFoundException("이 게시물에는 아직 좋아요를 누르지 않았습니다."));
+            .orElseThrow(() -> new NotFoundException("이 게시물에는 아직 좋아요를 누르지 않았습니다."));
     }
 }

--- a/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostService.java
@@ -651,10 +651,11 @@ public class CommunityPostService {
             AnonymousProfile anonymousProfile = anonymousProfileMap.get(postId);
             InternalUserDetails userDetails = userDetailsMap.get(authorId);
 
-            if (
-                userDetails == null
-                    && !(Boolean.TRUE.equals(post.getIsBlindWriter()) && anonymousProfile != null)
-            ) {
+            if (Boolean.TRUE.equals(post.getIsBlindWriter()) && anonymousProfile == null) {
+                continue;
+            }
+
+            if (!Boolean.TRUE.equals(post.getIsBlindWriter()) && userDetails == null) {
                 continue;
             }
 
@@ -733,21 +734,34 @@ public class CommunityPostService {
             ? "https://playground.sopt.org/?feed="
             : "https://sopt-internal-dev.pages.dev/?feed=";
 
-        return IntStream.range(0, posts.size())
-            .mapToObj(index -> {
-                CommunityPost post = posts.get(index);
-                Long authorId = post.getMember().getId();
+        List<InternalPopularPostResponse> responses = new ArrayList<>();
+        int rank = 1;
 
-                return communityResponseMapper.toInternalPopularPostResponse(
-                    post,
-                    anonymousProfileMap.get(post.getId()),
-                    userDetailsMap.get(authorId),
-                    resolveRootCategoryName(post.getCategory()),
-                    index + 1,
-                    baseUrl
-                );
-            })
-            .toList();
+        for (CommunityPost post : posts) {
+            Long authorId = post.getMember().getId();
+
+            AnonymousProfile anonymousProfile = anonymousProfileMap.get(post.getId());
+            InternalUserDetails userDetails = userDetailsMap.get(authorId);
+
+            if (Boolean.TRUE.equals(post.getIsBlindWriter()) && anonymousProfile == null) {
+                continue;
+            }
+
+            if (!Boolean.TRUE.equals(post.getIsBlindWriter()) && userDetails == null) {
+                continue;
+            }
+
+            responses.add(communityResponseMapper.toInternalPopularPostResponse(
+                post,
+                anonymousProfile,
+                userDetails,
+                resolveRootCategoryName(post.getCategory()),
+                rank++,
+                baseUrl
+            ));
+        }
+
+        return responses;
     }
 
     private List<CommunityPost> getPopularPostsBase(int limitCount) {

--- a/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostService.java
@@ -7,12 +7,12 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
@@ -23,11 +23,19 @@ import org.sopt.makers.internal.community.domain.CommunityPostLike;
 import org.sopt.makers.internal.community.domain.ReportPost;
 import org.sopt.makers.internal.community.domain.anonymous.AnonymousProfile;
 import org.sopt.makers.internal.community.domain.category.Category;
+import org.sopt.makers.internal.community.domain.enums.CommunityCategoryCode;
+import org.sopt.makers.internal.community.domain.enums.CommunityCategoryGroup;
+import org.sopt.makers.internal.community.domain.enums.CommunityPostListCategory;
+import org.sopt.makers.internal.community.domain.enums.CommunityPostListFilter;
+import org.sopt.makers.internal.community.domain.enums.CommunityPostSourceType;
 import org.sopt.makers.internal.community.dto.CategoryPostMemberDao;
+import org.sopt.makers.internal.community.dto.CommunityDbCursor;
+import org.sopt.makers.internal.community.dto.CommunityFeedCursor;
 import org.sopt.makers.internal.community.dto.CommunityPostMemberVo;
 import org.sopt.makers.internal.community.dto.MemberVo;
 import org.sopt.makers.internal.community.dto.PostCategoryDao;
 import org.sopt.makers.internal.community.dto.PostDetailData;
+import org.sopt.makers.internal.community.dto.comment.CommentInfo;
 import org.sopt.makers.internal.community.dto.request.MentionRequest;
 import org.sopt.makers.internal.community.dto.request.PostSaveRequest;
 import org.sopt.makers.internal.community.dto.request.PostUpdateRequest;
@@ -52,10 +60,18 @@ import org.sopt.makers.internal.community.repository.post.DeletedCommunityPostRe
 import org.sopt.makers.internal.community.service.SopticleScrapedService;
 import org.sopt.makers.internal.community.service.anonymous.AnonymousProfileService;
 import org.sopt.makers.internal.community.service.category.CategoryRetriever;
+import org.sopt.makers.internal.community.service.category.CommunityCategoryPolicy;
+import org.sopt.makers.internal.community.service.comment.CommunityCommentLikeService;
+import org.sopt.makers.internal.community.service.comment.CommunityCommentService;
+import org.sopt.makers.internal.community.service.member.CommunityMemberVoAssembler;
 import org.sopt.makers.internal.exception.PlaygroundException;
 import org.sopt.makers.internal.exception.BadRequestException;
-import org.sopt.makers.internal.external.makers.CrewPostListResponse;
-import org.sopt.makers.internal.external.makers.MakersCrewClient;
+import org.sopt.makers.internal.community.service.post.crew.CachedCrewPost;
+import org.sopt.makers.internal.community.service.post.crew.CrewMeetingCandidate;
+import org.sopt.makers.internal.community.service.post.crew.CrewMeetingFeedCache;
+import org.sopt.makers.internal.community.service.post.crew.CrewMeetingFeedCacheService;
+import org.sopt.makers.internal.community.service.post.crew.CrewMeetingFetchResult;
+import org.sopt.makers.internal.external.makers.CrewPost;
 import org.sopt.makers.internal.external.platform.InternalUserDetails;
 import org.sopt.makers.internal.external.platform.PlatformService;
 import org.sopt.makers.internal.external.platform.SoptActivity;
@@ -81,8 +97,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Duration;
 import java.time.format.DateTimeFormatter;
 
-import static java.util.stream.Collectors.*;
-
 @Slf4j
 @RequiredArgsConstructor
 @Service
@@ -93,8 +107,8 @@ public class CommunityPostService {
     private final VoteService voteService;
     private final ApplicationEventPublisher eventPublisher;
     private final PlatformService platformService;
-    private final MakersCrewClient makersCrewClient;
     private final RedisTemplate<String, Object> redisTemplate;
+    private final CrewMeetingFeedCacheService crewMeetingFeedCacheService;
 
     private final CommunityPostModifier communityPostModifier;
 
@@ -102,6 +116,7 @@ public class CommunityPostService {
     private final CategoryRetriever categoryRetriever;
     private final CommunityPostRetriever communityPostRetriever;
     private final MemberCareerRetriever memberCareerRetriever;
+    private final CommunityMemberVoAssembler communityMemberVoAssembler;
 
     private final CommunityCommentRepository communityCommentRepository;
     private final CommunityPostLikeRepository communityPostLikeRepository;
@@ -113,8 +128,14 @@ public class CommunityPostService {
     private final MemberBlockRepository memberBlockRepository;
     private final AnonymousProfileRetriever anonymousProfileRetriever;
 
+    private final CommunityCommentService communityCommentService;
+    private final CommunityCommentLikeService commentLikeService;
+
     private final CommunityMapper communityMapper;
     private final CommunityResponseMapper communityResponseMapper;
+
+    private final CommunityFeedCursorCodec communityFeedCursorCodec;
+    private final CommunityCategoryPolicy communityCategoryPolicy;
 
     private final SlackMessageUtil slackMessageUtil;
     private final SlackClient slackClient;
@@ -124,45 +145,270 @@ public class CommunityPostService {
 
     private final ZoneId KST = ZoneId.of("Asia/Seoul");
     private static final int MIN_POINTS_FOR_HOT_POST = 10;
-    private static final long SOPTICLE_CATEGORY_ID = 21;
-    private static final long MEETING_CATEGORY_ID = 24L;
+
+    private static final int HOME_PREVIEW_LIMIT = 3;
+    private static final int POPULAR_LOOKBACK_DAYS = 30;
+    private static final int POPULAR_COMMENT_WEIGHT = 5;
+    private static final int POPULAR_LIKE_WEIGHT = 3;
+    private static final int POPULAR_MEETING_MAX_PAGE = 2;
 
     private static final String VIEW_COUNT_PREFIX = "post:view:";
     private static final Duration VIEW_COUNT_TTL = Duration.ofHours(24);
 
-    @Transactional(readOnly = true)
-    public PostAllResponse getMeetingPosts(Long userId, Integer page, Integer take) {
-        CrewPostListResponse crewResponse = makersCrewClient.getPosts(userId, page, take);
+    private record FeedCandidate(
+        CommunityPostSourceType sourceType,
+        LocalDateTime createdAt,
+        Long communityPostId,
+        Integer meetingConsumedCount,
+        PostResponse response
+    ) {
+    }
 
-        List<PostResponse> postResponses = crewResponse.posts().stream()
-                .map(crewPost -> communityResponseMapper.toPostResponse(crewPost, userId))
-                .collect(Collectors.toList());
+    private record PopularPreviewCandidate(
+        CommunityPostSourceType sourceType,
+        int score,
+        LocalDateTime createdAt,
+        Long id,
+        PopularPostResponse response
+    ) {
+    }
 
-        return new PostAllResponse(
-                MEETING_CATEGORY_ID,
-                crewResponse.pageMeta().hasNextPage(),
-                postResponses
+    private record RecentPreviewCandidate(
+        CommunityPostSourceType sourceType,
+        LocalDateTime createdAt,
+        Long id,
+        RecentPostResponse response
+    ) {
+    }
+
+    // 커뮤니티글 목록 조회 entrypoint
+    public PostAllResponse getPosts(
+        Long userId,
+        CommunityPostListCategory category,
+        CommunityPostListFilter filter,
+        Boolean isBlockedOn,
+        Integer limit,
+        String cursor
+    ) {
+        int normalizedLimit = normalizeLimit(limit);
+        CommunityFeedCursor decodedCursor = communityFeedCursorCodec.decodeOrInitial(cursor);
+
+        List<CommunityCategoryCode> categoryCodes = communityCategoryPolicy.resolveCategoryCodes(category, filter);
+
+        if (category == CommunityPostListCategory.FREE) {
+            return getFreePostsWithMeetingPosts(
+                userId,
+                isBlockedOn,
+                normalizedLimit,
+                decodedCursor,
+                categoryCodes
+            );
+        }
+
+        return getCommunityOnlyPosts(
+            userId,
+            category,
+            isBlockedOn,
+            normalizedLimit,
+            decodedCursor,
+            categoryCodes
         );
     }
 
-    @Transactional(readOnly = true)
-    public List<CommunityPostMemberVo> getAllPosts(Long categoryId, Boolean isBlockedOn, Long memberId, Integer limit, Long cursor) {
-        if (limit == null || limit >= 50) limit = 50;
-        categoryRetriever.checkExistsCategoryById(categoryId);
+    // Playground DB 글만 조회
+    private PostAllResponse getCommunityOnlyPosts(
+        Long userId,
+        CommunityPostListCategory category,
+        Boolean isBlockedOn,
+        Integer limit,
+        CommunityFeedCursor cursor,
+        List<CommunityCategoryCode> categoryCodes
+    ) {
+        List<CategoryPostMemberDao> postDaos = communityQueryRepository.findPostsByCategoryCodes(
+            categoryCodes,
+            cursor.community(),
+            cursor.snapshotTime(),
+            limit + 1,
+            userId,
+            isBlockedOn
+        );
 
-        List<CategoryPostMemberDao> posts = communityQueryRepository.findAllParentCategoryPostByCursor(categoryId, limit, cursor, memberId, isBlockedOn);
+        boolean hasNext = postDaos.size() > limit;
 
-        return posts.stream()
-                .map(postDao -> {
-                    val authorDetails = platformService.getInternalUser(postDao.member().getId());
-                    val authorCareer = memberCareerRetriever.findMemberLastCareerByMemberId(postDao.member().getId());
-                    val voteResponse = voteService.getVoteByPostId(postDao.post().getId(), memberId);
-                    val memberVo = MemberVo.of(authorDetails, authorCareer);
-                    val categoryVo = communityResponseMapper.toCategoryResponse(postDao.category());
-                    val postVo = communityResponseMapper.toPostVo(postDao.post(), voteResponse);
-                    return new CommunityPostMemberVo(memberVo, postVo, categoryVo);
-                })
-                .toList();
+        List<CategoryPostMemberDao> slicedPostDaos = hasNext
+            ? postDaos.subList(0, limit)
+            : postDaos;
+
+        List<CommunityPostMemberVo> postVos = toCommunityPostMemberVos(slicedPostDaos, userId);
+        List<PostResponse> responses = toPostResponses(postVos, userId, isBlockedOn);
+
+        CommunityDbCursor nextDbCursor = null;
+
+        if (!slicedPostDaos.isEmpty()) {
+            CommunityPost lastPost = slicedPostDaos.get(slicedPostDaos.size() - 1).post();
+            nextDbCursor = new CommunityDbCursor(lastPost.getCreatedAt(), lastPost.getId());
+        }
+
+        String nextCursor = null;
+
+        if (hasNext && nextDbCursor != null) {
+            nextCursor = communityFeedCursorCodec.encode(
+                new CommunityFeedCursor(
+                    cursor.snapshotTime(),
+                    nextDbCursor,
+                    cursor.safeMeetingConsumedCount()
+                )
+            );
+        }
+
+        return new PostAllResponse(category, hasNext, nextCursor, responses);
+    }
+
+    // 자유 + 모임(Crew) merge 조회
+    private PostAllResponse getFreePostsWithMeetingPosts(
+        Long userId,
+        Boolean isBlockedOn,
+        Integer limit,
+        CommunityFeedCursor cursor,
+        List<CommunityCategoryCode> freeCategoryCodes
+    ) {
+        List<CategoryPostMemberDao> communityPostDaos = communityQueryRepository.findPostsByCategoryCodes(
+            freeCategoryCodes,
+            cursor.community(),
+            cursor.snapshotTime(),
+            limit + 1,
+            userId,
+            isBlockedOn
+        );
+
+        List<CommunityPostMemberVo> communityPostVos = toCommunityPostMemberVos(communityPostDaos, userId);
+        List<PostResponse> communityResponses = toPostResponses(communityPostVos, userId, isBlockedOn);
+
+        CrewMeetingFetchResult meetingFetchResult = fetchMeetingResponses(
+            userId,
+            cursor.snapshotTime(),
+            cursor.safeMeetingConsumedCount(),
+            limit + 1
+        );
+
+        List<FeedCandidate> candidates = new ArrayList<>();
+
+        for (int index = 0; index < communityResponses.size(); index++) {
+            CommunityPost post = communityPostDaos.get(index).post();
+
+            candidates.add(new FeedCandidate(
+                CommunityPostSourceType.COMMUNITY,
+                post.getCreatedAt(),
+                post.getId(),
+                null,
+                communityResponses.get(index)
+            ));
+        }
+
+        for (CrewMeetingCandidate meetingCandidate : meetingFetchResult.candidates()) {
+            candidates.add(new FeedCandidate(
+                CommunityPostSourceType.MEETING,
+                meetingCandidate.createdAt(),
+                null,
+                meetingCandidate.nextConsumedCount(),
+                meetingCandidate.response()
+            ));
+        }
+
+        List<FeedCandidate> sortedCandidates = candidates.stream()
+            .sorted(
+                Comparator.comparing(FeedCandidate::createdAt)
+                    .reversed()
+                    .thenComparing(candidate -> candidate.sourceType().name())
+                    .thenComparing(candidate -> candidate.response().id(), Comparator.reverseOrder())
+            )
+            .toList();
+
+        boolean hasNext = sortedCandidates.size() > limit || meetingFetchResult.hasMore();
+
+        List<FeedCandidate> slicedCandidates = sortedCandidates.size() > limit
+            ? sortedCandidates.subList(0, limit)
+            : sortedCandidates;
+
+        List<PostResponse> responses = slicedCandidates.stream()
+            .map(FeedCandidate::response)
+            .toList();
+
+        CommunityDbCursor nextDbCursor = cursor.community();
+        int nextMeetingConsumedCount = cursor.safeMeetingConsumedCount();
+
+        Optional<FeedCandidate> lastCommunityCandidate = slicedCandidates.stream()
+            .filter(candidate -> candidate.sourceType() == CommunityPostSourceType.COMMUNITY)
+            .reduce((previous, current) -> current);
+
+        if (lastCommunityCandidate.isPresent()) {
+            FeedCandidate candidate = lastCommunityCandidate.get();
+            nextDbCursor = new CommunityDbCursor(candidate.createdAt(), candidate.communityPostId());
+        }
+
+        Optional<FeedCandidate> lastMeetingCandidate = slicedCandidates.stream()
+            .filter(candidate -> candidate.sourceType() == CommunityPostSourceType.MEETING)
+            .reduce((previous, current) -> current);
+
+        if (lastMeetingCandidate.isPresent()) {
+            nextMeetingConsumedCount = lastMeetingCandidate.get().meetingConsumedCount();
+        }
+
+        String nextCursor = null;
+
+        if (hasNext) {
+            nextCursor = communityFeedCursorCodec.encode(
+                new CommunityFeedCursor(
+                    cursor.snapshotTime(),
+                    nextDbCursor,
+                    nextMeetingConsumedCount
+                )
+            );
+        }
+
+        return new PostAllResponse(
+            CommunityPostListCategory.FREE,
+            hasNext,
+            nextCursor,
+            responses
+        );
+    }
+
+    // Crew 모임 글 fetch
+    private CrewMeetingFetchResult fetchMeetingResponses(
+        Long userId,
+        LocalDateTime snapshotTime,
+        int alreadyConsumedCount,
+        int requiredCount
+    ) {
+        CrewMeetingFeedCache cache = crewMeetingFeedCacheService.getOrBuildCache(
+            userId,
+            snapshotTime,
+            alreadyConsumedCount + requiredCount
+        );
+
+        List<CachedCrewPost> cachedPosts = cache.safePosts();
+
+        int fromIndex = Math.min(alreadyConsumedCount, cachedPosts.size());
+        int toIndex = Math.min(fromIndex + requiredCount, cachedPosts.size());
+
+        List<CrewMeetingCandidate> candidates = new ArrayList<>();
+
+        for (int index = fromIndex; index < toIndex; index++) {
+            CachedCrewPost cachedCrewPost = cachedPosts.get(index);
+            CrewPost crewPost = cachedCrewPost.toCrewPost();
+            PostResponse response = communityResponseMapper.toPostResponse(crewPost, userId);
+
+            candidates.add(new CrewMeetingCandidate(
+                crewPost.createdDate(),
+                index + 1,
+                response
+            ));
+        }
+
+        boolean hasMore = cache.hasMorePage() || cachedPosts.size() > toIndex;
+
+        return new CrewMeetingFetchResult(candidates, hasMore);
     }
 
     @Transactional(readOnly = true)
@@ -225,22 +471,36 @@ public class CommunityPostService {
     public PostUpdateResponse updatePost(Long writerId, PostUpdateRequest request) {
         Member member = memberRetriever.findMemberById(writerId);
         CommunityPost post = communityPostRetriever.findCommunityPostById(request.postId());
-        categoryRetriever.checkExistsCategoryById(request.categoryId());
+        Category category = categoryRetriever.findActiveCategoryByCode(request.categoryCode());
+
         validatePostOwner(member.getId(), post.getMember().getId());
 
-        if (isSopticleCategory(request.categoryId())) {
+        if (communityCategoryPolicy.isSopticleCategoryCode(category.getCode())) {
             SopticleScrapedResponse scrapedResponse = sopticleScrapedService.getSopticleMetaData(request.link());
-            post.updatePost(request.categoryId(), scrapedResponse.title(), scrapedResponse.description(), List.of(scrapedResponse.thumbnailUrl()),
-                            request.isQuestion(), request.isBlindWriter(), scrapedResponse.url());
+
+            post.updatePost(
+                category,
+                scrapedResponse.title(),
+                scrapedResponse.description(),
+                List.of(scrapedResponse.thumbnailUrl()),
+                false,
+                scrapedResponse.url()
+            );
         } else {
-            post.updatePost(request.categoryId(), request.title(), request.content(), request.images(),
-                            request.isQuestion(), request.isBlindWriter(), "");
+            post.updatePost(
+                category,
+                request.title(),
+                request.content(),
+                request.images(),
+                request.isBlindWriter(),
+                ""
+            );
         }
 
         communityPostRepository.save(post);
 
-        if(Objects.nonNull(request.mention())) {
-            sendMentionPushNotification(post.getTitle(), request.isBlindWriter(), request.mention());
+        if (Objects.nonNull(request.mention())) {
+            sendMentionPushNotification(post.getTitle(), post.getIsBlindWriter(), request.mention());
         }
 
         return communityResponseMapper.toPostUpdateResponse(post);
@@ -350,53 +610,144 @@ public class CommunityPostService {
     }
 
     @Transactional(readOnly = true)
-    public PostCategoryDao getRecentPostByCategory(String category) {
-        return communityPostRepository.findRecentPostByCategory(category);
+    public PostCategoryDao getRecentPostByCategoryGroup(CommunityCategoryGroup categoryGroup) {
+        return communityPostRepository.findRecentPostByCategoryGroup(categoryGroup);
     }
 
     @Transactional(readOnly = true)
-    public List<PopularPostResponse> getPopularPosts(int limitCount) {
-        List<CommunityPost> posts = getPopularPostsBase(limitCount);
+    public List<PopularPostResponse> getPopularPosts(Long userId, int limitCount) {
+        int normalizedLimit = normalizePreviewLimit(limitCount);
 
-        Map<Long, String> categoryNameMap = categoryRetriever.getAllCategories().stream()
-                .collect(Collectors.toMap(Category::getId, Category::getName));
-        Map<Long, AnonymousProfile> anonymousProfileMap = getAnonymousProfileMap(posts);
+        LocalDateTime snapshotTime = LocalDateTime.now()
+            .withSecond(0)
+            .withNano(0);
 
-        return posts.stream()
-                .map(post -> {
-                    val authorDetails = platformService.getInternalUser(post.getMember().getId());
-                    val anonymousProfile = anonymousProfileMap.get(post.getId());
-                    String categoryName = categoryNameMap.getOrDefault(post.getCategoryId(), "");
-                    return communityResponseMapper.toPopularPostResponse(post, anonymousProfile, authorDetails, categoryName);
-                })
-                .toList();
+        LocalDateTime since = snapshotTime.minusDays(POPULAR_LOOKBACK_DAYS);
+
+        List<CommunityPost> communityPosts = communityQueryRepository.findPopularCandidatePosts(since);
+
+        Map<Long, AnonymousProfile> anonymousProfileMap = getAnonymousProfileMap(communityPosts);
+
+        List<Long> postIds = communityPosts.stream()
+            .map(CommunityPost::getId)
+            .toList();
+
+        Map<Long, Integer> postLikeCountMap = getPostLikeCountMap(postIds);
+        Map<Long, Integer> postCommentCountMap = getPostCommentCountMap(postIds);
+
+        List<Long> authorIds = communityPosts.stream()
+            .map(post -> post.getMember().getId())
+            .distinct()
+            .toList();
+
+        Map<Long, InternalUserDetails> userDetailsMap = platformService.getInternalUserDetailsMap(authorIds);
+
+        List<PopularPreviewCandidate> candidates = new ArrayList<>();
+
+        for (CommunityPost post : communityPosts) {
+            Long postId = post.getId();
+            Long authorId = post.getMember().getId();
+
+            AnonymousProfile anonymousProfile = anonymousProfileMap.get(postId);
+            InternalUserDetails userDetails = userDetailsMap.get(authorId);
+
+            if (
+                userDetails == null
+                    && !(Boolean.TRUE.equals(post.getIsBlindWriter()) && anonymousProfile != null)
+            ) {
+                continue;
+            }
+
+            int likeCount = postLikeCountMap.getOrDefault(postId, 0);
+            int commentCount = postCommentCountMap.getOrDefault(postId, 0);
+            int score = calculatePopularScore(post.getHits(), commentCount, likeCount);
+
+            PopularPostResponse response = communityResponseMapper.toPopularPostResponse(
+                post,
+                anonymousProfile,
+                userDetails,
+                likeCount,
+                commentCount,
+                communityCategoryPolicy.resolvePreviewTag(post.getCategory())
+            );
+
+            candidates.add(new PopularPreviewCandidate(
+                CommunityPostSourceType.COMMUNITY,
+                score,
+                post.getCreatedAt(),
+                post.getId(),
+                response
+            ));
+        }
+
+        List<CrewPost> meetingPosts = getMeetingPostsForPopular(userId, since, snapshotTime);
+
+        for (CrewPost crewPost : meetingPosts) {
+            int score = calculatePopularScore(
+                crewPost.viewCount(),
+                crewPost.commentCount(),
+                crewPost.likeCount()
+            );
+
+            candidates.add(new PopularPreviewCandidate(
+                CommunityPostSourceType.MEETING,
+                score,
+                crewPost.createdDate(),
+                crewPost.id(),
+                communityResponseMapper.toPopularPostResponse(crewPost)
+            ));
+        }
+
+        return candidates.stream()
+            .sorted(
+                Comparator.comparingInt(PopularPreviewCandidate::score)
+                    .reversed()
+                    .thenComparing(PopularPreviewCandidate::createdAt, Comparator.reverseOrder())
+                    .thenComparing(candidate -> candidate.sourceType().name())
+                    .thenComparing(PopularPreviewCandidate::id, Comparator.reverseOrder())
+            )
+            .limit(normalizedLimit)
+            .map(PopularPreviewCandidate::response)
+            .toList();
+    }
+
+    private int calculatePopularScore(int viewCount, int commentCount, int likeCount) {
+        return viewCount
+            + commentCount * POPULAR_COMMENT_WEIGHT
+            + likeCount * POPULAR_LIKE_WEIGHT;
     }
 
     @Transactional(readOnly = true)
     public List<InternalPopularPostResponse> getPopularPostsForInternal(int limitCount) {
         List<CommunityPost> posts = getPopularPostsBase(limitCount);
-
-        Map<Long, String> categoryNameMap = getCategoryNameMap(posts);
         Map<Long, AnonymousProfile> anonymousProfileMap = getAnonymousProfileMap(posts);
 
+        List<Long> authorIds = posts.stream()
+            .map(post -> post.getMember().getId())
+            .distinct()
+            .toList();
+
+        Map<Long, InternalUserDetails> userDetailsMap = platformService.getInternalUserDetailsMap(authorIds);
+
         String baseUrl = activeProfile.equals("prod")
-                ? "https://playground.sopt.org/?feed="
-                : "https://sopt-internal-dev.pages.dev/?feed=";
+            ? "https://playground.sopt.org/?feed="
+            : "https://sopt-internal-dev.pages.dev/?feed=";
 
         return IntStream.range(0, posts.size())
-                .mapToObj(idx -> {
-                    CommunityPost post = posts.get(idx);
-                    InternalUserDetails userDetails = platformService.getInternalUser(post.getMember().getId());
-                    return communityResponseMapper.toInternalPopularPostResponse(
-                            post,
-                            anonymousProfileMap.get(post.getId()),
-                            userDetails,
-                            categoryNameMap.get(post.getCategoryId()),
-                            idx + 1,
-                            baseUrl
-                    );
-                })
-                .toList();
+            .mapToObj(index -> {
+                CommunityPost post = posts.get(index);
+                Long authorId = post.getMember().getId();
+
+                return communityResponseMapper.toInternalPopularPostResponse(
+                    post,
+                    anonymousProfileMap.get(post.getId()),
+                    userDetailsMap.get(authorId),
+                    resolveRootCategoryName(post.getCategory()),
+                    index + 1,
+                    baseUrl
+                );
+            })
+            .toList();
     }
 
     private List<CommunityPost> getPopularPostsBase(int limitCount) {
@@ -426,83 +777,306 @@ public class CommunityPostService {
 
     @Transactional(readOnly = true)
     public List<SopticlePostResponse> getRecentSopticlePosts() {
-        List<CommunityPost> posts = communityPostRepository.findTop5ByCategoryIdOrderByCreatedAtDesc(SOPTICLE_CATEGORY_ID);
+        List<CommunityCategoryCode> sopticleCodes = communityCategoryPolicy.resolveCategoryCodes(
+            CommunityPostListCategory.SOPTICLE,
+            CommunityPostListFilter.ALL
+        );
+
+        List<CommunityPost> posts = communityPostRepository
+            .findTop5ByCategory_CodeInOrderByCreatedAtDesc(sopticleCodes);
+
+        List<Long> authorIds = posts.stream()
+            .map(post -> post.getMember().getId())
+            .distinct()
+            .toList();
+
+        Map<Long, MemberVo> memberVoMap = communityMemberVoAssembler.getMemberVoMap(authorIds);
+
         return posts.stream()
-                .map(post -> {
-                    val authorDetails = platformService.getInternalUser(post.getMember().getId());
-                    val authorCareer = memberCareerRetriever.findMemberLastCareerByMemberId(post.getMember().getId());
-                    val memberVo = MemberVo.of(authorDetails, authorCareer);
-                    return communityResponseMapper.toSopticlePostResponse(post, memberVo);
-                })
-                .toList();
+            .map(post -> {
+                Long authorId = post.getMember().getId();
+                return communityResponseMapper.toSopticlePostResponse(post, memberVoMap.get(authorId));
+            })
+            .toList();
     }
 
     @Transactional(readOnly = true)
     public List<RecentPostResponse> getRecentPosts(Long memberId) {
-        List<CommunityPost> posts = communityPostRepository.findTop5ByCategoryIdNotOrderByCreatedAtDesc(SOPTICLE_CATEGORY_ID);
+        List<CommunityPost> communityPosts = communityPostRepository
+            .findTop3ByCategory_CategoryGroupInOrderByCreatedAtDesc(
+                List.of(CommunityCategoryGroup.FREE, CommunityCategoryGroup.PROMOTION)
+            );
 
-        Map<Long, Category> categoryMap = getCategoryMap(posts); //n+1 문제 방지를 위해 미리 카테고리 조회
+        List<Long> postIds = communityPosts.stream()
+            .map(CommunityPost::getId)
+            .toList();
 
-        return posts.stream()
-                .map(post -> {
-                    int likeCount = communityPostLikeRepository.countAllByPostId(post.getId());
-                    int commentCount = communityCommentRepository.countAllByPostIdAndIsDeleted(post.getId(), false);
-                    VoteResponse vote = voteService.getVoteByPostId(post.getId(), memberId);
-                    Integer totalVoteCount = Objects.nonNull(vote) ? vote.totalParticipants() : null;
-                    Category category = categoryMap.get(post.getCategoryId());
+        Map<Long, Integer> postLikeCountMap = getPostLikeCountMap(postIds);
+        Map<Long, Integer> postCommentCountMap = getPostCommentCountMap(postIds);
+        Map<Long, VoteResponse> voteResponseMap = voteService.getVoteMapByPostIds(postIds, memberId);
 
-                    Long categoryId = null;
-                    String categoryName = "";
+        List<RecentPreviewCandidate> candidates = new ArrayList<>();
 
-                    if (Objects.nonNull(category)) {
-                        categoryName = (category.getParent() != null) ? category.getParent().getName() : category.getName();
-                        categoryId = (category.getParent() != null) ? category.getParent().getId() : category.getId();
-                    }
+        for (CommunityPost post : communityPosts) {
+            Long postId = post.getId();
 
-                    return communityResponseMapper.toRecentPostResponse(
-                            post, likeCount, commentCount, categoryId, categoryName, totalVoteCount
-                    );
-                })
-                .toList();
+            VoteResponse vote = voteResponseMap.get(postId);
+            Integer totalVoteCount = Objects.nonNull(vote) ? vote.totalParticipants() : null;
+
+            RecentPostResponse response = communityResponseMapper.toRecentPostResponse(
+                post,
+                postLikeCountMap.getOrDefault(postId, 0),
+                postCommentCountMap.getOrDefault(postId, 0),
+                communityCategoryPolicy.resolvePreviewTag(post.getCategory()),
+                totalVoteCount
+            );
+
+            candidates.add(new RecentPreviewCandidate(
+                CommunityPostSourceType.COMMUNITY,
+                post.getCreatedAt(),
+                post.getId(),
+                response
+            ));
+        }
+
+        List<CrewPost> meetingPosts = getMeetingPostsForPreview(memberId, HOME_PREVIEW_LIMIT);
+
+        for (CrewPost crewPost : meetingPosts) {
+            candidates.add(new RecentPreviewCandidate(
+                CommunityPostSourceType.MEETING,
+                crewPost.createdDate(),
+                crewPost.id(),
+                communityResponseMapper.toRecentPostResponse(crewPost)
+            ));
+        }
+
+        return candidates.stream()
+            .sorted(
+                Comparator.comparing(RecentPreviewCandidate::createdAt)
+                    .reversed()
+                    .thenComparing(candidate -> candidate.sourceType().name())
+                    .thenComparing(RecentPreviewCandidate::id, Comparator.reverseOrder())
+            )
+            .limit(HOME_PREVIEW_LIMIT)
+            .map(RecentPreviewCandidate::response)
+            .toList();
     }
 
     @Transactional(readOnly = true)
     public List<InternalLatestPostResponse> getInternalLatestPosts() {
-        final List<Long> topLevelCategoryIds = List.of(1L, 22L, 4L, 2L, 21L);
+        List<CommunityPostListCategory> topLevelCategories = List.of(
+            CommunityPostListCategory.FREE,
+            CommunityPostListCategory.PROMOTION,
+            CommunityPostListCategory.SOPTICLE
+        );
 
-        Map<Long, String> categoryNameMap = categoryRetriever.findAllByIds(topLevelCategoryIds).stream()
-                .collect(toMap(Category::getId, Category::getName));
+        List<CommunityPost> latestPosts = new ArrayList<>();
+
+        for (CommunityPostListCategory listCategory : topLevelCategories) {
+            List<CommunityCategoryCode> categoryCodes = communityCategoryPolicy.resolveCategoryCodes(
+                listCategory,
+                listCategory == CommunityPostListCategory.FREE ? null : CommunityPostListFilter.ALL
+            );
+
+            communityPostRepository.findFirstByCategory_CodeInOrderByCreatedAtDesc(categoryCodes)
+                .ifPresent(latestPosts::add);
+        }
+
+        List<Long> authorIds = latestPosts.stream()
+            .map(post -> post.getMember().getId())
+            .distinct()
+            .toList();
+
+        Map<Long, InternalUserDetails> userDetailsMap =
+            platformService.getInternalUserDetailsMap(authorIds);
+
+        Map<Long, AnonymousProfile> anonymousProfileMap =
+            getAnonymousProfileMap(latestPosts);
 
         List<InternalLatestPostResponse> responses = new ArrayList<>();
 
         String baseUrl = activeProfile.equals("prod")
-                ? "https://playground.sopt.org/?feed="
-                : "https://sopt-internal-dev.pages.dev/?feed=";
+            ? "https://playground.sopt.org/?feed="
+            : "https://sopt-internal-dev.pages.dev/?feed=";
 
-        for (Long categoryId : topLevelCategoryIds) {
-            List<Long> allCategoryIds = categoryRetriever.findAllDescendantIds(categoryId);
+        for (CommunityPost post : latestPosts) {
+            Long authorId = post.getMember().getId();
+            InternalUserDetails userDetails = userDetailsMap.get(authorId);
 
-            Optional<CommunityPost> postOptional = communityPostRepository.findFirstByCategoryIdInOrderByCreatedAtDesc(allCategoryIds);
+            if (userDetails == null) {
+                continue;
+            }
 
-            postOptional.ifPresent(post -> {
-                InternalUserDetails userDetails = platformService.getInternalUser(post.getMember().getId());
-                // 같은 generation에서 메이커스 활동 우선 (isSopt=false가 메이커스)
-                SoptActivity latestActivity = userDetails.soptActivities().stream()
-                        .max(Comparator.comparing(SoptActivity::generation)
-                                .thenComparing(activity -> !activity.isSopt())) // 메이커스(false) 우선
-                        .orElse(null);
+            SoptActivity latestActivity = userDetails.soptActivities() == null
+                ? null
+                : userDetails.soptActivities().stream()
+                  .max(Comparator.comparing(SoptActivity::generation)
+                       .thenComparing(activity -> !activity.isSopt()))
+                  .orElse(null);
 
-                String categoryName = categoryNameMap.getOrDefault(categoryId, "");
+            String categoryName = resolveRootCategoryName(post.getCategory());
 
-                Optional<AnonymousProfile> anonymousProfile = Optional.empty();
-                if (post.getIsBlindWriter()) {
-                    anonymousProfile = anonymousProfileRetriever.findByPostId(post.getId());
-                }
+            Optional<AnonymousProfile> anonymousProfile = Boolean.TRUE.equals(post.getIsBlindWriter())
+                ? Optional.ofNullable(anonymousProfileMap.get(post.getId()))
+                : Optional.empty();
 
-                responses.add(InternalLatestPostResponse.of(post, latestActivity, userDetails, categoryName, anonymousProfile, baseUrl));
-            });
+            responses.add(InternalLatestPostResponse.of(
+                post,
+                latestActivity,
+                userDetails,
+                categoryName,
+                anonymousProfile,
+                baseUrl
+            ));
         }
+
         return responses;
+    }
+
+    private List<CommunityPostMemberVo> toCommunityPostMemberVos(
+        List<CategoryPostMemberDao> postDaos,
+        Long memberId
+    ) {
+        if (postDaos == null || postDaos.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> authorIds = postDaos.stream()
+            .map(postDao -> postDao.member().getId())
+            .distinct()
+            .toList();
+
+        List<Long> postIds = postDaos.stream()
+            .map(postDao -> postDao.post().getId())
+            .distinct()
+            .toList();
+
+        Map<Long, MemberVo> memberVoMap = communityMemberVoAssembler.getMemberVoMap(authorIds);
+        Map<Long, VoteResponse> voteResponseMap = voteService.getVoteMapByPostIds(postIds, memberId);
+
+        return postDaos.stream()
+            .map(postDao -> {
+                Long authorId = postDao.member().getId();
+                Long postId = postDao.post().getId();
+
+                val memberVo = memberVoMap.get(authorId);
+                val categoryVo = communityResponseMapper.toCategoryResponse(postDao.category());
+                val postVo = communityResponseMapper.toPostVo(
+                    postDao.post(),
+                    postDao.category(),
+                    voteResponseMap.get(postId)
+                );
+
+                return new CommunityPostMemberVo(memberVo, postVo, categoryVo);
+            })
+            .toList();
+    }
+
+    private List<PostResponse> toPostResponses(
+        List<CommunityPostMemberVo> posts,
+        Long userId,
+        Boolean isBlockedOn
+    ) {
+        if (posts == null || posts.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> postIds = posts.stream()
+            .map(post -> post.post().id())
+            .toList();
+
+        Map<Long, List<CommentInfo>> postCommentsMap = communityCommentService.getPostCommentMap(
+            postIds,
+            userId,
+            isBlockedOn
+        );
+
+        List<Long> allCommentIds = postCommentsMap.values().stream()
+            .flatMap(List::stream)
+            .map(commentInfo -> commentInfo.commentDao().comment().getId())
+            .toList();
+
+        Map<Long, Boolean> commentLikedMap = commentLikeService.getLikedMapByCommentIds(userId, allCommentIds);
+        Map<Long, Integer> commentLikeCountMap = commentLikeService.getLikeCountMapByCommentIds(allCommentIds);
+
+        Map<Long, AnonymousProfile> anonymousPostProfileMap = communityQueryRepository.getAnonymousProfilesByPostId(postIds);
+        Map<Long, Boolean> postLikedMap = getPostLikedMap(userId, postIds);
+        Map<Long, Integer> postLikeCountMap = getPostLikeCountMap(postIds);
+
+        return posts.stream()
+            .map(post -> {
+                Long postId = post.post().id();
+
+                List<CommentInfo> comments = postCommentsMap.getOrDefault(postId, List.of());
+                AnonymousProfile anonymousPostProfile = anonymousPostProfileMap.get(postId);
+                Boolean isLiked = postLikedMap.getOrDefault(postId, false);
+                Integer likes = postLikeCountMap.getOrDefault(postId, 0);
+
+                return communityResponseMapper.toPostResponse(
+                    post,
+                    comments,
+                    userId,
+                    anonymousPostProfile,
+                    isLiked,
+                    likes,
+                    commentLikedMap,
+                    commentLikeCountMap
+                );
+            })
+            .toList();
+    }
+
+    private Map<Long, Boolean> getPostLikedMap(Long userId, List<Long> postIds) {
+        if (postIds == null || postIds.isEmpty()) {
+            return Map.of();
+        }
+
+        List<Long> likedPostIds = communityPostLikeRepository.findLikedPostIdsByMemberIdAndPostIds(
+            userId,
+            postIds
+        );
+
+        Set<Long> likedPostIdSet = Set.copyOf(likedPostIds);
+
+        return postIds.stream()
+            .collect(Collectors.toMap(
+                postId -> postId,
+                likedPostIdSet::contains
+            ));
+    }
+
+    private Map<Long, Integer> getPostLikeCountMap(List<Long> postIds) {
+        if (postIds == null || postIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return communityPostLikeRepository.countLikesByPostIds(postIds).stream()
+            .collect(Collectors.toMap(
+                CommunityPostLikeRepository.PostLikeCountProjection::getPostId,
+                projection -> projection.getLikeCount().intValue()
+            ));
+    }
+
+    private Map<Long, Integer> getPostCommentCountMap(List<Long> postIds) {
+        if (postIds == null || postIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return communityCommentRepository.countCommentsByPostIds(postIds).stream()
+            .collect(Collectors.toMap(
+                CommunityCommentRepository.PostCommentCountProjection::getPostId,
+                projection -> projection.getCommentCount().intValue()
+            ));
+    }
+
+    private String resolveRootCategoryName(Category category) {
+        if (category == null) {
+            return "";
+        }
+
+        return category.getParent() == null
+            ? category.getName()
+            : category.getParent().getName();
     }
 
     private PostWithPoints createPostWithPoints(CommunityPost post) {
@@ -571,39 +1145,30 @@ public class CommunityPostService {
     }
 
     private CommunityPost createCommunityPostBasedOnCategory(Member member, PostSaveRequest request) {
-        if (isSopticleCategory(request.categoryId())) {
-            SopticleScrapedResponse scrapedResponse = sopticleScrapedService.getSopticleMetaData(request.link());
-            PostSaveRequest enrichedRequest = PostSaveRequest.builder()
-                    .categoryId(request.categoryId())
-                    .content(scrapedResponse.description())
-                    .images(List.of(scrapedResponse.thumbnailUrl()))
-                    .link(scrapedResponse.url())
-                    .title(scrapedResponse.title())
-                    .isBlindWriter(false)
-                    .isQuestion(false)
-                    .build();
-            return communityPostModifier.createCommunityPost(member, enrichedRequest);
-        } else {
-            return communityPostModifier.createCommunityPost(member, request);
-        }
-    }
+        Category category = categoryRetriever.findActiveCategoryByCode(request.categoryCode());
 
-    private boolean isSopticleCategory(Long categoryId) {
-        return categoryId == 21;
+        if (communityCategoryPolicy.isSopticleCategoryCode(category.getCode())) {
+            SopticleScrapedResponse scrapedResponse = sopticleScrapedService.getSopticleMetaData(request.link());
+
+            PostSaveRequest enrichedRequest = PostSaveRequest.builder()
+                .categoryCode(request.categoryCode())
+                .content(scrapedResponse.description())
+                .images(List.of(scrapedResponse.thumbnailUrl()))
+                .link(scrapedResponse.url())
+                .title(scrapedResponse.title())
+                .isBlindWriter(false)
+                .build();
+
+            return communityPostModifier.createCommunityPost(member, category, enrichedRequest);
+        }
+
+        return communityPostModifier.createCommunityPost(member, category, request);
     }
 
     private void validatePostOwner(Long memberId, Long postWriterId) {
         if (!Objects.equals(memberId, postWriterId)) {
             throw new BadRequestException("수정/삭제 권한이 없는 유저입니다.");
         }
-    }
-
-    private Map<Long, String> getCategoryNameMap(List<CommunityPost> posts) {
-        List<Long> categoryIds = posts.stream()
-                .map(CommunityPost::getCategoryId)
-                .distinct()
-                .toList();
-        return communityQueryRepository.getCategoryNamesByIds(categoryIds);
     }
 
     private Map<Long, AnonymousProfile> getAnonymousProfileMap(List<CommunityPost> posts) {
@@ -614,22 +1179,67 @@ public class CommunityPostService {
         return communityQueryRepository.getAnonymousProfilesByPostId(postIds);
     }
 
-    private Map<Long, Category> getCategoryMap(List<CommunityPost> posts) {
-        List<Long> categoryIds = posts.stream()
-                .map(CommunityPost::getCategoryId)
-                .distinct()
-                .toList();
-
-        if (categoryIds.isEmpty()) {
-            return Collections.emptyMap();
+    private List<CrewPost> getMeetingPostsForPreview(Long userId, int requiredCount) {
+        if (userId == null || requiredCount <= 0) {
+            return List.of();
         }
 
-        return categoryRetriever.findAllByIds(categoryIds).stream()
-                .collect(toMap(Category::getId, category -> category));
+        LocalDateTime snapshotTime = LocalDateTime.now()
+            .withSecond(0)
+            .withNano(0);
+
+        CrewMeetingFeedCache cache = crewMeetingFeedCacheService.getOrBuildPreviewCache(
+            userId,
+            snapshotTime,
+            requiredCount
+        );
+
+        return cache.safePosts().stream()
+            .limit(requiredCount)
+            .map(CachedCrewPost::toCrewPost)
+            .toList();
+    }
+
+    private List<CrewPost> getMeetingPostsForPopular(
+        Long userId,
+        LocalDateTime since,
+        LocalDateTime snapshotTime
+    ) {
+        if (userId == null) {
+            return List.of();
+        }
+
+        CrewMeetingFeedCache cache = crewMeetingFeedCacheService.getOrBuildPopularPreviewCache(
+            userId,
+            snapshotTime,
+            since,
+            POPULAR_MEETING_MAX_PAGE
+        );
+
+        return cache.safePosts().stream()
+            .map(CachedCrewPost::toCrewPost)
+            .filter(post -> !post.createdDate().isAfter(snapshotTime))
+            .filter(post -> !post.createdDate().isBefore(since))
+            .toList();
     }
 
     private String generateRedisKey(Long userId, Long postId) {
         String today = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE);
         return VIEW_COUNT_PREFIX + today + ":" + userId + ":" + postId;
+    }
+
+    private int normalizeLimit(Integer limit) {
+        if (limit == null || limit <= 0 || limit > 50) {
+            return 50;
+        }
+
+        return limit;
+    }
+
+    private int normalizePreviewLimit(int limit) {
+        if (limit <= 0 || limit > HOME_PREVIEW_LIMIT) {
+            return HOME_PREVIEW_LIMIT;
+        }
+        return limit;
     }
 }

--- a/src/main/java/org/sopt/makers/internal/community/service/post/crew/CachedCrewPost.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/post/crew/CachedCrewPost.java
@@ -1,0 +1,71 @@
+package org.sopt.makers.internal.community.service.post.crew;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.sopt.makers.internal.external.makers.CrewPost;
+
+public record CachedCrewPost(
+	long id,
+	String title,
+	String contents,
+	LocalDateTime createdDate,
+	List<String> images,
+	long userId,
+	long orgId,
+	String userName,
+	String profileImage,
+	String part,
+	int generation,
+	int likeCount,
+	boolean liked,
+	int viewCount,
+	int commentCount,
+	Long meetingId
+) {
+	public static CachedCrewPost from(CrewPost crewPost) {
+		CrewPost.CrewUser crewUser = crewPost.user();
+		CrewPost.PartInfo partInfo = crewUser.partInfo();
+
+		return new CachedCrewPost(
+			crewPost.id(),
+			crewPost.title(),
+			crewPost.contents(),
+			crewPost.createdDate(),
+			crewPost.images() == null ? List.of() : crewPost.images(),
+			crewUser.id(),
+			crewUser.orgId(),
+			crewUser.name(),
+			crewUser.profileImage(),
+			partInfo.part(),
+			partInfo.generation(),
+			crewPost.likeCount(),
+			crewPost.isLiked(),
+			crewPost.viewCount(),
+			crewPost.commentCount(),
+			crewPost.meetingId()
+		);
+	}
+
+	public CrewPost toCrewPost() {
+		return new CrewPost(
+			id,
+			title,
+			contents,
+			createdDate,
+			images == null ? List.of() : images,
+			new CrewPost.CrewUser(
+				userId,
+				orgId,
+				userName,
+				profileImage,
+				new CrewPost.PartInfo(part, generation)
+			),
+			likeCount,
+			liked,
+			viewCount,
+			commentCount,
+			meetingId
+		);
+	}
+}

--- a/src/main/java/org/sopt/makers/internal/community/service/post/crew/CrewMeetingCandidate.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/post/crew/CrewMeetingCandidate.java
@@ -1,0 +1,11 @@
+package org.sopt.makers.internal.community.service.post.crew;
+
+import java.time.LocalDateTime;
+import org.sopt.makers.internal.community.dto.response.PostResponse;
+
+public record CrewMeetingCandidate(
+	LocalDateTime createdAt,
+	Integer nextConsumedCount,
+	PostResponse response
+) {
+}

--- a/src/main/java/org/sopt/makers/internal/community/service/post/crew/CrewMeetingFeedCache.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/post/crew/CrewMeetingFeedCache.java
@@ -1,0 +1,16 @@
+package org.sopt.makers.internal.community.service.post.crew;
+
+import java.util.List;
+
+public record CrewMeetingFeedCache(
+	List<CachedCrewPost> posts,
+	boolean hasMorePage
+) {
+	public static CrewMeetingFeedCache empty() {
+		return new CrewMeetingFeedCache(List.of(), true);
+	}
+
+	public List<CachedCrewPost> safePosts() {
+		return posts == null ? List.of() : posts;
+	}
+}

--- a/src/main/java/org/sopt/makers/internal/community/service/post/crew/CrewMeetingFeedCacheService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/post/crew/CrewMeetingFeedCacheService.java
@@ -1,0 +1,253 @@
+package org.sopt.makers.internal.community.service.post.crew;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.sopt.makers.internal.external.makers.CrewPost;
+import org.sopt.makers.internal.external.makers.CrewPostListResponse;
+import org.sopt.makers.internal.external.makers.MakersCrewClient;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CrewMeetingFeedCacheService {
+
+	private static final String CACHE_PREFIX = "community:free-feed:meeting:";
+	private static final Duration CACHE_TTL = Duration.ofMinutes(10);
+	private static final int CREW_POST_CACHE_TAKE = 50;
+	private static final int PREFETCH_BUFFER_COUNT = 20;
+
+	private final MakersCrewClient makersCrewClient;
+	private final RedisTemplate<String, Object> redisTemplate;
+	private final ObjectMapper objectMapper;
+
+	public CrewMeetingFeedCache getOrBuildCache(
+		Long userId,
+		LocalDateTime snapshotTime,
+		int minimumRequiredCount
+	) {
+		return getOrBuildCache(
+			userId,
+			snapshotTime,
+			minimumRequiredCount,
+			PREFETCH_BUFFER_COUNT
+		);
+	}
+
+	public CrewMeetingFeedCache getOrBuildPreviewCache(
+		Long userId,
+		LocalDateTime snapshotTime,
+		int minimumRequiredCount
+	) {
+		return getOrBuildCache(
+			userId,
+			snapshotTime,
+			minimumRequiredCount,
+			0
+		);
+	}
+
+	public CrewMeetingFeedCache getOrBuildPopularPreviewCache(
+		Long userId,
+		LocalDateTime snapshotTime,
+		LocalDateTime since,
+		int maxPageCount
+	) {
+		CrewMeetingFeedCache cache = readCache(userId, snapshotTime);
+
+		if (containsOlderThanOrEqualToSince(cache.safePosts(), since) || !cache.hasMorePage()) {
+			return cache;
+		}
+
+		CrewMeetingFeedCache rebuiltCache = rebuildCacheUntil(
+			userId,
+			snapshotTime,
+			since,
+			maxPageCount
+		);
+
+		writeCache(userId, snapshotTime, rebuiltCache);
+		return rebuiltCache;
+	}
+
+	private CrewMeetingFeedCache rebuildCacheUntil(
+		Long userId,
+		LocalDateTime snapshotTime,
+		LocalDateTime since,
+		int maxPageCount
+	) {
+		int page = 1;
+		boolean hasMorePage = true;
+		List<CachedCrewPost> cachedPosts = new java.util.ArrayList<>();
+
+		while (page <= maxPageCount && hasMorePage) {
+			CrewPostListResponse crewResponse = makersCrewClient.getPosts(
+				userId,
+				page,
+				CREW_POST_CACHE_TAKE
+			);
+
+			if (crewResponse == null || crewResponse.posts() == null) {
+				hasMorePage = false;
+				break;
+			}
+
+			boolean reachedOlderThanSince = false;
+
+			for (CrewPost crewPost : crewResponse.posts()) {
+				if (crewPost.createdDate().isAfter(snapshotTime)) {
+					continue;
+				}
+
+				cachedPosts.add(CachedCrewPost.from(crewPost));
+
+				if (crewPost.createdDate().isBefore(since)) {
+					reachedOlderThanSince = true;
+				}
+			}
+
+			hasMorePage = crewResponse.pageMeta() != null
+				&& Boolean.TRUE.equals(crewResponse.pageMeta().hasNextPage());
+
+			if (reachedOlderThanSince) {
+				break;
+			}
+
+			page++;
+		}
+
+		return new CrewMeetingFeedCache(
+			normalize(cachedPosts),
+			hasMorePage
+		);
+	}
+
+	private boolean containsOlderThanOrEqualToSince(
+		List<CachedCrewPost> cachedPosts,
+		LocalDateTime since
+	) {
+		return cachedPosts.stream()
+			.anyMatch(post -> !post.createdDate().isAfter(since));
+	}
+
+	private CrewMeetingFeedCache getOrBuildCache(
+		Long userId,
+		LocalDateTime snapshotTime,
+		int minimumRequiredCount,
+		int prefetchBufferCount
+	) {
+		CrewMeetingFeedCache cache = readCache(userId, snapshotTime);
+
+		if (cache.safePosts().size() >= minimumRequiredCount || !cache.hasMorePage()) {
+			return cache;
+		}
+
+		int targetCount = minimumRequiredCount + prefetchBufferCount;
+		CrewMeetingFeedCache rebuiltCache = rebuildCache(userId, snapshotTime, targetCount);
+
+		writeCache(userId, snapshotTime, rebuiltCache);
+		return rebuiltCache;
+	}
+
+	private CrewMeetingFeedCache rebuildCache(
+		Long userId,
+		LocalDateTime snapshotTime,
+		int targetCount
+	) {
+		int page = 1;
+		boolean hasMorePage = true;
+		List<CachedCrewPost> cachedPosts = new java.util.ArrayList<>();
+
+		while (cachedPosts.size() < targetCount && hasMorePage) {
+			CrewPostListResponse crewResponse = makersCrewClient.getPosts(
+				userId,
+				page,
+				CREW_POST_CACHE_TAKE
+			);
+
+			if (crewResponse == null || crewResponse.posts() == null) {
+				hasMorePage = false;
+				break;
+			}
+
+			for (CrewPost crewPost : crewResponse.posts()) {
+				if (crewPost.createdDate().isAfter(snapshotTime)) {
+					continue;
+				}
+
+				cachedPosts.add(CachedCrewPost.from(crewPost));
+			}
+
+			hasMorePage = crewResponse.pageMeta() != null
+				&& Boolean.TRUE.equals(crewResponse.pageMeta().hasNextPage());
+
+			page++;
+		}
+
+		return new CrewMeetingFeedCache(
+			normalize(cachedPosts),
+			hasMorePage
+		);
+	}
+
+	private List<CachedCrewPost> normalize(List<CachedCrewPost> cachedPosts) {
+		Map<Long, CachedCrewPost> deduplicatedPosts = new LinkedHashMap<>();
+
+		for (CachedCrewPost cachedPost : cachedPosts) {
+			deduplicatedPosts.put(cachedPost.id(), cachedPost);
+		}
+
+		return deduplicatedPosts.values().stream()
+			.sorted(
+				Comparator.comparing(CachedCrewPost::createdDate)
+					.reversed()
+					.thenComparing(CachedCrewPost::id, Comparator.reverseOrder())
+			)
+			.toList();
+	}
+
+	private CrewMeetingFeedCache readCache(Long userId, LocalDateTime snapshotTime) {
+		String cacheKey = generateCacheKey(userId, snapshotTime);
+
+		Object cachedValue = redisTemplate.opsForValue().get(cacheKey);
+
+		if (!(cachedValue instanceof String cachedJson)) {
+			return CrewMeetingFeedCache.empty();
+		}
+
+		try {
+			return objectMapper.readValue(cachedJson, CrewMeetingFeedCache.class);
+		} catch (Exception exception) {
+			log.warn("모임 피드 캐시 역직렬화 실패. cacheKey: {}", cacheKey, exception);
+			return CrewMeetingFeedCache.empty();
+		}
+	}
+
+	private void writeCache(Long userId, LocalDateTime snapshotTime, CrewMeetingFeedCache cache) {
+		String cacheKey = generateCacheKey(userId, snapshotTime);
+
+		try {
+			String cacheJson = objectMapper.writeValueAsString(cache);
+			redisTemplate.opsForValue().set(cacheKey, cacheJson, CACHE_TTL);
+		} catch (Exception exception) {
+			log.warn("모임 피드 캐시 저장 실패. cacheKey: {}", cacheKey, exception);
+		}
+	}
+
+	private String generateCacheKey(Long userId, LocalDateTime snapshotTime) {
+		return CACHE_PREFIX
+			+ userId
+			+ ":"
+			+ snapshotTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+	}
+}

--- a/src/main/java/org/sopt/makers/internal/community/service/post/crew/CrewMeetingFeedCacheService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/post/crew/CrewMeetingFeedCacheService.java
@@ -31,6 +31,12 @@ public class CrewMeetingFeedCacheService {
 	private final RedisTemplate<String, Object> redisTemplate;
 	private final ObjectMapper objectMapper;
 
+	private record CacheRebuildResult(
+		CrewMeetingFeedCache cache,
+		boolean failed
+	) {
+	}
+
 	public CrewMeetingFeedCache getOrBuildCache(
 		Long userId,
 		LocalDateTime snapshotTime,
@@ -69,18 +75,26 @@ public class CrewMeetingFeedCacheService {
 			return cache;
 		}
 
-		CrewMeetingFeedCache rebuiltCache = rebuildCacheUntil(
+		CacheRebuildResult rebuildResult = rebuildCacheUntil(
 			userId,
 			snapshotTime,
 			since,
 			maxPageCount
 		);
 
-		writeCache(userId, snapshotTime, rebuiltCache);
-		return rebuiltCache;
+		if (rebuildResult.failed()) {
+			log.warn("모임 인기글 캐시 재구성 실패. 기존 캐시를 유지합니다. userId: {}, snapshotTime: {}",
+				userId,
+				snapshotTime
+			);
+			return fallbackWithoutMore(cache);
+		}
+
+		writeCache(userId, snapshotTime, rebuildResult.cache());
+		return rebuildResult.cache();
 	}
 
-	private CrewMeetingFeedCache rebuildCacheUntil(
+	private CacheRebuildResult rebuildCacheUntil(
 		Long userId,
 		LocalDateTime snapshotTime,
 		LocalDateTime since,
@@ -91,15 +105,13 @@ public class CrewMeetingFeedCacheService {
 		List<CachedCrewPost> cachedPosts = new java.util.ArrayList<>();
 
 		while (page <= maxPageCount && hasMorePage) {
-			CrewPostListResponse crewResponse = makersCrewClient.getPosts(
-				userId,
-				page,
-				CREW_POST_CACHE_TAKE
-			);
+			CrewPostListResponse crewResponse = safeGetPosts(userId, page);
 
 			if (crewResponse == null || crewResponse.posts() == null) {
-				hasMorePage = false;
-				break;
+				return new CacheRebuildResult(
+					new CrewMeetingFeedCache(normalize(cachedPosts), true),
+					true
+				);
 			}
 
 			boolean reachedOlderThanSince = false;
@@ -126,9 +138,12 @@ public class CrewMeetingFeedCacheService {
 			page++;
 		}
 
-		return new CrewMeetingFeedCache(
-			normalize(cachedPosts),
-			hasMorePage
+		return new CacheRebuildResult(
+			new CrewMeetingFeedCache(
+				normalize(cachedPosts),
+				hasMorePage
+			),
+			false
 		);
 	}
 
@@ -153,13 +168,21 @@ public class CrewMeetingFeedCacheService {
 		}
 
 		int targetCount = minimumRequiredCount + prefetchBufferCount;
-		CrewMeetingFeedCache rebuiltCache = rebuildCache(userId, snapshotTime, targetCount);
+		CacheRebuildResult rebuildResult = rebuildCache(userId, snapshotTime, targetCount);
 
-		writeCache(userId, snapshotTime, rebuiltCache);
-		return rebuiltCache;
+		if (rebuildResult.failed()) {
+			log.warn("모임 피드 캐시 재구성 실패. 기존 캐시를 유지합니다. userId: {}, snapshotTime: {}",
+				userId,
+				snapshotTime
+			);
+			return fallbackWithoutMore(cache);
+		}
+
+		writeCache(userId, snapshotTime, rebuildResult.cache());
+		return rebuildResult.cache();
 	}
 
-	private CrewMeetingFeedCache rebuildCache(
+	private CacheRebuildResult rebuildCache(
 		Long userId,
 		LocalDateTime snapshotTime,
 		int targetCount
@@ -169,15 +192,13 @@ public class CrewMeetingFeedCacheService {
 		List<CachedCrewPost> cachedPosts = new java.util.ArrayList<>();
 
 		while (cachedPosts.size() < targetCount && hasMorePage) {
-			CrewPostListResponse crewResponse = makersCrewClient.getPosts(
-				userId,
-				page,
-				CREW_POST_CACHE_TAKE
-			);
+			CrewPostListResponse crewResponse = safeGetPosts(userId, page);
 
 			if (crewResponse == null || crewResponse.posts() == null) {
-				hasMorePage = false;
-				break;
+				return new CacheRebuildResult(
+					new CrewMeetingFeedCache(normalize(cachedPosts), true),
+					true
+				);
 			}
 
 			for (CrewPost crewPost : crewResponse.posts()) {
@@ -194,9 +215,12 @@ public class CrewMeetingFeedCacheService {
 			page++;
 		}
 
-		return new CrewMeetingFeedCache(
-			normalize(cachedPosts),
-			hasMorePage
+		return new CacheRebuildResult(
+			new CrewMeetingFeedCache(
+				normalize(cachedPosts),
+				hasMorePage
+			),
+			false
 		);
 	}
 
@@ -249,5 +273,21 @@ public class CrewMeetingFeedCacheService {
 			+ userId
 			+ ":"
 			+ snapshotTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+	}
+
+	private CrewPostListResponse safeGetPosts(Long userId, int page) {
+		try {
+			return makersCrewClient.getPosts(userId, page, CREW_POST_CACHE_TAKE);
+		} catch (Exception exception) {
+			log.warn("모임 피드 조회 실패. userId: {}, page: {}", userId, page, exception);
+			return null;
+		}
+	}
+
+	private CrewMeetingFeedCache fallbackWithoutMore(CrewMeetingFeedCache cache) {
+		return new CrewMeetingFeedCache(
+			cache.safePosts(),
+			false
+		);
 	}
 }

--- a/src/main/java/org/sopt/makers/internal/community/service/post/crew/CrewMeetingFetchResult.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/post/crew/CrewMeetingFetchResult.java
@@ -1,0 +1,9 @@
+package org.sopt.makers.internal.community.service.post.crew;
+
+import java.util.List;
+
+public record CrewMeetingFetchResult(
+	List<CrewMeetingCandidate> candidates,
+	boolean hasMore
+) {
+}

--- a/src/main/java/org/sopt/makers/internal/external/platform/PlatformService.java
+++ b/src/main/java/org/sopt/makers/internal/external/platform/PlatformService.java
@@ -2,7 +2,10 @@ package org.sopt.makers.internal.external.platform;
 
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -48,6 +51,50 @@ public class PlatformService {
         }
 
         return Collections.emptyList();
+    }
+
+    /**
+     * batch map helper
+     */
+    public Map<Long, InternalUserDetails> getInternalUserDetailsMap(List<Long> userIds) {
+        if (userIds == null || userIds.isEmpty()) {
+            return Map.of();
+        }
+
+        List<Long> distinctUserIds = userIds.stream()
+            .filter(Objects::nonNull)
+            .distinct()
+            .toList();
+
+        if (distinctUserIds.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<Long, InternalUserDetails> userDetailsMap = getInternalUsers(distinctUserIds).stream()
+            .collect(Collectors.toMap(
+                InternalUserDetails::userId,
+                userDetails -> userDetails,
+                (previous, current) -> previous,
+                LinkedHashMap::new
+            ));
+
+        List<Long> missingUserIds = distinctUserIds.stream()
+            .filter(userId -> !userDetailsMap.containsKey(userId))
+            .toList();
+
+        for (Long missingUserId : missingUserIds) {
+            try {
+                InternalUserDetails userDetails = getInternalUser(missingUserId);
+                userDetailsMap.put(missingUserId, userDetails);
+            } catch (Exception exception) {
+                log.warn("[INTERNAL-PLATFORM] 단건 fallback 유저 정보 조회 실패. userId: {}, error: {}",
+                    missingUserId,
+                    exception.getMessage()
+                );
+            }
+        }
+
+        return userDetailsMap;
     }
 
     /**

--- a/src/main/java/org/sopt/makers/internal/member/repository/career/MemberCareerRepositoryCustom.java
+++ b/src/main/java/org/sopt/makers/internal/member/repository/career/MemberCareerRepositoryCustom.java
@@ -2,9 +2,12 @@ package org.sopt.makers.internal.member.repository.career;
 
 import org.sopt.makers.internal.member.domain.MemberCareer;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberCareerRepositoryCustom {
 
     Optional<MemberCareer> findMemberLastCareerByMemberId(Long memberId);
+
+    List<MemberCareer> findMemberLastCareersByMemberIds(List<Long> memberIds);
 }

--- a/src/main/java/org/sopt/makers/internal/member/repository/career/MemberCareerRepositoryCustomImpl.java
+++ b/src/main/java/org/sopt/makers/internal/member/repository/career/MemberCareerRepositoryCustomImpl.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.makers.internal.member.domain.MemberCareer;
 import org.sopt.makers.internal.member.domain.QMemberCareer;
 
+import java.util.List;
 import java.util.Optional;
 
 @RequiredArgsConstructor
@@ -22,5 +23,24 @@ public class MemberCareerRepositoryCustomImpl implements MemberCareerRepositoryC
                 .where(memberCareer.memberId.eq(memberId))
                 .orderBy(memberCareer.startDate.desc())
                 .stream().findFirst();
+    }
+
+    @Override
+    public List<MemberCareer> findMemberLastCareersByMemberIds(List<Long> memberIds) {
+        if (memberIds == null || memberIds.isEmpty()) {
+            return List.of();
+        }
+
+        QMemberCareer memberCareer = QMemberCareer.memberCareer;
+
+        return queryFactory
+            .selectFrom(memberCareer)
+            .where(memberCareer.memberId.in(memberIds))
+            .orderBy(
+                memberCareer.memberId.asc(),
+                memberCareer.startDate.desc(),
+                memberCareer.id.desc()
+            )
+            .fetch();
     }
 }

--- a/src/main/java/org/sopt/makers/internal/member/service/career/MemberCareerRetriever.java
+++ b/src/main/java/org/sopt/makers/internal/member/service/career/MemberCareerRetriever.java
@@ -1,5 +1,10 @@
 package org.sopt.makers.internal.member.service.career;
 
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
 import lombok.RequiredArgsConstructor;
 import org.sopt.makers.internal.member.domain.MemberCareer;
 import org.sopt.makers.internal.member.repository.career.MemberCareerRepository;
@@ -14,5 +19,30 @@ public class MemberCareerRetriever {
     public MemberCareer findMemberLastCareerByMemberId(Long memberId) {
         return memberCareerRepository.findMemberLastCareerByMemberId(memberId)
                 .orElse(null);
+    }
+
+    public Map<Long, MemberCareer> findMemberLastCareerMapByMemberIds(List<Long> memberIds) {
+        if (memberIds == null || memberIds.isEmpty()) {
+            return Map.of();
+        }
+
+        List<Long> distinctMemberIds = memberIds.stream()
+            .filter(Objects::nonNull)
+            .distinct()
+            .toList();
+
+        if (distinctMemberIds.isEmpty()) {
+            return Map.of();
+        }
+
+        List<MemberCareer> careers = memberCareerRepository.findMemberLastCareersByMemberIds(distinctMemberIds);
+
+        Map<Long, MemberCareer> careerMap = new LinkedHashMap<>();
+
+        for (MemberCareer career : careers) {
+            careerMap.putIfAbsent(career.getMemberId(), career);
+        }
+
+        return careerMap;
     }
 }

--- a/src/main/java/org/sopt/makers/internal/vote/repository/VoteRepository.java
+++ b/src/main/java/org/sopt/makers/internal/vote/repository/VoteRepository.java
@@ -1,10 +1,18 @@
 package org.sopt.makers.internal.vote.repository;
 
+import java.util.List;
 import java.util.Optional;
 import org.sopt.makers.internal.community.domain.CommunityPost;
 import org.sopt.makers.internal.vote.domain.Vote;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface VoteRepository extends JpaRepository<Vote, Long> {
     Optional<Vote> findByPost(CommunityPost post);
+
+    @EntityGraph(attributePaths = "voteOptions")
+    Optional<Vote> findByPost_Id(Long postId);
+
+    @EntityGraph(attributePaths = {"post", "voteOptions"})
+    List<Vote> findByPost_IdIn(List<Long> postIds);
 }

--- a/src/main/java/org/sopt/makers/internal/vote/repository/VoteSelectionRepository.java
+++ b/src/main/java/org/sopt/makers/internal/vote/repository/VoteSelectionRepository.java
@@ -11,9 +11,46 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface VoteSelectionRepository extends JpaRepository<VoteSelection, Long> {
+
     boolean existsByVoteOptionInAndMember(List<VoteOption> voteOptions, Member member);
+
     List<VoteSelection> findByVoteOptionInAndMember(List<VoteOption> voteOptions, Member member);
 
     @Query("SELECT COUNT(DISTINCT vs.member.id) FROM VoteSelection vs WHERE vs.voteOption.vote = :vote")
     int countDistinctMembersByVote(@Param("vote") Vote vote);
+
+    @Query("""
+        SELECT voteOption.vote.id AS voteId,
+               COUNT(DISTINCT voteSelection.member.id) AS participantCount
+        FROM VoteSelection voteSelection
+        JOIN voteSelection.voteOption voteOption
+        WHERE voteOption.vote.id IN :voteIds
+        GROUP BY voteOption.vote.id
+    """)
+    List<VoteParticipantCountProjection> countDistinctMembersByVoteIds(
+        @Param("voteIds") List<Long> voteIds
+    );
+
+    @Query("""
+        SELECT voteOption.vote.id AS voteId,
+               voteOption.id AS optionId
+        FROM VoteSelection voteSelection
+        JOIN voteSelection.voteOption voteOption
+        WHERE voteOption.vote.id IN :voteIds
+          AND voteSelection.member.id = :memberId
+    """)
+    List<MemberVoteSelectionProjection> findSelectedOptionIdsByVoteIdsAndMemberId(
+        @Param("voteIds") List<Long> voteIds,
+        @Param("memberId") Long memberId
+    );
+
+    interface VoteParticipantCountProjection {
+        Long getVoteId();
+        Long getParticipantCount();
+    }
+
+    interface MemberVoteSelectionProjection {
+        Long getVoteId();
+        Long getOptionId();
+    }
 }

--- a/src/main/java/org/sopt/makers/internal/vote/service/VoteService.java
+++ b/src/main/java/org/sopt/makers/internal/vote/service/VoteService.java
@@ -1,13 +1,18 @@
 package org.sopt.makers.internal.vote.service;
 
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.makers.internal.community.domain.CommunityPost;
+import org.sopt.makers.internal.community.domain.category.Category;
+import org.sopt.makers.internal.community.domain.enums.CommunityCategoryGroup;
 import org.sopt.makers.internal.community.service.post.CommunityPostRetriever;
 import org.sopt.makers.internal.exception.BadRequestException;
 import org.sopt.makers.internal.member.domain.Member;
@@ -16,15 +21,15 @@ import org.sopt.makers.internal.vote.domain.Vote;
 import org.sopt.makers.internal.vote.domain.VoteOption;
 import org.sopt.makers.internal.vote.domain.VoteSelection;
 import org.sopt.makers.internal.vote.dto.request.VoteRequest;
-import org.sopt.makers.internal.vote.repository.VoteOptionRepository;
 import org.sopt.makers.internal.vote.dto.response.VoteOptionResponse;
 import org.sopt.makers.internal.vote.dto.response.VoteResponse;
+import org.sopt.makers.internal.vote.repository.VoteOptionRepository;
 import org.sopt.makers.internal.vote.repository.VoteRepository;
 import org.sopt.makers.internal.vote.repository.VoteSelectionRepository;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
-import org.springframework.http.HttpStatus;
 
 @Service
 @RequiredArgsConstructor
@@ -39,7 +44,11 @@ public class VoteService {
 
     @Transactional
     public void createVote(CommunityPost post, VoteRequest voteRequest) {
-        validateVotePolicy(post.getCategoryId(), voteRequest);
+        if (voteRequest == null) {
+            return;
+        }
+
+        validateVotePolicy(post.getCategory(), voteRequest);
 
         Vote vote = Vote.of(post, voteRequest.isMultiple(), voteRequest.voteOptions());
         voteRepository.save(vote);
@@ -50,7 +59,7 @@ public class VoteService {
         CommunityPost post = communityPostRetriever.findCommunityPostById(postId);
         Member member = memberRetriever.findMemberById(userId);
         Vote vote = voteRepository.findByPost(post)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "해당 게시글에는 투표가 존재하지 않습니다."));
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "해당 게시글에는 투표가 존재하지 않습니다."));
 
         List<VoteOption> selectedOptions = voteOptionRepository.findAllById(selectedOptionIds);
 
@@ -72,51 +81,130 @@ public class VoteService {
 
     @Transactional(readOnly = true)
     public VoteResponse getVoteByPostId(Long postId, Long userId) {
-        Vote vote = voteRepository.findByPost(
-                communityPostRetriever.findCommunityPostById(postId)).orElse(null);
+        return getVoteMapByPostIds(List.of(postId), userId).get(postId);
+    }
 
-        if (vote == null) return null;
+    @Transactional(readOnly = true)
+    public Map<Long, VoteResponse> getVoteMapByPostIds(List<Long> postIds, Long memberId) {
+        if (postIds == null || postIds.isEmpty()) {
+            return Map.of();
+        }
 
-        Member member = memberRetriever.findMemberById(userId);
+        List<Long> distinctPostIds = postIds.stream()
+            .filter(Objects::nonNull)
+            .distinct()
+            .toList();
 
+        if (distinctPostIds.isEmpty()) {
+            return Map.of();
+        }
+
+        List<Vote> votes = voteRepository.findByPost_IdIn(distinctPostIds);
+
+        if (votes.isEmpty()) {
+            return Map.of();
+        }
+
+        List<Vote> distinctVotes = votes.stream()
+            .filter(Objects::nonNull)
+            .collect(Collectors.toMap(
+                Vote::getId,
+                vote -> vote,
+                (previous, current) -> previous
+            ))
+            .values()
+            .stream()
+            .toList();
+
+        List<Long> voteIds = distinctVotes.stream()
+            .map(Vote::getId)
+            .toList();
+
+        Map<Long, Integer> participantCountMap = voteSelectionRepository
+            .countDistinctMembersByVoteIds(voteIds)
+            .stream()
+            .collect(Collectors.toMap(
+                VoteSelectionRepository.VoteParticipantCountProjection::getVoteId,
+                projection -> projection.getParticipantCount().intValue()
+            ));
+
+        Map<Long, Set<Long>> selectedOptionIdsByVoteId = memberId == null
+            ? Map.of()
+            : voteSelectionRepository.findSelectedOptionIdsByVoteIdsAndMemberId(voteIds, memberId)
+              .stream()
+              .collect(Collectors.groupingBy(
+                  VoteSelectionRepository.MemberVoteSelectionProjection::getVoteId,
+                  Collectors.mapping(
+                      VoteSelectionRepository.MemberVoteSelectionProjection::getOptionId,
+                      Collectors.toSet()
+                  )
+              ));
+
+        Map<Long, VoteResponse> voteResponseMap = new HashMap<>();
+
+        for (Vote vote : distinctVotes) {
+            Long postId = vote.getPost().getId();
+            Set<Long> selectedOptionIds = selectedOptionIdsByVoteId.getOrDefault(vote.getId(), Collections.emptySet());
+            int participantCount = participantCountMap.getOrDefault(vote.getId(), 0);
+
+            voteResponseMap.put(
+                postId,
+                toVoteResponse(vote, participantCount, selectedOptionIds)
+            );
+        }
+
+        return voteResponseMap;
+    }
+
+    private VoteResponse toVoteResponse(
+        Vote vote,
+        int totalParticipants,
+        Set<Long> selectedOptionIds
+    ) {
         List<VoteOption> sortedOptions = vote.getVoteOptions().stream()
-                .sorted(Comparator.comparing(VoteOption::getId))
-                .collect(Collectors.toList());
+            .sorted(Comparator.comparing(VoteOption::getId))
+            .toList();
 
-        // 총 투표자 계산
-        int totalParticipants = voteSelectionRepository.countDistinctMembersByVote(vote);
+        boolean hasVoted = selectedOptionIds != null && !selectedOptionIds.isEmpty();
 
-        // 유저가 투표했는지 여부 및 선택한 옵션 ID 조회
-        List<VoteSelection> selections = voteSelectionRepository.findByVoteOptionInAndMember(sortedOptions, member);
-        boolean hasVoted = !selections.isEmpty();
-        Set<Long> selectedOptionIds = selections.stream()
-                .map(selection -> selection.getVoteOption().getId())
-                .collect(Collectors.toSet());
+        int totalVoteCount = sortedOptions.stream()
+            .mapToInt(VoteOption::getVoteCount)
+            .sum();
 
         List<VoteOptionResponse> optionsResponse = sortedOptions.stream()
-                .map(option -> new VoteOptionResponse(
-                        option.getId(),
-                        option.getContent(),
-                        option.getVoteCount(),
-                        calculateVotePercent(option.getVoteCount(), sortedOptions.stream().mapToInt(VoteOption::getVoteCount).sum()),
-                        selectedOptionIds.contains(option.getId()))
-                ).toList();
-        return new VoteResponse(vote.getId(), vote.isMultipleOptions(), hasVoted, totalParticipants, optionsResponse);
+            .map(option -> new VoteOptionResponse(
+                option.getId(),
+                option.getContent(),
+                option.getVoteCount(),
+                calculateVotePercent(option.getVoteCount(), totalVoteCount),
+                selectedOptionIds != null && selectedOptionIds.contains(option.getId())
+            ))
+            .toList();
+
+        return new VoteResponse(
+            vote.getId(),
+            vote.isMultipleOptions(),
+            hasVoted,
+            totalParticipants,
+            optionsResponse
+        );
     }
 
     private int calculateVotePercent(int voteCount, int totalCount) {
-        if (totalCount == 0) return 0;
+        if (totalCount == 0) {
+            return 0;
+        }
+
         return (int) Math.round((double) voteCount * 100 / totalCount);
     }
 
-    private void validateVotePolicy(Long categoryId, VoteRequest vote) {
-        if (Objects.isNull(vote)) return;
-
-        if (Objects.equals(categoryId, 21L)) {
+    private void validateVotePolicy(Category category, VoteRequest vote) {
+        if (category != null && category.getCategoryGroup() == CommunityCategoryGroup.SOPTICLE) {
             throw new BadRequestException("솝티클 카테고리는 투표를 만들 수 없습니다.");
         }
 
         List<String> options = vote.voteOptions();
+
         if (options == null || options.size() < 2 || options.size() > 5) {
             throw new BadRequestException("투표 옵션은 2개 이상 5개 이하만 가능합니다.");
         }
@@ -125,6 +213,7 @@ public class VoteService {
             if (option == null || option.trim().isEmpty()) {
                 throw new BadRequestException("투표 옵션 내용은 공백일 수 없습니다.");
             }
+
             if (option.length() > 40) {
                 throw new BadRequestException("투표 옵션은 40자까지만 입력 가능합니다.");
             }
@@ -139,6 +228,7 @@ public class VoteService {
 
         // 선택한 옵션이 존재하지 않는 경우 체크
         List<VoteOption> selectedOptions = voteOptionRepository.findAllById(selectedOptionIds);
+
         if (selectedOptions.size() != selectedOptionIds.size()) {
             throw new BadRequestException("존재하지 않는 투표 옵션이 포함되어 있습니다.");
         }


### PR DESCRIPTION
## 🐬 요약
PR의 요약을 작성해주세요!
커뮤니티 카테고리 개편 요구사항을 반영하여 기존 `categoryId` 중심 구조를 `CommunityCategoryCode` / `CommunityCategoryGroup` 기반 구조로 변경했습니다.

또한 자유 탭에 기존 자유/질문/파트톡 글을 일반 자유글로 통합하고, 모임글은 Crew 서버의 피드 데이터를 병합하여 `MEETING` 태그로 구분되도록 수정했습니다. 홈 인기글/최신글 미리보기에도 모임글이 조건에 따라 함께 노출되도록 반영했습니다.

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [x] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
### 카테고리 구조 개편

- `Category`에 `code`, `categoryGroup`, `isActive` 컬럼 기반 구조 반영
- 게시글 생성/수정 요청에서 `categoryId` 대신 `CommunityCategoryCode` 사용
- `CommunityPost.categoryId` 제거 후 `Category` 연관관계로 전환
- 목록 조회 요청 category를 `FREE`, `PROMOTION`, `SOPTICLE` enum으로 제한
- 홍보 필터 유지
  - `ALL`, `EVENT`, `PROJECT`, `RECRUIT`, `ETC`
- 솝티클 필터 추가
  - `ALL`, `PLAN`, `DESIGN`, `SERVER`, `WEB`, `IOS`, `ANDROID`, `ETC`
- 자유 탭은 별도 filter를 받지 않도록 검증

### 자유 피드 + 모임글 병합

- 자유 탭 조회 시 커뮤니티 자유글과 Crew 모임글을 최신순으로 병합
- 모임글은 `sourceType=MEETING`, `tags=[MEETING]`으로 응답
- 커뮤니티 글과 모임글의 cursor 상태를 함께 관리하는 `CommunityFeedCursor` 도입
- snapshot 기반 cursor를 사용해 페이지 이동 중 새 글 유입에 따른 순서 흔들림 완화
- Crew 피드 Redis cache 도입
  - 일반 자유 피드용 cache
  - 최신글 preview용 cache
  - 인기글 후보용 cache 분리

### 홈 인기글/최신글 개편

- 홈 인기글/최신글 기본 노출 개수 3개로 조정
- 인기글/최신글 응답에 다음 필드 추가
  - `likeCount`
  - `commentCount`
  - `categoryTag`
  - `categoryTagLabel`
- 화면 표시용 태그 정책 반영
  - 자유
  - 모임
  - 행사
  - 프로젝트
  - 채용
  - 홍보
  - 솝티클
- 실시간 인기글 점수 정책 반영
  - 최근 30일 이내 게시글 대상
  - 인기 점수 = 조회수 + 댓글 수 * 5 + 좋아요 수 * 3
  - 동점일 경우 최신 작성일 우선
  - 삭제/신고 글 미노출
  - 후보가 없으면 빈 리스트 반환

### 목록 조회 성능 개선

- 게시글 좋아요 여부 batch 조회
- 게시글 좋아요 수 batch 조회
- 댓글 목록 postIds 기준 batch 조회
- 댓글 좋아요 여부/좋아요 수 commentIds 기준 batch 조회
- 댓글 수 batch count query 추가
- 플랫폼 유저 정보 batch 조회
- 작성자 career 정보 batch 조회
- vote 응답 postIds 기준 batch 조회
- `CommunityMemberVoAssembler`를 추가하여 `MemberVo` 조립 로직 중복 제거

### Internal API 영향

- internal 인기글 API는 기존 조회수 기준을 유지
- internal 최신글/인기글 응답 조립에서 작성자/익명 프로필 조회를 batch화
- internal 응답 스펙은 변경하지 않음

## API 변경사항

### 커뮤니티 목록 조회

`GET /api/v1/community/posts`

요청 파라미터:

- `category`
  - `FREE`
  - `PROMOTION`
  - `SOPTICLE`
- `filter`
  - `FREE`: 사용하지 않음
  - `PROMOTION`: `ALL`, `EVENT`, `PROJECT`, `RECRUIT`, `ETC`
  - `SOPTICLE`: `ALL`, `PLAN`, `DESIGN`, `SERVER`, `WEB`, `IOS`, `ANDROID`, `ETC`
- `cursor`
  - 첫 조회 시 null
  - 이후 응답의 `nextCursor` 사용

응답 변경:

- `category`
- `hasNext`
- `nextCursor`
- `posts[].sourceType`
- `posts[].categoryGroup`
- `posts[].categoryCode`
- `posts[].tags`

### 홈 인기글

`GET /api/v1/community/posts/popular`

변경사항:

- 기본 노출 개수 3개
- 모임글도 후보에 포함
- 인기 점수 기반 정렬
- `likeCount`, `commentCount`, `categoryTag`, `categoryTagLabel` 응답 추가

### 홈 최신글

`GET /api/v1/community/posts/recent`

변경사항:

- 기본 노출 개수 3개
- 커뮤니티 최신글과 모임글을 함께 후보로 병합
- `likeCount`, `commentCount`, `categoryTag`, `categoryTagLabel` 응답 추가

## 마이그레이션 필요사항

배포 전 DB category row에 다음 값이 반영되어야 합니다.

- `code`
- `category_group`
- `is_active`

또한 기존 자유/질문/파트톡 글은 일반 자유 카테고리로 편입하고, 기존 홍보/솝티클 하위 카테고리는 새 enum code와 매칭되도록 migration이 필요합니다.


## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #941 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 커서 기반 피드 조회 도입 — 더 부드러운 무한 스크롤 및 다음 페이지 토큰 제공
  * 카테고리 + 필터 기반 게시글 목록 제공 및 모임 글 통합 조회 지원
  * 인기글 조회에 사용자 정보 반영 및 더 풍부한 미리보기(좋아요/댓글 수, 카테고리 태그)

* **Refactor**
  * 카테고리 표현 방식 개선(코드/그룹/태그 기반) — 카테고리 표시 및 필터링 일관성 향상
  * 목록/댓글/좋아요 조회 흐름 단순화 및 응답 페이징 형식 변경(커서/nextCursor)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sopt-makers/sopt-playground-backend/pull/942)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->