### PR TITLE
[Fix] 프로젝트 통합 검색 특수문자 처리 오류 수정

### DIFF
--- a/src/main/java/org/sopt/makers/internal/project/repository/ProjectQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/project/repository/ProjectQueryRepository.java
@@ -3,6 +3,7 @@ package org.sopt.makers.internal.project.repository;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -130,11 +131,30 @@ public class ProjectQueryRepository {
 
         val project = QProject.project;
         String normalizedSearchWord = searchWord.trim().toLowerCase(Locale.ROOT);
-        String likeSearchWord = "%" + escapeLikePattern(normalizedSearchWord) + "%";
 
-        return project.name.lower().like(likeSearchWord, '!')
-            .or(project.summary.lower().like(likeSearchWord, '!'))
-            .or(project.detail.lower().like(likeSearchWord, '!'));
+        if (containsLikeMetaCharacter(normalizedSearchWord)) {
+            return containsByLocate(project.name, normalizedSearchWord)
+                .or(containsByLocate(project.summary, normalizedSearchWord))
+                .or(containsByLocate(project.detail, normalizedSearchWord));
+        }
+
+        String likeSearchWord = "%" + normalizedSearchWord + "%";
+
+        return project.name.lower().like(likeSearchWord)
+            .or(project.summary.lower().like(likeSearchWord))
+            .or(project.detail.lower().like(likeSearchWord));
+    }
+
+    private boolean containsLikeMetaCharacter(String value) {
+        return value.contains("%") || value.contains("_") || value.contains("\\");
+    }
+
+    private BooleanExpression containsByLocate(StringExpression target, String searchWord) {
+        return Expressions.booleanTemplate(
+            "locate({0}, lower({1})) > 0",
+            searchWord,
+            target
+        );
     }
 
     private BooleanExpression checkProjectCategory(String category) {
@@ -175,12 +195,5 @@ public class ProjectQueryRepository {
         }
 
         return QProject.project.id.lt(projectId);
-    }
-
-    private String escapeLikePattern(String value) {
-        return value
-            .replace("!", "!!")
-            .replace("%", "!%")
-            .replace("_", "!_");
     }
 }

