### PR TITLE
[FIX] 커뮤니티 카테고리 조회 인증 명세 및 LazyInitializationException 수정

### DIFF
--- a/src/main/java/org/sopt/makers/internal/community/controller/CommunityCategoryController.java
+++ b/src/main/java/org/sopt/makers/internal/community/controller/CommunityCategoryController.java
@@ -1,6 +1,7 @@
 package org.sopt.makers.internal.community.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.sopt.makers.internal.community.dto.response.CommunityCategoryResponse;
@@ -16,6 +17,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/community/category")
+@SecurityRequirement(name = "Authorization")
 @Tag(name = "커뮤니티 카테고리 관련 API", description = "커뮤니티 카테고리 관련 API List")
 public class CommunityCategoryController {
 

--- a/src/main/java/org/sopt/makers/internal/community/mapper/CommunityResponseMapper.java
+++ b/src/main/java/org/sopt/makers/internal/community/mapper/CommunityResponseMapper.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Objects;
 import lombok.val;
 
+import org.hibernate.Hibernate;
 import org.sopt.makers.internal.community.domain.enums.CommunityCategoryCode;
 import org.sopt.makers.internal.community.domain.enums.CommunityCategoryGroup;
 import org.sopt.makers.internal.community.domain.enums.CommunityPostSourceType;
@@ -133,13 +134,15 @@ public class CommunityResponseMapper {
             return null;
         }
 
-        CommunityCategoryCode parentCode = category.getParent() == null
-            ? null
-            : category.getParent().getCode();
+        Category parent = category.getParent();
 
-        String parentCategoryName = category.getParent() == null
-            ? null
-            : category.getParent().getName();
+        CommunityCategoryCode parentCode = null;
+        String parentCategoryName = null;
+
+        if (parent != null && Hibernate.isInitialized(parent)) {
+            parentCode = parent.getCode();
+            parentCategoryName = parent.getName();
+        }
 
         return new CategoryVo(
             category.getCategoryGroup(),

--- a/src/main/java/org/sopt/makers/internal/community/repository/CommunityQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/community/repository/CommunityQueryRepository.java
@@ -44,16 +44,18 @@ public class CommunityQueryRepository {
         if (filterBlockedUsers && memberId == null) {
             throw new IllegalArgumentException("memberId is required when filterBlockedUsers is true");
         }
+
         val post = QCommunityPost.communityPost;
         val member = QMember.member;
         val category = QCategory.category;
+        val parentCategory = new QCategory("parentCategory");
         val memberBlock = QMemberBlock.memberBlock;
 
-        JPAQuery<CategoryPostMemberDao> query = queryFactory
-            .select(Projections.constructor(CategoryPostMemberDao.class, post, member, category))
-            .from(post)
-            .innerJoin(post.member, member)
-            .innerJoin(post.category, category)
+        JPAQuery<CommunityPost> query = queryFactory
+            .selectFrom(post)
+            .innerJoin(post.member, member).fetchJoin()
+            .innerJoin(post.category, category).fetchJoin()
+            .leftJoin(category.parent, parentCategory).fetchJoin()
             .where(
                 category.code.in(categoryCodes),
                 post.createdAt.loe(snapshotTime),
@@ -71,20 +73,38 @@ public class CommunityQueryRepository {
                 .where(memberBlock.isNull());
         }
 
-        return query.fetch();
+        return query.fetch().stream()
+            .map(fetchedPost -> new CategoryPostMemberDao(
+                fetchedPost,
+                fetchedPost.getMember(),
+                fetchedPost.getCategory()
+            ))
+            .toList();
     }
 
     public CategoryPostMemberDao getPostById(Long postId) {
         val post = QCommunityPost.communityPost;
         val category = QCategory.category;
+        val parentCategory = new QCategory("parentCategory");
         val member = QMember.member;
 
-        return queryFactory.select(Projections.constructor(CategoryPostMemberDao.class, post, member, category))
-            .from(post)
-            .innerJoin(post.member, member)
-            .innerJoin(post.category, category)
+        CommunityPost fetchedPost = queryFactory
+            .selectFrom(post)
+            .innerJoin(post.member, member).fetchJoin()
+            .innerJoin(post.category, category).fetchJoin()
+            .leftJoin(category.parent, parentCategory).fetchJoin()
             .where(post.id.eq(postId))
             .fetchOne();
+
+        if (fetchedPost == null) {
+            return null;
+        }
+
+        return new CategoryPostMemberDao(
+            fetchedPost,
+            fetchedPost.getMember(),
+            fetchedPost.getCategory()
+        );
     }
 
     public Map<Long, AnonymousProfile> getAnonymousProfilesByPostId(List<Long> postIds) {

--- a/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostService.java
@@ -2,7 +2,6 @@ package org.sopt.makers.internal.community.service.post;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.time.LocalDate;
-import org.hibernate.Hibernate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
@@ -14,7 +13,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -182,6 +180,7 @@ public class CommunityPostService {
     }
 
     // 커뮤니티글 목록 조회 entrypoint
+    @Transactional(readOnly = true)
     public PostAllResponse getPosts(
         Long userId,
         CommunityPostListCategory category,
@@ -429,11 +428,7 @@ public class CommunityPostService {
         val authorDetails = platformService.getInternalUser(authorId);
         val authorCareer = memberCareerRetriever.findMemberLastCareerByMemberId(authorId);
         val voteResponse = voteService.getVoteByPostId(postId, memberId);
-
         val category = postDao.category();
-        if (category != null) {
-            Hibernate.initialize(category.getParent());
-        }
 
         return new PostDetailData(postDao.post(), authorDetails, authorCareer, category, voteResponse);
     }


### PR DESCRIPTION
## 🐬 요약
커뮤니티 카테고리 개편 이후 dev API 테스트 중 발견된 Swagger 인증 명세 누락과 게시글 목록/상세 조회의 `LazyInitializationException`을 수정했습니다.

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [x] 버그 수정
- [ ] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
## 커뮤니티 카테고리 조회 API Swagger 인증 헤더 누락
`GET /api/v1/community/category` 호출 시 실제 API는 인증 헤더가 필요하지만, Swagger 문서상 해당 API에 인증 요구사항이 표시되지 않아 Swagger에서 바로 테스트할 경우 아래와 같은 응답이 발생했습니다.
```text
인증 헤더가 존재하지 않습니다.
```
이를 해결하기 위해 CommunityCategoryController에 아래 annotation을 추가했습니다.
```
@SecurityRequirement(name = "Authorization")
```
이를 통해 Swagger에서 해당 API 테스트 시 인증 헤더 입력이 가능하도록 수정했습니다.

## 홍보 하위 필터 / 솝티클 목록 조회 시 LazyInitializationException 발생
아래 API에서 데이터가 존재하는 경우 Category.parent 접근 시점에 Hibernate session이 닫혀 있어 LazyInitializationException이 발생했습니다.
```
GET /api/v1/community/posts?category=PROMOTION&filter=EVENT
GET /api/v1/community/posts?category=SOPTICLE&filter=ALL
```
에러 메시지:
```
could not initialize proxy [org.sopt.makers.internal.community.domain.category.Category#4] - no Session
could not initialize proxy [org.sopt.makers.internal.community.domain.category.Category#21] - no Session
```

### 원인
LazyInitializationException 문제

게시글 목록/상세 조회에서 Category는 조회했지만, Category.parent는 LAZY 관계라 실제 parent row가 초기화되지 않은 proxy 상태로 남아 있었습니다.

이후 응답 매핑 과정에서 parentCode, parentCategoryName을 만들기 위해 category.getParent().getCode() 또는 category.getParent().getName()에 접근하면서, 이미 session이 닫힌 경우 lazy loading을 수행하지 못해 예외가 발생했습니다.

### 해결 방법
1. 게시글 목록 조회 transaction 범위 보강
CommunityPostService#getPosts()에 @Transactional(readOnly = true)를 추가하여 목록 조회와 응답 조립이 같은 persistence context 안에서 수행되도록 수정했습니다.

2. 카테고리 parent fetch join 적용
CommunityQueryRepository의 게시글 목록/상세 조회 쿼리에서 post.member, post.category, category.parent를 fetch join하도록 수정했습니다.
변경 대상:
- findPostsByCategoryCodes(...)
- getPostById(...)
기존 DTO projection 기반 조회는 parent lazy proxy를 남길 수 있어, entity fetch join으로 조회한 뒤 CategoryPostMemberDao로 변환하는 방식으로 변경했습니다.

3. Mapper 방어 코드 추가
CommunityResponseMapper#toCategoryResponse(...)에서 parent가 초기화된 경우에만 parent 정보를 읽도록 방어했습니다.
```
if (parent != null && Hibernate.isInitialized(parent)) {
    parentCode = parent.getCode();
    parentCategoryName = parent.getName();
}
```
query에서 parent를 fetch join하더라도, 추후 다른 경로에서 초기화되지 않은 Category가 들어올 가능성을 대비하기 위한 방어 로직입니다.

비고) Category.parent를 전역 EAGER로 변경하지 않고, 필요한 조회 쿼리에서만 fetch join하도록 수정했습니다. 이를 통해 불필요한 전역 로딩은 피하면서, 목록/상세 응답에 필요한 부모 카테고리 정보는 안정적으로 조회할 수 있도록 했습니다.

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #00


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서화**
  * 커뮤니티 카테고리 API 엔드포인트에 인증 요구사항을 명시했습니다.

* **개선사항**
  * 카테고리 조회 성능을 최적화했습니다.
  * 상위 카테고리 데이터 로딩 로직을 개선하여 불필요한 데이터 접근을 방지했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sopt-makers/sopt-playground-backend/pull/950?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->