### PR TITLE
[Fix] 프로젝트 카드 응답 수정 및 커서 에러 해결

### DIFF
--- a/src/main/java/org/sopt/makers/internal/project/mapper/ProjectResponseMapper.java
+++ b/src/main/java/org/sopt/makers/internal/project/mapper/ProjectResponseMapper.java
@@ -32,8 +32,8 @@ public class ProjectResponseMapper {
                 project.getServiceType(),
                 project.getIsAvailable(),
                 project.getIsFounding(),
-                truncateString(project.getSummary()),
-                truncateString(project.getDetail()),
+                project.getSummary(),
+                project.getDetail(),
                 project.getLogoImage(),
                 project.getThumbnailImage(),
                 links
@@ -127,13 +127,5 @@ public class ProjectResponseMapper {
 
     public ProjectLinkResponse toIntenralProjectLinkResponse (ProjectLinkDao project) {
         return new ProjectLinkResponse(project.linkId(), project.linkTitle(), project.linkUrl());
-    }
-
-
-    private String truncateString(String str) {
-        if (str != null && str.length() > 20) {
-            return str.substring(0, 20) + "...";
-        }
-        return str;
     }
 }

--- a/src/main/java/org/sopt/makers/internal/wordchaingame/controller/WordChainGameController.java
+++ b/src/main/java/org/sopt/makers/internal/wordchaingame/controller/WordChainGameController.java
@@ -99,9 +99,11 @@ public class WordChainGameController {
         @RequestParam(required = false, name = "limit") Integer limit,
         @RequestParam(required = false, name = "cursor") Integer cursor
     ) {
+        int checkedCursor = cursor == null ? 0 : cursor;
+
         val winners = wordChainGameService.getAllWinner(
             infiniteScrollUtil.checkLimitForPagination(limit),
-            cursor
+            checkedCursor
         );
 
         val hasNextWinner = infiniteScrollUtil.checkHasNextElement(limit, winners);

--- a/src/main/java/org/sopt/makers/internal/wordchaingame/controller/WordChainGameController.java
+++ b/src/main/java/org/sopt/makers/internal/wordchaingame/controller/WordChainGameController.java
@@ -97,13 +97,11 @@ public class WordChainGameController {
     @GetMapping("/winners")
     public ResponseEntity<WordChainGameWinnerAllResponse> getGameWinners(
         @RequestParam(required = false, name = "limit") Integer limit,
-        @RequestParam(required = false, name = "cursor") Integer cursor
+        @RequestParam(defaultValue = "0", name = "cursor") int cursor
     ) {
-        int checkedCursor = cursor == null ? 0 : cursor;
-
         val winners = wordChainGameService.getAllWinner(
             infiniteScrollUtil.checkLimitForPagination(limit),
-            checkedCursor
+            cursor
         );
 
         val hasNextWinner = infiniteScrollUtil.checkHasNextElement(limit, winners);


### PR DESCRIPTION
## 🐬 요약
명예의 전당 목록 조회 시 `cursor`를 전달하지 않으면 발생하던 NPE를 수정하고, 프로젝트 카드 응답에서 `summary`, `detail`을 원문 그대로 반환하도록 변경했습니다.

## 👻 유형
PR의 유형에 맞게 체크해주세요!
<!-- Please check the one that applies to this PR using "x". -->

- [x] 버그 수정
- [ ] 기능 개발
- [ ] 코드 스타일 수정 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] CD 관련 변경사항
- [ ] 문서 내용 변경
- [ ] Release
- [ ] 기타... (다음 줄에 사유를 입력해주세요)

## 🍀 작업 내용
### 명예의 전당 목록 cursor 기본값 처리

`GET /api/v1/chainWordGame/winners` 요청에서 `cursor`를 생략하면 `WordChainGameService.getAllWinner(...)` 호출 과정에서 `Integer cursor`가 언박싱되며 NPE가 발생했습니다.

기존에는 프론트에서 첫 페이지 요청 시 `cursor=0`을 전달하면 정상 응답되었지만, API 파라미터가 `required=false`로 선언되어 있으므로 서버에서도 cursor 생략 케이스를 방어하도록 수정했습니다.

* `cursor == null`인 경우 `0`으로 보정
* `GET /api/v1/chainWordGame/winners?limit=1` 요청 시 정상 응답되도록 수정

### 프로젝트 카드 응답 원문 반환

프로젝트 카드 응답 매핑 시 `summary`, `detail`에 `truncateString(...)`이 적용되어 20자 초과 시 말줄임 처리되고 있었습니다.

FE 요청에 따라 서버에서 임의로 자르지 않고 원본 값을 그대로 반환하도록 변경했습니다.

* 기존: `summary`, `detail` 20자 초과 시 `...` 처리
* 변경: `summary`, `detail` 원문 그대로 반환
* 사용하지 않는 `truncateString(...)` 메서드 제거

## 변경 대상

* `WordChainGameController`
* `ProjectResponseMapper`

## 테스트 항목

* `GET /api/v1/chainWordGame/winners?limit=1` 요청 시 500 에러 없이 정상 응답되는지 확인
* `GET /api/v1/chainWordGame/winners?limit=1&cursor=0` 요청이 기존처럼 정상 응답되는지 확인
* 명예의 전당 목록 응답 개수가 `limit`을 초과하지 않는지 확인
* 프로젝트 카드 응답에서 `summary`, `detail`이 20자 이후 잘리지 않고 원문 그대로 내려오는지 확인
* 프로젝트 상세 조회 응답은 기존처럼 원문 그대로 유지되는지 확인

## 🌟 관련 이슈
PR과 관련된 이슈 번호를 작성해주세요!

close: #980 