--- a/src/main/java/org/sopt/makers/internal/project/repository/ProjectQueryRepository.java
+++ b/src/main/java/org/sopt/makers/internal/project/repository/ProjectQueryRepository.java
@@ -150,11 +150,7 @@ public class ProjectQueryRepository {
     }
 
     private BooleanExpression containsByLocate(StringExpression target, String searchWord) {
-        return Expressions.booleanTemplate(
-            "locate({0}, lower({1})) > 0",
-            searchWord,
-            target
-        );
+        return target.lower().locate(searchWord).gt(0);
     }
 
     private BooleanExpression checkProjectCategory(String category) {


### PR DESCRIPTION
## 🐬 요약
PR의 요약을 작성해주세요!
프로젝트 통합 검색에서 LIKE ESCAPE 구문이 잘못 렌더링되어 발생하던 SQL syntax error를 수정했습니다.

기존에는 검색어 내 %, _ 같은 LIKE wildcard 문자를 문자 그대로 검색하기 위해 QueryDSL의 like(pattern, escapeChar) 또는 SQL template 기반 ESCAPE 구문을 사용했습니다. 하지만 Hibernate가 최종 PostgreSQL SQL로 변환하는 과정에서 escape 문자가 따옴표 없이 렌더링되어 검색 요청이 500 에러로 실패했습니다.

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [x] 버그 수정
- [ ] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
<h2><span>발생한 문제</span></h2><p class="isSelectedEnd"><span>아래와 같은 프로젝트 검색 요청에서 500 에러가 발생했습니다.</span></p><pre dir="ltr"><code dir="ltr"><span>GET /api/v1/projects?limit=20&amp;name=함께
GET /api/v1/projects?limit=20&amp;name=%25
GET /api/v1/projects?limit=20&amp;name=%21</span></code></pre><p class="isSelectedEnd"><span>에러 타입은 </span><code dir="ltr"><span>InvalidDataAccessResourceUsageException</span></code><span>이었고, PostgreSQL에서 SQL syntax error가 발생했습니다.</span></p><p class="isSelectedEnd"><span>실제 SQL은 아래처럼 렌더링되었습니다.</span></p><pre dir="ltr"><code dir="ltr"><span>lower(p1_0.name) like ? escape !</span></code></pre><p class="isSelectedEnd"><span>PostgreSQL에서는 </span><code dir="ltr"><span>ESCAPE</span></code><span> 뒤의 문자가 문자열 리터럴 형태여야 하므로, </span><code dir="ltr"><span>escape !</span></code><span>는 올바른 SQL이 아닙니다. 이로 인해 </span><code dir="ltr"><span>or</span></code><span> 근처에서 syntax error가 발생했습니다.</span></p><h2><span>원인</span></h2><p class="isSelectedEnd"><span>기존 구현은 QueryDSL/Hibernate가 </span><code dir="ltr"><span>ESCAPE</span></code><span> 구문을 최종 SQL에서 안전하게 렌더링할 것이라고 가정했습니다.</span></p><p class="isSelectedEnd"><span>하지만 실제 lambda-dev 환경에서는 </span><code dir="ltr"><span>escape '!'</span></code><span>가 아니라 </span><code dir="ltr"><span>escape !</span></code><span>처럼 따옴표 없이 렌더링되었습니다. 따라서 검색어가 특수문자인 경우뿐 아니라, 검색 조건이 포함된 일반 검색 요청에서도 SQL syntax error가 발생할 수 있었습니다.</span></p><h2><span>해결 방법</span></h2><p class="isSelectedEnd"><code dir="ltr"><span>ESCAPE</span></code><span> 구문에 의존하지 않도록 검색 방식을 분기했습니다.</span></p><ul data-spread="false"><li><span>일반 검색어는 기존처럼 </span><code dir="ltr"><span>LIKE</span></code><span> 검색 사용</span></li><li><code dir="ltr"><span>%</span></code><span>, </span><code dir="ltr"><span>_</span></code><span>, </span><code dir="ltr"><span>\</span></code><span> 등 LIKE 메타 문자가 포함된 검색어는 </span><code dir="ltr"><span>locate()</span></code><span> 기반 포함 검색 사용</span></li></ul><p class="isSelectedEnd"><span>이를 통해 일반 검색어는 기존 검색 성능을 유지하고, LIKE 메타 문자가 포함된 검색어는 wildcard가 아닌 일반 문자로 안전하게 처리합니다.</span></p><pre dir="ltr"><code dir="ltr"><span>if (containsLikeMetaCharacter(normalizedSearchWord)) {
    return containsByLocate(project.name, normalizedSearchWord)
        .or(containsByLocate(project.summary, normalizedSearchWord))
        .or(containsByLocate(project.detail, normalizedSearchWord));
}

String likeSearchWord = "%" + normalizedSearchWord + "%";

return project.name.lower().like(likeSearchWord)
    .or(project.summary.lower().like(likeSearchWord))
    .or(project.detail.lower().like(likeSearchWord));</span></code></pre><h2><span>처리 방식</span></h2>
검색어 | 처리 방식 | 의미
-- | -- | --
함께 | LIKE | 일반 포함 검색
! | LIKE | 일반 문자 포함 검색
% | locate() | % 문자 자체 포함 검색
_ | locate() | _ 문자 자체 포함 검색
\ | locate() | \ 문자 자체 포함 검색

<h2><span>변경 대상</span></h2><ul data-spread="false"><li><code dir="ltr"><span>ProjectQueryRepository</span></code></li></ul>


## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #977 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 검색어에 특수 문자가 포함된 경우에도 프로젝트 이름, 요약, 상세 내용에서 더 안정적으로 검색되도록 개선했습니다.
  * 일반 검색어는 기존보다 단순한 포함 검색 방식으로 처리되어, 검색 동작이 더 일관되게 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->