### PR TITLE
fix : 답변 달린 최신순 정렬로 쿼리 수정

### DIFF
--- a/src/main/java/org/sopt/makers/internal/member/repository/MemberQuestionRepository.java
+++ b/src/main/java/org/sopt/makers/internal/member/repository/MemberQuestionRepository.java
@@ -98,8 +98,8 @@ public interface MemberQuestionRepository extends JpaRepository<MemberQuestion, 
         WHERE q.receiver.id = :receiverId
           AND q.answer IS NOT NULL
           AND (
-              q.createdAt > :createdAt
-              OR (q.createdAt = :createdAt AND q.id > :questionId)
+              q.answer.createdAt > :createdAt
+              OR (q.answer.createdAt = :createdAt AND q.id > :questionId)
           )
     """)
 	long countAnsweredQuestionsBeforeTargetInLatestOrder(

--- a/src/main/java/org/sopt/makers/internal/member/repository/MemberQuestionRepository.java
+++ b/src/main/java/org/sopt/makers/internal/member/repository/MemberQuestionRepository.java
@@ -141,7 +141,7 @@ public interface MemberQuestionRepository extends JpaRepository<MemberQuestion, 
     FROM MemberQuestion q
     WHERE q.isReported = false
       AND q.answer IS NOT NULL
-    ORDER BY q.createdAt DESC, q.id DESC
+    ORDER BY q.answer.createdAt DESC, q.id DESC
 """)
 	List<MemberQuestion> findLatestAnsweredQuestions(Pageable pageable);
 

--- a/src/main/java/org/sopt/makers/internal/member/service/MemberQuestionService.java
+++ b/src/main/java/org/sopt/makers/internal/member/service/MemberQuestionService.java
@@ -496,7 +496,7 @@ public class MemberQuestionService {
 			tab = QuestionTab.ANSWERED;
 			precedingQuestionCount = memberQuestionRetriever.countAnsweredQuestionsBeforeTargetInLatestOrder(
 				question.getReceiver().getId(),
-				question.getCreatedAt(),
+				question.getAnswer().getCreatedAt(),
 				question.getId()
 			);
 		} else {


### PR DESCRIPTION
## 🐬 요약
PR의 요약을 작성해주세요!

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [x] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
PR에 담긴 작업 내용을 작성해주세요!
- 최신 에스크 조회 시 답변 달린 순으로 정렬하도록 쿼리를 수정했습니다. 
## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

- close: #946 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 최근 답변된 질문 목록의 정렬 기준을 개선했습니다. 이전에는 질문 생성 시간을 기준으로 정렬되었으나, 이제 답변 생성 시간을 기준으로 정렬되도록 수정되어 가장 최신 답변을 받은 질문들이 정확하게 표시됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sopt-makers/sopt-playground-backend/pull/947)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->