### PR TITLE
[Fix] 프로젝트 검색어 특수문자 escape 처리 수정

### DIFF
--- a/src/main/java/org/sopt/makers/internal/project/repository/ProjectQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/project/repository/ProjectQueryRepository.java
@@ -129,21 +129,12 @@ public class ProjectQueryRepository {
         }
 
         val project = QProject.project;
-        String likeSearchWord = "%" + escapeLikePattern(searchWord.trim().toLowerCase(Locale.ROOT)) + "%";
+        String normalizedSearchWord = searchWord.trim().toLowerCase(Locale.ROOT);
+        String likeSearchWord = "%" + escapeLikePattern(normalizedSearchWord) + "%";
 
-        return Expressions.booleanTemplate(
-            """
-			(
-				lower({0}) like {1} escape '\\'
-				or lower({2}) like {1} escape '\\'
-				or lower({3}) like {1} escape '\\'
-			)
-			""",
-            project.name,
-            likeSearchWord,
-            project.summary,
-            project.detail
-        );
+        return project.name.lower().like(likeSearchWord, '!')
+            .or(project.summary.lower().like(likeSearchWord, '!'))
+            .or(project.detail.lower().like(likeSearchWord, '!'));
     }
 
     private BooleanExpression checkProjectCategory(String category) {
@@ -188,8 +179,8 @@ public class ProjectQueryRepository {
 
     private String escapeLikePattern(String value) {
         return value
-            .replace("\\", "\\\\")
-            .replace("%", "\\%")
-            .replace("_", "\\_");
+            .replace("!", "!!")
+            .replace("%", "!%")
+            .replace("_", "!_");
     }
 }


### PR DESCRIPTION
## 🐬 요약
프로젝트 검색어 특수문자 escape 처리 수정

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [x] 버그 수정
- [ ] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
프로젝트 통합 검색에서 검색어에 특수문자가 포함될 때 발생하던 LIKE escape 처리 오류를 수정했습니다.

기존에는 `Expressions.booleanTemplate`으로 SQL escape 구문을 직접 작성했으나, Hibernate/QueryDSL 변환 과정에서 escape 문자가 올바르게 렌더링되지 않아 검색 요청 시 SQL syntax error가 발생했습니다.

## 발생한 문제

아래와 같은 프로젝트 검색 요청에서 500 에러가 발생했습니다.

```text
GET /api/v1/projects?limit=20&name=함께
GET /api/v1/projects?limit=20&name=%25
GET /api/v1/projects?limit=20&name=%21
```

에러 타입은 `InvalidDataAccessResourceUsageException`이었고, PostgreSQL에서 아래 오류가 발생했습니다.

```text
ERROR: syntax error at or near "\"
```

실제 SQL에서는 LIKE escape 구문이 다음처럼 잘못 렌더링되었습니다.

```sql
lower(p1_0.name) like ? escape \
```

PostgreSQL에서는 `ESCAPE` 문자가 문자열 리터럴 형태로 전달되어야 하므로, 위 SQL은 문법 오류가 발생합니다.

## 원인

기존 구현에서는 `Expressions.booleanTemplate` 안에서 escape 문자를 직접 작성했습니다.

```sql
escape '\\'
```

하지만 JPQL/Hibernate/SQL 변환 과정을 거치면서 백슬래시가 문자열 리터럴로 안전하게 렌더링되지 않고, 최종 SQL에서 `escape \` 형태로 출력되었습니다.

그 결과 검색어 자체가 일반 문자열이어도, 검색 조건이 포함된 요청에서는 SQL syntax error가 발생할 수 있었습니다.

## 해결 방법

직접 SQL template을 작성하는 방식을 제거하고, QueryDSL의 `like(pattern, escapeChar)` API를 사용하도록 수정했습니다.

또한 백슬래시 대신 `!`를 LIKE escape 문자로 사용하도록 변경했습니다.

```java
return project.name.lower().like(likeSearchWord, '!')
    .or(project.summary.lower().like(likeSearchWord, '!'))
    .or(project.detail.lower().like(likeSearchWord, '!'));
```

검색어 내 특수문자는 아래와 같이 escape 처리됩니다.

```text
!  -> !!
%  -> !%
_  -> !_
```

이를 통해 최종 SQL이 `escape '!'` 형태로 안전하게 렌더링되도록 수정했습니다.

## 변경 대상

* `ProjectQueryRepository`

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #977 
