### PR TITLE
[refactor] internal 게시글 webLink 생성 로직 분리 및 링크 수정

### DIFF
--- a/src/main/java/org/sopt/makers/internal/community/mapper/CommunityResponseMapper.java
+++ b/src/main/java/org/sopt/makers/internal/community/mapper/CommunityResponseMapper.java
@@ -2,6 +2,7 @@ package org.sopt.makers.internal.community.mapper;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -9,6 +10,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+
+import lombok.RequiredArgsConstructor;
 import lombok.val;
 
 import org.hibernate.Hibernate;
@@ -16,6 +19,7 @@ import org.sopt.makers.internal.community.domain.enums.CommunityCategoryCode;
 import org.sopt.makers.internal.community.domain.enums.CommunityCategoryGroup;
 import org.sopt.makers.internal.community.domain.enums.CommunityPostSourceType;
 import org.sopt.makers.internal.community.domain.enums.CommunityPostTag;
+import org.sopt.makers.internal.community.service.post.link.CommunityPostWebLinkBuilder;
 import org.sopt.makers.internal.community.utils.MentionCleaner;
 import org.sopt.makers.internal.community.domain.CommunityPost;
 import org.sopt.makers.internal.community.domain.anonymous.AnonymousProfile;
@@ -39,6 +43,7 @@ import org.sopt.makers.internal.community.dto.response.SopticlePostResponse;
 import org.sopt.makers.internal.external.makers.CrewPost;
 import org.sopt.makers.internal.external.platform.InternalUserDetails;
 import org.sopt.makers.internal.external.platform.SoptActivity;
+import org.sopt.makers.internal.internal.dto.InternalLatestPostResponse;
 import org.sopt.makers.internal.internal.dto.InternalPopularPostResponse;
 import org.sopt.makers.internal.member.dto.response.MemberNameAndProfileImageResponse;
 import org.sopt.makers.internal.vote.dto.response.VoteResponse;
@@ -46,9 +51,16 @@ import org.springframework.stereotype.Component;
 
 import static java.util.stream.Collectors.*;
 
