### PR TITLE
[Feat] 프로젝트 통합 검색 및 무한스크롤 응답 보정

### DIFF
--- a/src/main/java/org/sopt/makers/internal/common/util/InfiniteScrollUtil.java
+++ b/src/main/java/org/sopt/makers/internal/common/util/InfiniteScrollUtil.java
@@ -1,6 +1,6 @@
 package org.sopt.makers.internal.common.util;
 
-import lombok.val;
+import org.sopt.makers.internal.exception.BadRequestException;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -9,8 +9,15 @@ import java.util.List;
 @Component
 public class InfiniteScrollUtil {
     public Integer checkLimitForPagination(Integer limit) {
-        val isLimitEmpty = (limit == null || limit <= 0);
-        return isLimitEmpty ? null : limit + 1;
+        if (limit == null || limit == 0) {
+            return null;
+        }
+
+        if (limit < 0) {
+            throw new BadRequestException("limit은 0 이상이어야 합니다.");
+        }
+
+        return limit + 1;
     }
 
     public <T> Boolean checkHasNextElement(Integer limit, List<T> elementList) {

--- a/src/main/java/org/sopt/makers/internal/common/util/InfiniteScrollUtil.java
+++ b/src/main/java/org/sopt/makers/internal/common/util/InfiniteScrollUtil.java
@@ -9,17 +9,19 @@ import java.util.List;
 @Component
 public class InfiniteScrollUtil {
     public Integer checkLimitForPagination(Integer limit) {
-        val isLimitEmpty = (limit == null || limit == 0);
+        val isLimitEmpty = (limit == null || limit <= 0);
         return isLimitEmpty ? null : limit + 1;
     }
 
-    public <T extends Record> Boolean checkHasNextElement(Integer limit, List<T> elementList) {
-        val hasNextElement = ((limit != null && limit != 0) && elementList.size() > limit);
+    public <T> Boolean checkHasNextElement(Integer limit, List<T> elementList) {
+        return (limit != null && limit > 0) && elementList.size() > limit;
+    }
 
-        elementList = new ArrayList<>(elementList);
-        if (hasNextElement) {
-            elementList.remove(elementList.size() - 1);
+    public <T> List<T> removeNextElementIfExist(Integer limit, List<T> elementList) {
+        if (!checkHasNextElement(limit, elementList)) {
+            return elementList;
         }
-        return hasNextElement;
+
+        return new ArrayList<>(elementList.subList(0, limit));
     }
 }

--- a/src/main/java/org/sopt/makers/internal/project/controller/ProjectController.java
+++ b/src/main/java/org/sopt/makers/internal/project/controller/ProjectController.java
@@ -4,10 +4,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.sopt.makers.internal.common.util.InfiniteScrollUtil;
 import org.sopt.makers.internal.project.domain.Project;
@@ -54,35 +54,57 @@ public class ProjectController {
     }
 
     @Operation(
-            summary = "Project 전체 조회 API",
-            description = "cursor : 처음에는 null 또는 0, 이후 마지막으로 조회된 project id"
+        summary = "Project 전체 조회 API",
+        description = """
+                cursor : 처음에는 null 또는 0, 이후 마지막으로 조회된 project id
+                name : 프로젝트명, 요약, 상세 설명을 대상으로 검색하는 통합 검색어
+                """
     )
     @GetMapping("")
     public ResponseEntity<ProjectAllResponse> getProjects (
-            @RequestParam(required = false, name = "limit") Integer limit,
-            @RequestParam(required = false, name = "cursor") Long cursor,
-            @RequestParam(required = false, name = "name") String name,
-            @RequestParam(required = false, name = "category") String category,
-            @RequestParam(required = false, name = "isAvailable") Boolean isAvailable,
-            @RequestParam(required = false, name = "isFounding") Boolean isFounding,
-            @RequestParam(required = false, name = "generation") Integer generation
+        @RequestParam(required = false, name = "limit") Integer limit,
+        @RequestParam(required = false, name = "cursor") Long cursor,
+        @RequestParam(required = false, name = "name") String searchWord,
+        @RequestParam(required = false, name = "category") String category,
+        @RequestParam(required = false, name = "isAvailable") Boolean isAvailable,
+        @RequestParam(required = false, name = "isFounding") Boolean isFounding,
+        @RequestParam(required = false, name = "generation") Integer generation
     ) {
-        List<Project> projectList = projectService.fetchAll(infiniteScrollUtil.checkLimitForPagination(limit),
-                        cursor, name, category, isAvailable, isFounding, generation);
-        List<ProjectResponse> projectResponseList = new ArrayList<>(
-                projectService.getAllProjectResponseList(projectList).stream()
-                        .sorted(Comparator.comparing(ProjectResponse::id).reversed())
-                        .toList());
-        Boolean hasNextProject = infiniteScrollUtil.checkHasNextElement(limit, projectResponseList);
-        int totalProjectsCount = projectService.getProjectsCount(name, category, isAvailable, isFounding, generation);
+        List<Project> projectList = projectService.fetchAll(
+            infiniteScrollUtil.checkLimitForPagination(limit),
+            cursor,
+            searchWord,
+            category,
+            isAvailable,
+            isFounding,
+            generation
+        );
 
-        ProjectAllResponse responses = new ProjectAllResponse(projectResponseList, hasNextProject, totalProjectsCount);
+        Boolean hasNextProject = infiniteScrollUtil.checkHasNextElement(limit, projectList);
+        List<Project> responseProjectList = infiniteScrollUtil.removeNextElementIfExist(limit, projectList);
+
+        List<ProjectResponse> projectResponseList = projectService.getAllProjectResponseList(responseProjectList);
+
+        int totalProjectsCount = projectService.getProjectsCount(
+            searchWord,
+            category,
+            isAvailable,
+            isFounding,
+            generation
+        );
+
+        ProjectAllResponse responses = new ProjectAllResponse(
+            projectResponseList,
+            hasNextProject,
+            totalProjectsCount
+        );
+
         return ResponseEntity.status(HttpStatus.OK).body(responses);
     }
 
     @Operation(summary = "Project 생성 API")
     @PostMapping("")
-    public ResponseEntity<Map<String, Boolean>> createProject (@RequestBody ProjectSaveRequest request) {
+    public ResponseEntity<Map<String, Boolean>> createProject (@RequestBody @Valid ProjectSaveRequest request) {
         projectService.createProject(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(Map.of("success", true));
     }
@@ -92,7 +114,7 @@ public class ProjectController {
     public ResponseEntity<Map<String, Boolean>> updateProject (
             @PathVariable("id") Long projectId,
             @Parameter(hidden = true) @AuthenticationPrincipal Long userId,
-            @RequestBody ProjectUpdateRequest request
+            @RequestBody @Valid ProjectUpdateRequest request
     ) {
         projectService.updateProject(userId, projectId, request);
         return ResponseEntity.status(HttpStatus.OK).body(Map.of("success", true));

--- a/src/main/java/org/sopt/makers/internal/project/dto/request/ProjectSaveRequest.java
+++ b/src/main/java/org/sopt/makers/internal/project/dto/request/ProjectSaveRequest.java
@@ -39,6 +39,20 @@ public record ProjectSaveRequest(
         List<ProjectMemberSaveRequest> members,
         List<ProjectLinkSaveRequest> links
 ) {
+    public ProjectSaveRequest {
+        if (images == null) {
+            images = List.of();
+        }
+
+        if (members == null) {
+            members = List.of();
+        }
+
+        if (links == null) {
+            links = List.of();
+        }
+    }
+
     public record ProjectMemberSaveRequest(
             Long memberId,
             String memberRole,

--- a/src/main/java/org/sopt/makers/internal/project/dto/request/ProjectSaveRequest.java
+++ b/src/main/java/org/sopt/makers/internal/project/dto/request/ProjectSaveRequest.java
@@ -1,6 +1,8 @@
 package org.sopt.makers.internal.project.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -22,8 +24,12 @@ public record ProjectSaveRequest(
         Boolean isAvailable,
         Boolean isFounding,
         @Schema(required = true)
+        @NotBlank(message = "summary는 필수입니다.")
+        @Size(max = 30, message = "summary는 30자 이하여야 합니다.")
         String summary,
         @Schema(required = true)
+        @NotBlank(message = "detail은 필수입니다.")
+        @Size(max = 3000, message = "detail은 3000자 이하여야 합니다.")
         String detail,
         @Schema(required = true)
         String logoImage,

--- a/src/main/java/org/sopt/makers/internal/project/dto/request/ProjectUpdateRequest.java
+++ b/src/main/java/org/sopt/makers/internal/project/dto/request/ProjectUpdateRequest.java
@@ -1,6 +1,8 @@
 package org.sopt.makers.internal.project.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -19,8 +21,12 @@ public record ProjectUpdateRequest(
         Boolean isAvailable,
         Boolean isFounding,
         @Schema(required = true)
+        @NotBlank(message = "summary는 필수입니다.")
+        @Size(max = 30, message = "summary는 30자 이하여야 합니다.")
         String summary,
         @Schema(required = true)
+        @NotBlank(message = "detail은 필수입니다.")
+        @Size(max = 3000, message = "detail은 3000자 이하여야 합니다.")
         String detail,
         @Schema(required = true)
         String logoImage,

--- a/src/main/java/org/sopt/makers/internal/project/repository/ProjectQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/project/repository/ProjectQueryRepository.java
@@ -6,6 +6,7 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
@@ -128,14 +129,14 @@ public class ProjectQueryRepository {
         }
 
         val project = QProject.project;
-        String likeSearchWord = "%" + escapeLikePattern(searchWord.trim()) + "%";
+        String likeSearchWord = "%" + escapeLikePattern(searchWord.trim().toLowerCase(Locale.ROOT)) + "%";
 
         return Expressions.booleanTemplate(
             """
 			(
-				lower({0}) like lower({1}) escape '\\'
-				or lower({2}) like lower({1}) escape '\\'
-				or lower({3}) like lower({1}) escape '\\'
+				lower({0}) like {1} escape '\\'
+				or lower({2}) like {1} escape '\\'
+				or lower({3}) like {1} escape '\\'
 			)
 			""",
             project.name,

--- a/src/main/java/org/sopt/makers/internal/project/repository/ProjectQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/project/repository/ProjectQueryRepository.java
@@ -22,178 +22,173 @@ import org.springframework.stereotype.Repository;
 public class ProjectQueryRepository {
     private final JPAQueryFactory queryFactory;
 
-//    private JPAQuery<ProjectMemberDao> getProjectQuery () {
-//        val project = QProject.project;
-//        val member = QMember.member;
-//        val relation = QMemberProjectRelation.memberProjectRelation;
-//
-//        return queryFactory.select(
-//                        new QProjectMemberDao(
-//                                project.id, project.name, project.writerId, project.generation, project.category,
-//                                project.startAt, project.endAt, project.serviceType, project.isAvailable, project.isFounding,
-//                                project.summary, project.detail, project.logoImage, project.thumbnailImage, project.images,
-//                                project.createdAt, project.updatedAt,
-//                                member.id, member.hasProfile,
-//                                relation.role, relation.description, relation.isTeamMember
-//                        )).from(project)
-//                .innerJoin(relation).on(relation.projectId.eq(project.id))
-//                .innerJoin(member).on(relation.userId.eq(member.id));
-//    }
-
-    private JPAQuery<ProjectLinkDao> getProjectLinkQuery () {
+    private JPAQuery<ProjectLinkDao> getProjectLinkQuery() {
         val project = QProject.project;
         val projectLink = QProjectLink.projectLink;
 
         return queryFactory.select(
-                        Projections.constructor(ProjectLinkDao.class,
-                                project.id, project.name,
-                                projectLink.id, projectLink.title, projectLink.url
-                        )).from(project)
-                .innerJoin(projectLink).on(projectLink.projectId.eq(project.id));
+                Projections.constructor(
+                    ProjectLinkDao.class,
+                    project.id,
+                    project.name,
+                    projectLink.id,
+                    projectLink.title,
+                    projectLink.url
+                )
+            ).from(project)
+            .innerJoin(projectLink).on(projectLink.projectId.eq(project.id));
     }
 
-    private BooleanExpression checkProjectContainsName(String name) {
-        val checkNameIsEmpty = Objects.isNull(name);
-        if (checkNameIsEmpty) {
-            return null;
-        }
-        // Expressions.stringTemplate를 사용하여 직접 SQL 작성 (escape 없이)
-        return Expressions.booleanTemplate(
-            "lower({0}) like lower({1})",
-            QProject.project.name,
-            "%" + name + "%"
-        );
-    }
-
-    private BooleanExpression checkProjectCategory(String category) {
-        val checkCategoryIsEmpty = Objects.isNull(category);
-        return checkCategoryIsEmpty ? null : QProject.project.category.eq(category);
-    }
-
-    private BooleanExpression checkProjectIsFounding(Boolean isFounding) {
-        val checkIsFoundingIsEmpty = Objects.isNull(isFounding);
-        return checkIsFoundingIsEmpty ? null : QProject.project.isFounding.eq(isFounding);
-    }
-
-    private BooleanExpression checkProjectIsAvailable(Boolean isAvailable) {
-        val checkIsAvailableIsEmpty = Objects.isNull(isAvailable);
-        return checkIsAvailableIsEmpty ? null : QProject.project.isAvailable.eq(isAvailable);
-    }
-
-    private BooleanExpression checkProjectGeneration(Integer generation) {
-        return Objects.isNull(generation) ? null : QProject.project.generation.eq(generation);
-    }
-
-    private BooleanExpression ltProjectId(Long projectId) {
-        val project = QProject.project;
-        if(projectId == null || projectId == 0) return null;
-        return project.id.lt(projectId);
-    }
-
-//    public List<ProjectMemberDao> findById(Long id) {
-//        val project = QProject.project;
-//        return getProjectQuery().where(project.id.eq(id)).fetch();
-//    }
-
-//    public List<ProjectLinkDao> findLinksById(Long id) {
-//        val project = QProject.project;
-//        return getProjectLinkQuery().where(project.id.eq(id)).fetch();
-//    }
-    
     public List<ProjectLinkDao> findAllLinks() {
         return getProjectLinkQuery().fetch();
     }
 
-    public List<Project> findAllProjects(
-            String category, Boolean isAvailable, Boolean isFounding, Integer generation
+    public List<Project> findProjects(
+        Integer limit,
+        Long cursor,
+        String searchWord,
+        String category,
+        Boolean isAvailable,
+        Boolean isFounding,
+        Integer generation
     ) {
         val project = QProject.project;
 
-        return queryFactory.selectFrom(project)
-                .where(checkProjectIsFounding(isFounding), checkProjectCategory(category),
-                        checkProjectIsAvailable(isAvailable), checkProjectGeneration(generation))
-                .orderBy(project.id.desc())
-                .groupBy(project.id)
-                .fetch();
+        JPAQuery<Project> query = queryFactory.selectFrom(project)
+            .where(
+                ltProjectId(cursor),
+                checkProjectContainsSearchWord(searchWord),
+                checkProjectIsFounding(isFounding),
+                checkProjectCategory(category),
+                checkProjectIsAvailable(isAvailable),
+                checkProjectGeneration(generation)
+            )
+            .orderBy(project.id.desc());
+
+        if (limit != null) {
+            query.limit(limit);
+        }
+
+        return query.fetch();
     }
 
-    public List<Project> findAllNameProjects(
-            String name, String category, Boolean isAvailable, Boolean isFounding, Integer generation
+    public int countAllProjects(
+        String searchWord,
+        String category,
+        Boolean isAvailable,
+        Boolean isFounding,
+        Integer generation
     ) {
         val project = QProject.project;
 
-        return queryFactory.selectFrom(project)
-                .where(checkProjectContainsName(name), checkProjectIsFounding(isFounding),
-                        checkProjectCategory(category), checkProjectIsAvailable(isAvailable),
-                        checkProjectGeneration(generation))
-                .orderBy(project.id.desc())
-                .groupBy(project.id)
-                .fetch();
-    }
+        Long count = queryFactory.select(project.id.count())
+            .from(project)
+            .where(
+                checkProjectContainsSearchWord(searchWord),
+                checkProjectIsFounding(isFounding),
+                checkProjectCategory(category),
+                checkProjectIsAvailable(isAvailable),
+                checkProjectGeneration(generation)
+            )
+            .fetchOne();
 
-    public List<Project> findAllLimitedProjects(
-            Integer limit, Long cursor, String category, Boolean isAvailable, Boolean isFounding, Integer generation
-    ) {
-        val project = QProject.project;
-
-        return queryFactory.selectFrom(project)
-                .where(ltProjectId(cursor), checkProjectIsFounding(isFounding),
-                        checkProjectCategory(category), checkProjectIsAvailable(isAvailable),
-                        checkProjectGeneration(generation))
-                .limit(limit)
-                .orderBy(project.id.desc())
-                .groupBy(project.id)
-                .fetch();
-    }
-
-    public List<Project> findAllLimitedProjectsContainsName(
-            Integer limit, Long cursor, String name, String category, Boolean isAvailable, Boolean isFounding, Integer generation
-    ) {
-        val project = QProject.project;
-
-        return queryFactory.selectFrom(project)
-                .where(ltProjectId(cursor), checkProjectContainsName(name), checkProjectIsFounding(isFounding),
-                        checkProjectCategory(category), checkProjectIsAvailable(isAvailable),
-                        checkProjectGeneration(generation))
-                .limit(limit)
-                .orderBy(project.id.desc())
-                .groupBy(project.id)
-                .fetch();
-    }
-
-    public int countAllProjects(String name, String category, Boolean isAvailable, Boolean isFounding, Integer generation) {
-        val project = QProject.project;
-        Long count = queryFactory.select(project.id.countDistinct())
-                .from(project)
-                .where(checkProjectContainsName(name), checkProjectIsFounding(isFounding),
-                        checkProjectCategory(category), checkProjectIsAvailable(isAvailable),
-                        checkProjectGeneration(generation))
-                .fetchOne();
         return count == null ? 0 : count.intValue();
     }
 
     public int countProjectsExcludeSopkathon(Long memberId) {
-        QMember member = QMember.member;
-        QProject project = QProject.project;
-        QMemberProjectRelation relation = QMemberProjectRelation.memberProjectRelation;
+        val member = QMember.member;
+        val project = QProject.project;
+        val relation = QMemberProjectRelation.memberProjectRelation;
 
-        return queryFactory.select(project.id)
-                .from(project)
-                .innerJoin(relation).on(relation.projectId.eq(project.id))
-                .innerJoin(member).on(relation.userId.eq(member.id))
-                .where(
-                    member.id.eq(memberId)
-                    .and(project.category.ne("SOPKATHON")))
-                .fetch()
-                .size();
+        Long count = queryFactory.select(project.id.countDistinct())
+            .from(project)
+            .innerJoin(relation).on(relation.projectId.eq(project.id))
+            .innerJoin(member).on(relation.userId.eq(member.id))
+            .where(
+                member.id.eq(memberId),
+                project.category.ne("SOPKATHON")
+            )
+            .fetchOne();
+
+        return count == null ? 0 : count.intValue();
     }
 
     public List<Project> findRandomProjects(int limit) {
         val project = QProject.project;
 
         return queryFactory.selectFrom(project)
-                .orderBy(Expressions.numberTemplate(Double.class, "random()").asc())
-                .limit(limit)
-                .fetch();
+            .orderBy(Expressions.numberTemplate(Double.class, "random()").asc())
+            .limit(limit)
+            .fetch();
+    }
+
+    private BooleanExpression checkProjectContainsSearchWord(String searchWord) {
+        if (searchWord == null || searchWord.trim().isEmpty()) {
+            return null;
+        }
+
+        val project = QProject.project;
+        String likeSearchWord = "%" + escapeLikePattern(searchWord.trim()) + "%";
+
+        return Expressions.booleanTemplate(
+            """
+			(
+				lower({0}) like lower({1}) escape '\\'
+				or lower({2}) like lower({1}) escape '\\'
+				or lower({3}) like lower({1}) escape '\\'
+			)
+			""",
+            project.name,
+            likeSearchWord,
+            project.summary,
+            project.detail
+        );
+    }
+
+    private BooleanExpression checkProjectCategory(String category) {
+        if (Objects.isNull(category)) {
+            return null;
+        }
+
+        return QProject.project.category.eq(category);
+    }
+
+    private BooleanExpression checkProjectIsFounding(Boolean isFounding) {
+        if (Objects.isNull(isFounding)) {
+            return null;
+        }
+
+        return QProject.project.isFounding.eq(isFounding);
+    }
+
+    private BooleanExpression checkProjectIsAvailable(Boolean isAvailable) {
+        if (Objects.isNull(isAvailable)) {
+            return null;
+        }
+
+        return QProject.project.isAvailable.eq(isAvailable);
+    }
+
+    private BooleanExpression checkProjectGeneration(Integer generation) {
+        if (Objects.isNull(generation)) {
+            return null;
+        }
+
+        return QProject.project.generation.eq(generation);
+    }
+
+    private BooleanExpression ltProjectId(Long projectId) {
+        if (projectId == null || projectId == 0) {
+            return null;
+        }
+
+        return QProject.project.id.lt(projectId);
+    }
+
+    private String escapeLikePattern(String value) {
+        return value
+            .replace("\\", "\\\\")
+            .replace("%", "\\%")
+            .replace("_", "\\_");
     }
 }

--- a/src/main/java/org/sopt/makers/internal/project/repository/ProjectRepository.java
+++ b/src/main/java/org/sopt/makers/internal/project/repository/ProjectRepository.java
@@ -6,5 +6,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface ProjectRepository extends JpaRepository<Project, Long> {
-    List<Project> findAllByNameContaining(String name);
 }

--- a/src/main/java/org/sopt/makers/internal/project/service/ProjectService.java
+++ b/src/main/java/org/sopt/makers/internal/project/service/ProjectService.java
@@ -168,33 +168,50 @@ public class ProjectService {
     }
 
     @Transactional(readOnly = true)
-    public List<Project> fetchAll (Integer limit, Long cursor, String name, String category, Boolean isAvailable, Boolean isFounding, Integer generation) {
-        if(limit != null && name != null) {
-            return projectQueryRepository.findAllLimitedProjectsContainsName(limit, cursor, name, category, isAvailable, isFounding, generation);
-        } else if(limit != null) {
-            return projectQueryRepository.findAllLimitedProjects(limit, cursor, category, isAvailable, isFounding, generation);
-        } else if(name != null) {
-            return projectQueryRepository.findAllNameProjects(name, category, isAvailable, isFounding, generation);
-        }
-        return projectQueryRepository.findAllProjects(category, isAvailable, isFounding, generation);
+    public List<Project> fetchAll (
+        Integer limit,
+        Long cursor,
+        String searchWord,
+        String category,
+        Boolean isAvailable,
+        Boolean isFounding,
+        Integer generation
+    ) {
+        return projectQueryRepository.findProjects(
+            limit,
+            cursor,
+            searchWord,
+            category,
+            isAvailable,
+            isFounding,
+            generation
+        );
     }
 
     @Transactional(readOnly = true)
     public List<ProjectResponse> getAllProjectResponseList(List<Project> projectList) {
+        if (projectList.isEmpty()) {
+            return List.of();
+        }
+
         List<Long> projectIds = projectList.stream().map(Project::getId).toList();
+
         Map<Long, List<ProjectLinkResponse>> linksByProjectId = projectLinkRepository.findAllByProjectIdIn(projectIds)
-                .stream()
-                .collect(Collectors.groupingBy(
-                        ProjectLink::getProjectId,
-                        Collectors.mapping(link -> new ProjectLinkResponse(link.getId(), link.getTitle(), link.getUrl()), Collectors.toList())
-                ));
+            .stream()
+            .collect(Collectors.groupingBy(
+                ProjectLink::getProjectId,
+                Collectors.mapping(
+                    link -> new ProjectLinkResponse(link.getId(), link.getTitle(), link.getUrl()),
+                    Collectors.toList()
+                )
+            ));
 
         return projectList.stream()
-                .map(project -> projectResponseMapper.toProjectResponse(
-                        project,
-                        linksByProjectId.getOrDefault(project.getId(), List.of())
-                ))
-                .toList();
+            .map(project -> projectResponseMapper.toProjectResponse(
+                project,
+                linksByProjectId.getOrDefault(project.getId(), List.of())
+            ))
+            .toList();
     }
 
     @Transactional(readOnly = true)
@@ -213,8 +230,20 @@ public class ProjectService {
     }
 
     @Transactional(readOnly = true)
-    public int getProjectsCount(String name, String category, Boolean isAvailable, Boolean isFounding, Integer generation) {
-        return projectQueryRepository.countAllProjects(name, category, isAvailable, isFounding, generation);
+    public int getProjectsCount(
+        String searchWord,
+        String category,
+        Boolean isAvailable,
+        Boolean isFounding,
+        Integer generation
+    ) {
+        return projectQueryRepository.countAllProjects(
+            searchWord,
+            category,
+            isAvailable,
+            isFounding,
+            generation
+        );
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/makers/internal/wordchaingame/controller/WordChainGameController.java
+++ b/src/main/java/org/sopt/makers/internal/wordchaingame/controller/WordChainGameController.java
@@ -62,11 +62,19 @@ public class WordChainGameController {
             @RequestParam(required = false, name = "limit") Integer limit,
             @RequestParam(required = false, name = "cursor") Long cursor
     ) {
-        List<WordChainGameRoom> rooms = wordChainGameService.getAllRoom(infiniteScrollUtil.checkLimitForPagination(limit), cursor);
-        Map<Long, InternalUserDetails> startUserMap = wordChainGameService.getUserMapFromCreatedUserIds(rooms);;
+        List<WordChainGameRoom> rooms = wordChainGameService.getAllRoom(
+            infiniteScrollUtil.checkLimitForPagination(limit),
+            cursor
+        );
 
-        List<WordChainGameRoomResponse> roomList = rooms.stream().map(room -> wordChainGameService.toRoomResponse(room, startUserMap)).toList();
-        boolean hasNextGame = infiniteScrollUtil.checkHasNextElement(limit, roomList);
+        boolean hasNextGame = infiniteScrollUtil.checkHasNextElement(limit, rooms);
+        List<WordChainGameRoom> responseRooms = infiniteScrollUtil.removeNextElementIfExist(limit, rooms);
+
+        Map<Long, InternalUserDetails> startUserMap = wordChainGameService.getUserMapFromCreatedUserIds(responseRooms);
+
+        List<WordChainGameRoomResponse> roomList = responseRooms.stream()
+            .map(room -> wordChainGameService.toRoomResponse(room, startUserMap))
+            .toList();
 
         WordChainGameAllResponse response = new WordChainGameAllResponse(roomList, hasNextGame);
         return ResponseEntity.status(HttpStatus.OK).body(response);
@@ -91,9 +99,15 @@ public class WordChainGameController {
         @RequestParam(required = false, name = "limit") Integer limit,
         @RequestParam(required = false, name = "cursor") Integer cursor
     ) {
-        val winners = wordChainGameService.getAllWinner(infiniteScrollUtil.checkLimitForPagination(limit), cursor);
+        val winners = wordChainGameService.getAllWinner(
+            infiniteScrollUtil.checkLimitForPagination(limit),
+            cursor
+        );
+
         val hasNextWinner = infiniteScrollUtil.checkHasNextElement(limit, winners);
-        val response = new WordChainGameWinnerAllResponse(winners, hasNextWinner);
+        val responseWinners = infiniteScrollUtil.removeNextElementIfExist(limit, winners);
+
+        val response = new WordChainGameWinnerAllResponse(responseWinners, hasNextWinner);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }


### PR DESCRIPTION
## 🐬 요약
프로젝트 전체 조회 API에서 기존 `name` 검색 파라미터를 유지하면서, 검색 대상을 프로젝트명뿐 아니라 요약과 상세 설명까지 확장했습니다.

기존에는 `projects.name`만 검색했지만, 이제 `projects.name`, `projects.summary`, `projects.detail`을 대상으로 통합 검색합니다.

또한 무한스크롤 조회 시 `hasNext` 판단을 위해 `limit + 1`개를 조회한 뒤, 실제 응답에는 초과 조회된 데이터를 제거하도록 수정했습니다.

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [x] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
### 프로젝트 통합 검색 추가

* 기존 API 파라미터 `name` 유지
* 내부적으로는 `searchWord`로 사용
* 검색 대상 확장

  * `projects.name`
  * `projects.summary`
  * `projects.detail`
* `%`, `_`, `\` 문자를 LIKE wildcard가 아닌 일반 문자로 검색할 수 있도록 escape 처리 추가
* 기존 분기형 조회 메서드 제거

  * `findAllProjects`
  * `findAllNameProjects`
  * `findAllLimitedProjects`
  * `findAllLimitedProjectsContainsName`
* `findProjects` 단일 메서드로 프로젝트 조회 로직 통합
* 사용하지 않는 `ProjectRepository.findAllByNameContaining` 제거

### 무한스크롤 응답 보정

* `InfiniteScrollUtil`에 `removeNextElementIfExist` 추가
* `limit <= 0`인 경우 pagination limit이 적용되지 않도록 보정
* `limit + 1`개 조회 후 `hasNext`를 계산하고, 실제 응답에는 `limit`개만 내려가도록 수정
* Project 전체 조회 API와 끝말잇기 게임 조회 API에 동일한 무한스크롤 보정 로직 적용
* 프로젝트 응답 변환 전 extra row를 제거하여 불필요한 링크 조회 방지
* 프로젝트 목록이 비어 있을 경우 링크 조회를 생략하도록 방어 코드 추가

### 프로젝트 생성/수정 요청 validation 추가

* `ProjectSaveRequest`, `ProjectUpdateRequest`의 텍스트 길이 제한 추가

  * `summary`: 최대 30자
  * `detail`: 최대 3000자

## 변경 대상

* `InfiniteScrollUtil`
* `ProjectController`
* `ProjectService`
* `ProjectQueryRepository`
* `ProjectRepository`
* `WordChainGameController`
* `ProjectSaveRequest`
* `ProjectUpdateRequest`

## DB 작업 안내

이번 PR에는 DB index SQL을 코드 변경으로 포함하지 않습니다.

다만 프로젝트 통합 검색은 `name`, `summary`, `detail`에 대한 부분 문자열 검색을 수행하므로, 검색 성능 개선을 위해 배포 전후 운영 DB에 아래 SQL을 별도로 적용해야 합니다.

```sql
CREATE EXTENSION IF NOT EXISTS pg_trgm;

CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_projects_name_trgm
ON projects USING gin (lower(name) gin_trgm_ops);

CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_projects_summary_trgm
ON projects USING gin (lower(summary) gin_trgm_ops);

CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_projects_detail_trgm
ON projects USING gin (lower(detail) gin_trgm_ops);
```

`CONCURRENTLY`는 transaction 내부에서 실행할 수 없으므로, 운영 DB에 별도 SQL로 직접 적용합니다.

## 참고 사항

기존 API 호환성을 유지하기 위해 request parameter 이름은 `name`을 그대로 사용합니다.

다만 해당 파라미터의 의미는 기존 “프로젝트명 검색”에서 “프로젝트명, 요약, 상세 설명을 대상으로 하는 통합 검색어”로 확장되었습니다.

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #975 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 프로젝트 목록 조회에서 검색 범위가 확장되어, 이름뿐 아니라 소개와 상세 내용까지 함께 검색할 수 있습니다.
  * 목록 조회와 페이지네이션 동작이 정리되어, 다음 페이지 여부와 반환 항목이 더 일관되게 처리됩니다.

* **Bug Fixes**
  * 프로젝트 생성/수정 시 입력값 검증이 강화되어, 필수 항목 누락이나 길이 초과를 더 정확하게 막습니다.
  * 게임룸 및 승자 목록 조회에서 페이지네이션 결과가 올바르게 반영되도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->