### PR TITLE
[Refactor] 카테고리 전체 조회 응답 db-driven으로 수정

### DIFF
--- a/src/main/java/org/sopt/makers/internal/community/domain/category/Category.java
+++ b/src/main/java/org/sopt/makers/internal/community/domain/category/Category.java
@@ -49,6 +49,7 @@ public class Category {
     private Category parent;
 
     @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY)
+    @OrderBy("displayOrder ASC")
     private List<Category> children = new ArrayList<>();
 
     @Column

--- a/src/main/java/org/sopt/makers/internal/community/domain/enums/CommunityCategoryCode.java
+++ b/src/main/java/org/sopt/makers/internal/community/domain/enums/CommunityCategoryCode.java
@@ -2,6 +2,7 @@ package org.sopt.makers.internal.community.domain.enums;
 
 public enum CommunityCategoryCode {
 	FREE,
+	MEETING,
 
 	PROMOTION,
 	PROMOTION_EVENT,

--- a/src/main/java/org/sopt/makers/internal/community/dto/response/CommunityCategoryResponse.java
+++ b/src/main/java/org/sopt/makers/internal/community/dto/response/CommunityCategoryResponse.java
@@ -1,7 +1,10 @@
 package org.sopt.makers.internal.community.dto.response;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import org.sopt.makers.internal.community.domain.category.Category;
+import org.sopt.makers.internal.community.domain.enums.CommunityCategoryCode;
 import org.sopt.makers.internal.community.domain.enums.CommunityPostListFilter;
 
 public record CommunityCategoryResponse(
@@ -12,53 +15,54 @@ public record CommunityCategoryResponse(
     List<CommunityCategoryResponse> children
 ) {
 
-    public static CommunityCategoryResponse fromRoot(Category category) {
-        List<CommunityCategoryResponse> children = switch (category.getCode()) {
-            case FREE -> List.of();
-            case PROMOTION -> promotionFilters();
-            case SOPTICLE -> sopticleFilters();
-            default -> List.of();
-        };
+    private static final Comparator<Category> CATEGORY_DISPLAY_ORDER_COMPARATOR =
+        Comparator.comparing(
+                Category::getDisplayOrder,
+                Comparator.nullsLast(Integer::compareTo)
+            )
+            .thenComparing(Category::getId);
 
+    public static CommunityCategoryResponse from(
+        Category category,
+        Map<Long, List<Category>> childCategoriesByParentId
+    ) {
         return new CommunityCategoryResponse(
-            category.getCode().name(),
+            toResponseCode(category.getCode()),
             category.getName(),
             category.getContent(),
             category.getHasBlind(),
-            children
+            toChildren(category, childCategoriesByParentId)
         );
     }
 
-    private static List<CommunityCategoryResponse> promotionFilters() {
-        return List.of(
-            filter(CommunityPostListFilter.ALL, "전체"),
-            filter(CommunityPostListFilter.EVENT, "행사"),
-            filter(CommunityPostListFilter.PROJECT, "프로젝트"),
-            filter(CommunityPostListFilter.RECRUIT, "채용"),
-            filter(CommunityPostListFilter.ETC, "기타")
-        );
+    private static List<CommunityCategoryResponse> toChildren(
+        Category category,
+        Map<Long, List<Category>> childCategoriesByParentId
+    ) {
+        return childCategoriesByParentId
+            .getOrDefault(category.getId(), List.of())
+            .stream()
+            .sorted(CATEGORY_DISPLAY_ORDER_COMPARATOR)
+            .map(childCategory -> CommunityCategoryResponse.from(childCategory, childCategoriesByParentId))
+            .toList();
     }
 
-    private static List<CommunityCategoryResponse> sopticleFilters() {
-        return List.of(
-            filter(CommunityPostListFilter.ALL, "전체"),
-            filter(CommunityPostListFilter.PLAN, "기획"),
-            filter(CommunityPostListFilter.DESIGN, "디자인"),
-            filter(CommunityPostListFilter.SERVER, "서버"),
-            filter(CommunityPostListFilter.WEB, "웹"),
-            filter(CommunityPostListFilter.IOS, "iOS"),
-            filter(CommunityPostListFilter.ANDROID, "Android"),
-            filter(CommunityPostListFilter.ETC, "기타")
-        );
-    }
+    private static String toResponseCode(CommunityCategoryCode code) {
+        return switch (code) {
+            case PROMOTION_EVENT -> CommunityPostListFilter.EVENT.name();
+            case PROMOTION_PROJECT -> CommunityPostListFilter.PROJECT.name();
+            case PROMOTION_RECRUIT -> CommunityPostListFilter.RECRUIT.name();
+            case PROMOTION_ETC -> CommunityPostListFilter.ETC.name();
 
-    private static CommunityCategoryResponse filter(CommunityPostListFilter filter, String name) {
-        return new CommunityCategoryResponse(
-            filter.name(),
-            name,
-            null,
-            false,
-            List.of()
-        );
+            case SOPTICLE_PLAN -> CommunityPostListFilter.PLAN.name();
+            case SOPTICLE_DESIGN -> CommunityPostListFilter.DESIGN.name();
+            case SOPTICLE_SERVER -> CommunityPostListFilter.SERVER.name();
+            case SOPTICLE_WEB -> CommunityPostListFilter.WEB.name();
+            case SOPTICLE_IOS -> CommunityPostListFilter.IOS.name();
+            case SOPTICLE_ANDROID -> CommunityPostListFilter.ANDROID.name();
+            case SOPTICLE_ETC -> CommunityPostListFilter.ETC.name();
+
+            default -> code.name();
+        };
     }
 }

--- a/src/main/java/org/sopt/makers/internal/community/repository/category/CategoryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/community/repository/category/CategoryRepository.java
@@ -14,7 +14,12 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
     List<Category> findAllByCodeInAndIsActiveTrue(List<CommunityCategoryCode> codes);
 
-	List<Category> findAllByIsActiveTrueAndParentIsNullAndCodeInOrderByDisplayOrderAsc(
-		List<CommunityCategoryCode> codes
-	);
+	@Query("""
+        select category
+        from Category category
+        left join fetch category.parent
+        where category.isActive = true
+        order by category.displayOrder asc, category.id asc
+    """)
+	List<Category> findAllActiveWithParentOrderByDisplayOrderAsc();
 }

--- a/src/main/java/org/sopt/makers/internal/community/service/category/CategoryRetriever.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/category/CategoryRetriever.java
@@ -23,14 +23,8 @@ public class CategoryRetriever {
     }
 
     @Transactional(readOnly = true)
-    public List<Category> findActiveRootListCategories() {
-        return categoryRepository.findAllByIsActiveTrueAndParentIsNullAndCodeInOrderByDisplayOrderAsc(
-            List.of(
-                CommunityCategoryCode.FREE,
-                CommunityCategoryCode.PROMOTION,
-                CommunityCategoryCode.SOPTICLE
-            )
-        );
+    public List<Category> findAllActiveCategoriesWithParent() {
+        return categoryRepository.findAllActiveWithParentOrderByDisplayOrderAsc();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/makers/internal/community/service/category/CategoryService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/category/CategoryService.java
@@ -1,20 +1,40 @@
 package org.sopt.makers.internal.community.service.category;
 
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.sopt.makers.internal.community.domain.category.Category;
 import org.sopt.makers.internal.community.dto.response.CommunityCategoryResponse;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class CategoryService {
 
+    private static final Comparator<Category> CATEGORY_DISPLAY_ORDER_COMPARATOR =
+        Comparator.comparing(
+                Category::getDisplayOrder,
+                Comparator.nullsLast(Integer::compareTo)
+            )
+            .thenComparing(Category::getId);
+
     private final CategoryRetriever categoryRetriever;
 
+    @Transactional(readOnly = true)
     public List<CommunityCategoryResponse> getAllCategoriesWithChildren() {
-        return categoryRetriever.findActiveRootListCategories().stream()
-            .map(CommunityCategoryResponse::fromRoot)
+        List<Category> activeCategories = categoryRetriever.findAllActiveCategoriesWithParent();
+
+        Map<Long, List<Category>> childCategoriesByParentId = activeCategories.stream()
+            .filter(category -> category.getParent() != null)
+            .collect(Collectors.groupingBy(category -> category.getParent().getId()));
+
+        return activeCategories.stream()
+            .filter(category -> category.getParent() == null)
+            .sorted(CATEGORY_DISPLAY_ORDER_COMPARATOR)
+            .map(category -> CommunityCategoryResponse.from(category, childCategoriesByParentId))
             .toList();
     }
 }


### PR DESCRIPTION
## 🐬 요약
커뮤니티 카테고리 전체 조회 API의 응답 생성 방식을 하드코딩 기반에서 DB 기반으로 변경했습니다.

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [ ] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
커뮤니티 카테고리 전체 조회 API의 응답 생성 방식을 하드코딩 기반에서 DB 기반으로 변경했습니다.

기존에는 `FREE`, `PROMOTION`, `SOPTICLE` root category를 고정 조회하고, `PROMOTION`과 `SOPTICLE`의 하위 카테고리는 `CommunityPostListFilter`를 기반으로 코드에서 직접 생성하고 있었습니다. 이로 인해 DB에 추가된 `MEETING` 카테고리가 응답에 포함되지 않았고, 하위 카테고리의 `content` 값도 DB에서 내려줄 수 없었습니다.

이번 변경에서는 활성화된 카테고리 전체를 한 번에 조회한 뒤, `parent` 값을 기준으로 root와 children을 조립하도록 수정했습니다. 이에 따라 DB에서 `parent = null`인 카테고리는 root로 내려가고, `parent`가 존재하는 카테고리는 해당 parent의 children으로 내려갑니다.

### 주요 변경 사항

* `MEETING` 카테고리 조회를 위해 `CommunityCategoryCode`에 `MEETING` 추가
* 활성화된 카테고리 전체를 `parent`와 함께 조회하는 repository 메서드 추가
* root category code 고정 조회 로직 제거
* DB의 `parent` 관계를 기준으로 카테고리 응답 트리 구성
* 하위 카테고리의 `name`, `content`, `hasBlind` 값을 DB 값으로 응답
* 기존 하드코딩된 `PROMOTION`, `SOPTICLE` children 생성 로직 제거
* 기존 FE 연동 호환을 위해 `PROMOTION_EVENT → EVENT`, `SOPTICLE_SERVER → SERVER` 등 응답 code 매핑 유지
* 기존 임시 `ALL` 응답 생성 로직 제거

### 응답 구조 변경

카테고리 전체 조회 API는 기존 response field 형태를 유지합니다.

* `code`
* `name`
* `content`
* `hasBlind`
* `children`

다만 children 생성 기준이 코드 하드코딩에서 DB의 parent-child 관계로 변경됩니다.

예를 들어 `MEETING`의 `parent`가 `FREE`이면 `FREE.children`으로 내려가고, `MEETING`의 `parent`가 `null`이면 root category로 내려갑니다.

### 참고 사항
현재는 기존 목록 조회 필터와의 호환을 위해 일부 category code를 response code로 매핑하고 있습니다.

* `PROMOTION_EVENT` → `EVENT`
* `PROMOTION_PROJECT` → `PROJECT`
* `PROMOTION_RECRUIT` → `RECRUIT`
* `PROMOTION_ETC` → `ETC`
* `SOPTICLE_PLAN` → `PLAN`
* `SOPTICLE_DESIGN` → `DESIGN`
* `SOPTICLE_SERVER` → `SERVER`
* `SOPTICLE_WEB` → `WEB`
* `SOPTICLE_IOS` → `IOS`
* `SOPTICLE_ANDROID` → `ANDROID`
* `SOPTICLE_ETC` → `ETC`

추후 목록 조회 API와 FE 연동 방식이 category code 기반으로 통일되면 해당 임시 매핑 로직은 제거할 수 있습니다.

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #962 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 새로운 "미팅" 카테고리가 추가되었습니다.

* **Improvements**
  * 모든 카테고리가 설정된 표시 순서에 따라 일관되게 정렬되도록 개선되었습니다.
  * 카테고리 계층 구조(부모-자식 관계) 처리 및 조회 성능이 최적화되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sopt-makers/sopt-playground-backend/pull/963?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->