+@RequiredArgsConstructor
 @Component
 public class CommunityResponseMapper {
-    public CommentResponse toCommentResponse(CommentInfo info, Long memberId, Boolean isLiked, Integer likeCount) {
+
+    private static final DateTimeFormatter INTERNAL_DATE_TIME_FORMATTER =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS");
+
+    private final CommunityPostWebLinkBuilder communityPostWebLinkBuilder;
+
+	public CommentResponse toCommentResponse(CommentInfo info, Long memberId, Boolean isLiked, Integer likeCount) {
         val comment = info.commentDao().comment();
         if (Boolean.TRUE.equals(comment.getIsDeleted())) {
             return new CommentResponse(
@@ -332,8 +344,51 @@ public class CommunityResponseMapper {
         );
     }
 
-    private AnonymousProfileVo toAnonymousProfileVo(AnonymousProfile anonymousProfile) {
-        return new AnonymousProfileVo(anonymousProfile.getNickname().getNickname(), anonymousProfile.getProfileImg().getImageUrl());
+    public InternalLatestPostResponse toInternalLatestPostResponse(
+        CommunityPost post,
+        SoptActivity latestActivity,
+        InternalUserDetails userDetails,
+        String categoryName,
+        AnonymousProfile anonymousProfile
+    ) {
+        String webLink = communityPostWebLinkBuilder.build(post);
+        String cleanedContent = MentionCleaner.removeMentionIds(post.getContent());
+
+        if (Boolean.TRUE.equals(post.getIsBlindWriter())) {
+            if (anonymousProfile == null) {
+                throw new IllegalStateException("anonymous profile is required for blind post");
+            }
+
+            return InternalLatestPostResponse.builder()
+                .id(post.getId())
+                .userId(null)
+                .profileImage(anonymousProfile.getProfileImg().getImageUrl())
+                .name(anonymousProfile.getNickname().getNickname())
+                .generationAndPart("")
+                .category(categoryName)
+                .title(post.getTitle())
+                .content(cleanedContent)
+                .webLink(webLink)
+                .createdAt(post.getCreatedAt().format(INTERNAL_DATE_TIME_FORMATTER))
+                .build();
+        }
+
+        if (userDetails == null) {
+            throw new IllegalStateException("user details is required for non-blind post");
+        }
+
+        return InternalLatestPostResponse.builder()
+            .id(post.getId())
+            .userId(userDetails.userId())
+            .profileImage(userDetails.profileImage())
+            .name(userDetails.name())
+            .generationAndPart(resolveLatestGenerationAndPart(latestActivity))
+            .category(categoryName)
+            .title(post.getTitle())
+            .content(cleanedContent)
+            .webLink(webLink)
+            .createdAt(post.getCreatedAt().format(INTERNAL_DATE_TIME_FORMATTER))
+            .build();
     }
 
     public InternalPopularPostResponse toInternalPopularPostResponse(
@@ -341,9 +396,11 @@ public class CommunityResponseMapper {
         AnonymousProfile anonymousProfile,
         InternalUserDetails userDetails,
         String categoryName,
-        int rank,
-        String baseUrl
+        int rank
     ) {
+        String webLink = communityPostWebLinkBuilder.build(post);
+        String cleanedContent = MentionCleaner.removeMentionIds(post.getContent());
+
         if (Boolean.TRUE.equals(post.getIsBlindWriter())) {
             if (anonymousProfile == null) {
                 throw new IllegalStateException("anonymous profile is required for blind post");
@@ -358,8 +415,8 @@ public class CommunityResponseMapper {
                 .rank(rank)
                 .category(categoryName)
                 .title(post.getTitle())
-                .content(MentionCleaner.removeMentionIds(post.getContent()))
-                .webLink(baseUrl + post.getId())
+                .content(cleanedContent)
+                .webLink(webLink)
                 .build();
         }
 
@@ -367,27 +424,17 @@ public class CommunityResponseMapper {
             throw new IllegalStateException("user details is required for non-blind post");
         }
 
-        SoptActivity lastActivity = userDetails.soptActivities() == null
-            ? null
-            : userDetails.soptActivities().stream()
-              .max(Comparator.comparing(SoptActivity::generation))
-              .orElse(null);
-
-        String generationAndPart = lastActivity == null
-            ? ""
-            : String.format("%d기 %s", lastActivity.generation(), lastActivity.part());
-
         return InternalPopularPostResponse.builder()
             .id(post.getId())
             .userId(userDetails.userId())
             .profileImage(userDetails.profileImage())
             .name(userDetails.name())
-            .generationAndPart(generationAndPart)
+            .generationAndPart(resolvePopularGenerationAndPart(userDetails))
             .rank(rank)
             .category(categoryName)
             .title(post.getTitle())
-            .content(MentionCleaner.removeMentionIds(post.getContent()))
-            .webLink(baseUrl + post.getId())
+            .content(cleanedContent)
+            .webLink(webLink)
             .build();
     }
 
@@ -474,6 +521,13 @@ public class CommunityResponseMapper {
         return topLevelComments;
     }
 
+    // ==========================================
+    // Private Methods
+    // ==========================================
+    private AnonymousProfileVo toAnonymousProfileVo(AnonymousProfile anonymousProfile) {
+        return new AnonymousProfileVo(anonymousProfile.getNickname().getNickname(), anonymousProfile.getProfileImg().getImageUrl());
+    }
+
     private String getRelativeTime(LocalDateTime createdAt) {
         Duration duration = Duration.between(createdAt, LocalDateTime.now());
 
@@ -497,5 +551,29 @@ public class CommunityResponseMapper {
 
         long years = months / 12;
         return years + "년 전";
+    }
+
+    private String resolveLatestGenerationAndPart(SoptActivity latestActivity) {
+        if (latestActivity == null) {
+            return "";
+        }
+
+        if (!latestActivity.isSopt()) {
+            return String.format("%d기/메이커스", latestActivity.generation());
+        }
+
+        return String.format("%d기 %s", latestActivity.generation(), latestActivity.part());
+    }
+
+    private String resolvePopularGenerationAndPart(InternalUserDetails userDetails) {
+        SoptActivity lastActivity = userDetails.soptActivities() == null
+            ? null
+            : userDetails.soptActivities().stream()
+              .max(Comparator.comparing(SoptActivity::generation))
+              .orElse(null);
+
+        return lastActivity == null
+            ? ""
+            : String.format("%d기 %s", lastActivity.generation(), lastActivity.part());
     }
 }

--- a/src/main/java/org/sopt/makers/internal/community/mapper/CommunityResponseMapper.java
+++ b/src/main/java/org/sopt/makers/internal/community/mapper/CommunityResponseMapper.java
@@ -346,7 +346,6 @@ public class CommunityResponseMapper {
 
     public InternalLatestPostResponse toInternalLatestPostResponse(
         CommunityPost post,
-        SoptActivity latestActivity,
         InternalUserDetails userDetails,
         String categoryName,
         AnonymousProfile anonymousProfile
@@ -382,7 +381,7 @@ public class CommunityResponseMapper {
             .userId(userDetails.userId())
             .profileImage(userDetails.profileImage())
             .name(userDetails.name())
-            .generationAndPart(resolveLatestGenerationAndPart(latestActivity))
+            .generationAndPart(resolveGenerationAndPart(resolveLatestActivity(userDetails)))
             .category(categoryName)
             .title(post.getTitle())
             .content(cleanedContent)
@@ -429,7 +428,7 @@ public class CommunityResponseMapper {
             .userId(userDetails.userId())
             .profileImage(userDetails.profileImage())
             .name(userDetails.name())
-            .generationAndPart(resolvePopularGenerationAndPart(userDetails))
+            .generationAndPart(resolveGenerationAndPart(resolveLatestActivity(userDetails)))
             .rank(rank)
             .category(categoryName)
             .title(post.getTitle())
@@ -553,27 +552,26 @@ public class CommunityResponseMapper {
         return years + "년 전";
     }
 
-    private String resolveLatestGenerationAndPart(SoptActivity latestActivity) {
-        if (latestActivity == null) {
+    private SoptActivity resolveLatestActivity(InternalUserDetails userDetails) {
+        if (userDetails == null || userDetails.soptActivities() == null || userDetails.soptActivities().isEmpty()) {
+            return null;
+        }
+
+        return userDetails.soptActivities().stream()
+            .max(Comparator.comparing(SoptActivity::normalizedGeneration)
+                .thenComparing(SoptActivity::isSopt))
+            .orElse(null);
+    }
+
+    private String resolveGenerationAndPart(SoptActivity activity) {
+        if (activity == null) {
             return "";
         }
 
-        if (!latestActivity.isSopt()) {
-            return String.format("%d기/메이커스", latestActivity.generation());
+        if (!activity.isSopt()) {
+            return String.format("%d기/메이커스", activity.generation());
         }
 
-        return String.format("%d기 %s", latestActivity.generation(), latestActivity.part());
-    }
-
-    private String resolvePopularGenerationAndPart(InternalUserDetails userDetails) {
-        SoptActivity lastActivity = userDetails.soptActivities() == null
-            ? null
-            : userDetails.soptActivities().stream()
-              .max(Comparator.comparing(SoptActivity::generation))
-              .orElse(null);
-
-        return lastActivity == null
-            ? ""
-            : String.format("%d기 %s", lastActivity.generation(), lastActivity.part());
+        return String.format("%d기 %s", activity.generation(), activity.part());
     }
 }

--- a/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostService.java
@@ -725,10 +725,6 @@ public class CommunityPostService {
 
         Map<Long, InternalUserDetails> userDetailsMap = platformService.getInternalUserDetailsMap(authorIds);
 
-        String baseUrl = activeProfile.equals("prod")
-            ? "https://playground.sopt.org/?feed="
-            : "https://sopt-internal-dev.pages.dev/?feed=";
-
         List<InternalPopularPostResponse> responses = new ArrayList<>();
         int rank = 1;
 
@@ -751,8 +747,7 @@ public class CommunityPostService {
                 anonymousProfile,
                 userDetails,
                 resolveRootCategoryName(post.getCategory()),
-                rank++,
-                baseUrl
+                rank++
             ));
         }
 
@@ -904,15 +899,17 @@ public class CommunityPostService {
 
         List<InternalLatestPostResponse> responses = new ArrayList<>();
 
-        String baseUrl = activeProfile.equals("prod")
-            ? "https://playground.sopt.org/?feed="
-            : "https://sopt-internal-dev.pages.dev/?feed=";
-
         for (CommunityPost post : latestPosts) {
             Long authorId = post.getMember().getId();
             InternalUserDetails userDetails = userDetailsMap.get(authorId);
 
             if (userDetails == null) {
+                continue;
+            }
+
+            AnonymousProfile anonymousProfile = anonymousProfileMap.get(post.getId());
+
+            if (Boolean.TRUE.equals(post.getIsBlindWriter()) && anonymousProfile == null) {
                 continue;
             }
 
@@ -923,19 +920,12 @@ public class CommunityPostService {
                        .thenComparing(activity -> !activity.isSopt()))
                   .orElse(null);
 
-            String categoryName = resolveRootCategoryName(post.getCategory());
-
-            Optional<AnonymousProfile> anonymousProfile = Boolean.TRUE.equals(post.getIsBlindWriter())
-                ? Optional.ofNullable(anonymousProfileMap.get(post.getId()))
-                : Optional.empty();
-
-            responses.add(InternalLatestPostResponse.of(
+            responses.add(communityResponseMapper.toInternalLatestPostResponse(
                 post,
                 latestActivity,
                 userDetails,
-                categoryName,
-                anonymousProfile,
-                baseUrl
+                resolveRootCategoryName(post.getCategory()),
+                anonymousProfile
             ));
         }
 

--- a/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostService.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/post/CommunityPostService.java
@@ -72,7 +72,6 @@ import org.sopt.makers.internal.community.service.post.crew.CrewMeetingFetchResu
 import org.sopt.makers.internal.external.makers.CrewPost;
 import org.sopt.makers.internal.external.platform.InternalUserDetails;
 import org.sopt.makers.internal.external.platform.PlatformService;
-import org.sopt.makers.internal.external.platform.SoptActivity;
 import org.sopt.makers.internal.external.pushNotification.message.SimplePushNotificationMessage;
 import org.sopt.makers.internal.common.event.PushNotificationEvent;
 import org.sopt.makers.internal.external.slack.SlackClient;
@@ -913,16 +912,8 @@ public class CommunityPostService {
                 continue;
             }
 
-            SoptActivity latestActivity = userDetails.soptActivities() == null
-                ? null
-                : userDetails.soptActivities().stream()
-                  .max(Comparator.comparing(SoptActivity::generation)
-                       .thenComparing(activity -> !activity.isSopt()))
-                  .orElse(null);
-
             responses.add(communityResponseMapper.toInternalLatestPostResponse(
                 post,
-                latestActivity,
                 userDetails,
                 resolveRootCategoryName(post.getCategory()),
                 anonymousProfile

--- a/src/main/java/org/sopt/makers/internal/community/service/post/link/CommunityPostWebLinkBuilder.java
+++ b/src/main/java/org/sopt/makers/internal/community/service/post/link/CommunityPostWebLinkBuilder.java
@@ -1,0 +1,77 @@
+package org.sopt.makers.internal.community.service.post.link;
+
+import java.util.Objects;
+import org.sopt.makers.internal.community.domain.CommunityPost;
+import org.sopt.makers.internal.community.domain.category.Category;
+import org.sopt.makers.internal.community.domain.enums.CommunityCategoryCode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CommunityPostWebLinkBuilder {
+
+	private static final String PROD_PROFILE = "prod";
+	private static final String PROD_BASE_URL = "https://playground.sopt.org";
+	private static final String DEV_BASE_URL = "https://sopt-internal-dev.pages.dev";
+
+	private final String activeProfile;
+
+	public CommunityPostWebLinkBuilder(
+		@Value("${spring.profiles.active}") String activeProfile
+	) {
+		this.activeProfile = activeProfile;
+	}
+
+	public String build(CommunityPost post) {
+		String baseUrl = resolveBaseUrl();
+		Category category = post.getCategory();
+
+		if (category == null || category.getCode() == null) {
+			return baseUrl + "/feed?feed=" + post.getId();
+		}
+
+		CommunityCategoryCode rootCategoryCode = resolveRootCategoryCode(category);
+
+		if (rootCategoryCode == CommunityCategoryCode.MEETING) {
+			return baseUrl + "/group/post?id=" + post.getId();
+		}
+
+		StringBuilder webLink = new StringBuilder(baseUrl)
+			.append("/feed?category=")
+			.append(rootCategoryCode.name())
+			.append("&feed=")
+			.append(post.getId());
+
+		String subcategory = resolveSubcategory(category);
+		if (subcategory != null) {
+			webLink.append("&subcategory=").append(subcategory);
+		}
+
+		return webLink.toString();
+	}
+
+	private String resolveBaseUrl() {
+		return Objects.equals(activeProfile, PROD_PROFILE)
+			? PROD_BASE_URL
+			: DEV_BASE_URL;
+	}
+
+	private CommunityCategoryCode resolveRootCategoryCode(Category category) {
+		return category.getParent() == null
+			? category.getCode()
+			: category.getParent().getCode();
+	}
+
+	private String resolveSubcategory(Category category) {
+		if (category.getParent() == null) {
+			return null;
+		}
+
+		String rootPrefix = category.getParent().getCode().name() + "_";
+		String categoryCode = category.getCode().name();
+
+		return categoryCode.startsWith(rootPrefix)
+			? categoryCode.substring(rootPrefix.length())
+			: categoryCode;
+	}
+}

--- a/src/main/java/org/sopt/makers/internal/internal/dto/InternalLatestPostResponse.java
+++ b/src/main/java/org/sopt/makers/internal/internal/dto/InternalLatestPostResponse.java
@@ -1,13 +1,6 @@
 package org.sopt.makers.internal.internal.dto;
 
-import java.time.format.DateTimeFormatter;
-import java.util.Optional;
 import lombok.Builder;
-import org.sopt.makers.internal.community.utils.MentionCleaner;
-import org.sopt.makers.internal.community.domain.CommunityPost;
-import org.sopt.makers.internal.community.domain.anonymous.AnonymousProfile;
-import org.sopt.makers.internal.external.platform.InternalUserDetails;
-import org.sopt.makers.internal.external.platform.SoptActivity;
 
 @Builder
 public record InternalLatestPostResponse(
@@ -22,48 +15,4 @@ public record InternalLatestPostResponse(
         String webLink,
         String createdAt
 ) {
-    public static InternalLatestPostResponse of(
-            CommunityPost post,
-            SoptActivity latestActivity,
-            InternalUserDetails userDetails,
-            String categoryName,
-            Optional<AnonymousProfile> anonymousProfile,
-            String baseUrl
-            ) {
-        String generationAndPart = "";
-        if (!post.getIsBlindWriter() && latestActivity != null) {
-            // 메이커스 활동인 경우 "기수/메이커스", SOPT 활동인 경우 "기수 파트"
-            if (!latestActivity.isSopt()) {
-                generationAndPart = String.format("%d기/메이커스", latestActivity.generation());
-            } else {
-                generationAndPart = String.format("%d기 %s", latestActivity.generation(), latestActivity.part());
-            }
-        }
-
-        String finalName = userDetails.name();
-        String finalProfileImage = userDetails.profileImage();
-        Long finalUserId = userDetails.userId();
-
-        if (post.getIsBlindWriter() && anonymousProfile.isPresent()) {
-            AnonymousProfile profile = anonymousProfile.get();
-            finalName = profile.getNickname().getNickname();
-            finalProfileImage = profile.getProfileImg().getImageUrl();
-            finalUserId = null;
-        }
-
-        String cleanedContent = MentionCleaner.removeMentionIds(post.getContent());
-
-        return new InternalLatestPostResponse(
-                post.getId(),
-                finalUserId,
-                finalProfileImage,
-                finalName,
-                generationAndPart,
-                categoryName,
-                post.getTitle(),
-                cleanedContent,
-                baseUrl + post.getId(),
-                post.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS"))
-        );
-    }
 }


### PR DESCRIPTION
## 🐬 요약
PR의 요약을 작성해주세요!

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [ ] 기능 개발
- [x] 코드 스타일 수정 (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
## 작업 내용

* internal 게시글 응답의 `webLink` 생성 로직을 `CommunityPostWebLinkBuilder`로 분리했습니다.
* FE 측 Playground 웹 URL 구조 변경사항을 반영했습니다.

  * prod: `https://playground.sopt.org`
  * dev: `https://sopt-internal-dev.pages.dev`
* 게시글 카테고리에 따라 변경된 웹 링크 형식으로 `webLink`를 생성하도록 수정했습니다.

  * 모임: `/group/post?id={postId}`
  * 자유: `/feed?category=FREE&feed={postId}`
  * 홍보/솝티클 하위 카테고리: `/feed?category={rootCategory}&feed={postId}&subcategory={subcategory}`
* `getPopularPostsForInternal`, `getInternalLatestPosts`에서 base URL 생성 책임을 제거했습니다.
* `CommunityResponseMapper`에서 internal popular/latest 응답을 일관되게 생성하도록 변경했습니다.
* `InternalLatestPostResponse.of(...)`를 제거하고, `InternalPopularPostResponse`와 동일하게 builder-only DTO 구조로 정리했습니다.
* internal popular/latest 응답의 기수/파트 계산 로직을 공통화했습니다.

  * 최신 활동 판단 시 `generation` 대신 `normalizedGeneration`을 기준으로 사용합니다.
  * 동일한 `normalizedGeneration` 내에서는 SOPT 활동을 우선합니다.
  * 메이커스 활동인 경우 `{기수}기/메이커스` 형식으로 반환합니다.

## 배경

FE 측 Playground 웹 URL 구조가 변경되면서 internal API에서 내려주는 `webLink`도 변경된 URL 규칙을 따라야 했습니다.

기존에는 `CommunityPostService`에서 prod/dev base URL을 만들고, mapper 또는 DTO에서 `baseUrl + postId` 형태로 최종 링크를 조립하고 있었습니다. 이로 인해 URL 생성 책임이 service, mapper, DTO에 분산되어 있었고, 변경된 FE URL 구조를 반영하기에도 적절하지 않았습니다.

또한 internal popular/latest 응답에서 기수/파트 정보를 계산하는 로직이 분리되어 있어, 메이커스 활동 포맷이 응답별로 다르게 처리될 수 있었습니다. 이에 latest/popular 응답 모두 동일한 기준으로 최신 활동을 판단하고 기수/파트 문자열을 생성하도록 정리했습니다.

## 변경 후 구조

* `CommunityPostService`

  * 게시글 조회, 필터링, 사용자 정보 조회 담당
  * URL 생성 로직 제거
  * 응답 표현을 위한 기수/파트 계산 로직 제거

* `CommunityResponseMapper`

  * internal popular/latest 응답 DTO 생성 담당
  * `CommunityPostWebLinkBuilder`를 통해 `webLink` 주입
  * internal 응답의 기수/파트 문자열 생성 담당

* `CommunityPostWebLinkBuilder`

  * prod/dev base URL 결정
  * FE 변경사항에 맞춘 카테고리별 게시글 URL 생성 규칙 관리

* `InternalLatestPostResponse`

  * static factory 제거
  * 순수 response record + builder 구조로 정리

## 테스트

* internal 인기글 응답에서 카테고리별 `webLink`가 변경된 FE URL 형식으로 생성되는지 확인
* internal 최신글 응답에서 카테고리별 `webLink`가 변경된 FE URL 형식으로 생성되는지 확인
* 익명 게시글 응답에서 익명 프로필 정보가 기존과 동일하게 내려오는지 확인
* 비익명 게시글 응답에서 유저 정보와 기수/파트 정보가 기존과 동일하게 내려오는지 확인
* 동일한 `normalizedGeneration`에 SOPT 활동과 메이커스 활동이 모두 있는 경우 SOPT 활동 기준으로 기수/파트가 반환되는지 확인

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #968 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 커뮤니티 게시물 응답 매핑 로직을 개선하여 최신 및 인기 게시물 조회 기능 강화
  * 게시물 웹링크 생성 방식을 개선하여 카테고리별 링크 처리 최적화
  * 익명 작성물 처리 로직을 재정비하여 안정성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->